### PR TITLE
ENH: add wkt / wkb ufuncs

### DIFF
--- a/pygeos/__init__.py
+++ b/pygeos/__init__.py
@@ -9,6 +9,7 @@ from .measurement import *
 from .set_operations import *
 from .linear import *
 from .coordinates import *
+from .io import *
 
 from ._version import get_versions
 

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -171,4 +171,8 @@ def from_wkb(geometry, **kwargs):
     <pygeos.Geometry POINT (1 1)>
 
     """
+    # ensure the input has object dtype, to avoid numpy inferring it as a
+    # fixed-length string dtype (which removes trailing null bytes upon access
+    # of array elements)
+    geometry = np.asarray(geometry, dtype=object)
     return lib.from_wkb(geometry, **kwargs)

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,9 +1,10 @@
 import numpy as np
+
 from . import Geometry  # noqa
 from . import lib
 
 
-__all__ = ["from_wkb", "from_wkt", "to_wkb", "to_wkb"]
+__all__ = ["from_wkb", "from_wkt", "to_wkb", "to_wkt"]
 
 
 def to_wkt(
@@ -15,10 +16,10 @@ def to_wkt(
     **kwargs
 ):
     """
-    Converts to the Well-Known Text (WKT) representation of a  Geometry.
+    Converts to the Well-Known Text (WKT) representation of a Geometry.
 
     The Well-known Text format is defined in the `OGC Simple Features
-    Specification for SQL <http://www.opengis.org/techno/specs.htm>`__.
+    Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
 
     Parameters
     ----------
@@ -70,3 +71,65 @@ def to_wkt(
         np.bool(old_3d),
         **kwargs,
     )
+
+
+def to_wkb(geometry, **kwargs):
+    """
+    Converts to the Well-Known Binary (WKB) representation of a Geometry.
+
+    The Well-Known Binary format is defined in the `OGC Simple Features
+    Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
+
+    Parameters
+    ----------
+    geometry : Geometry or array_like
+
+    Examples
+    --------
+    >>> to_wkb(Geometry("POINT (1 1)"))
+    b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?'
+
+    """
+    return lib.to_wkb(geometry, **kwargs)
+
+
+def from_wkt(geometry, **kwargs):
+    """
+    Creates geometries from the Well-Known Text (WKT) representation.
+
+    The Well-known Text format is defined in the `OGC Simple Features
+    Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
+
+    Parameters
+    ----------
+    geometry : str or array_like
+        The WKT string(s) to convert.
+
+    Examples
+    --------
+    >>> from_wkt('POINT (0 0)')
+    <pygeos.Geometry POINT (0 0)>
+
+    """
+    return lib.from_wkt(geometry, **kwargs)
+
+
+def from_wkb(geometry, **kwargs):
+    """
+    Creates geometries from the Well-Known Binary (WKB) representation.
+
+    The Well-Known Binary format is defined in the `OGC Simple Features
+    Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
+
+    Parameters
+    ----------
+    geometry : str or array_like
+        The WKB byte object(s) to convert.
+
+    Examples
+    --------
+    >>> from_wkb(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?')
+    <pygeos.Geometry POINT (1 1)>
+
+    """
+    return lib.from_wkb(geometry, **kwargs)

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -57,9 +57,9 @@ def to_wkt(
     Notes
     -----
     The defaults differ from the default of the GEOS library. To mimic this,
-    use:
+    use::
 
-    >>> to_wkt(geometry, rounding_precision=-1, trim=False, output_dimension=2)
+        to_wkt(geometry, rounding_precision=-1, trim=False, output_dimension=2)
 
     """
     if not np.isscalar(rounding_precision):

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -28,7 +28,7 @@ def to_wkt(
         The rounding precision when writing the WKT string. Set to a value of
         -1 to indicate the full precision.
     trim : bool, default True
-        Whether to trim unnecessary decimals (trailing zero's).
+        Whether to trim unnecessary decimals (trailing zeros).
     output_dimension : int, default 3
         The output dimension for the WKT string. Supported values are 2 and 3.
         Specifying 3 means that up to 3 dimensions will be written but 2D
@@ -46,7 +46,6 @@ def to_wkt(
     'POINT (0.000 0.000)'
     >>> to_wkt(Geometry("POINT (0 0)"), rounding_precision=-1, trim=False)
     'POINT (0.0000000000000000 0.0000000000000000)'
-
     >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True)
     'POINT Z (1 2 3)'
     >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True, output_dimension=2)
@@ -111,7 +110,6 @@ def to_wkb(geometry, hex=False, output_dimension=3, byte_order=-1, include_srid=
     b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?'
     >>> to_wkb(Geometry("POINT (1 1)"), hex=True)
     '0101000000000000000000F03F000000000000F03F'
-
     """
     if not np.isscalar(hex):
         raise TypeError("hex only accepts scalar values")
@@ -148,7 +146,6 @@ def from_wkt(geometry, **kwargs):
     --------
     >>> from_wkt('POINT (0 0)')
     <pygeos.Geometry POINT (0 0)>
-
     """
     return lib.from_wkt(geometry, **kwargs)
 
@@ -169,7 +166,6 @@ def from_wkb(geometry, **kwargs):
     --------
     >>> from_wkb(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?')
     <pygeos.Geometry POINT (1 1)>
-
     """
     # ensure the input has object dtype, to avoid numpy inferring it as a
     # fixed-length string dtype (which removes trailing null bytes upon access

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -73,7 +73,7 @@ def to_wkt(
     )
 
 
-def to_wkb(geometry, **kwargs):
+def to_wkb(geometry, hex=False, output_dimension=3, byte_order=-1, include_srid=False, **kwargs):
     """
     Converts to the Well-Known Binary (WKB) representation of a Geometry.
 
@@ -83,14 +83,45 @@ def to_wkb(geometry, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
+    hex : bool, default False
+        If true, export the WKB as a hexidecimal string. The default is to
+        return a binary bytes object.
+    output_dimension : int, default 3
+        The output dimension for the WKB. Supported values are 2 and 3.
+        Specifying 3 means that up to 3 dimensions will be written but 2D
+        geometries will still be represented as 2D in the WKB represenation.
+    byte_order : int
+        Defaults to native machine byte order (-1). Use 0 to force big endian
+        and 1 for little endian.
+    include_srid : bool, default False
+        Whether the SRID should be included in WKB (this is an extension
+        to the OGC WKB specification).
 
     Examples
     --------
     >>> to_wkb(Geometry("POINT (1 1)"))
     b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?'
+    >>> to_wkb(Geometry("POINT (1 1)"), hex=True)
+    '0101000000000000000000F03F000000000000F03F'
 
     """
-    return lib.to_wkb(geometry, **kwargs)
+    if not np.isscalar(hex):
+        raise TypeError("hex only accepts scalar values")
+    if not np.isscalar(output_dimension):
+        raise TypeError("output_dimension only accepts scalar values")
+    if not np.isscalar(byte_order):
+        raise TypeError("byte_order only accepts scalar values")
+    if not np.isscalar(include_srid):
+        raise TypeError("include_srid only accepts scalar values")
+
+    return lib.to_wkb(
+        geometry,
+        np.bool(hex),
+        np.intc(output_dimension),
+        np.intc(byte_order),
+        np.bool(include_srid),
+        **kwargs,
+    )
 
 
 def from_wkt(geometry, **kwargs):

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 from . import Geometry  # noqa
-from . import ufuncs
+from . import lib
 
 
 __all__ = ["from_wkb", "from_wkt", "to_wkb", "to_wkb"]
@@ -62,7 +62,7 @@ def to_wkt(
     if not np.isscalar(old_3d):
         raise TypeError("old_3d only accepts scalar values")
 
-    return ufuncs.to_wkt(
+    return lib.to_wkt(
         geometry,
         np.intc(rounding_precision),
         np.bool(trim),

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,0 +1,72 @@
+import numpy as np
+from . import Geometry  # noqa
+from . import ufuncs
+
+
+__all__ = ["from_wkb", "from_wkt", "to_wkb", "to_wkb"]
+
+
+def to_wkt(
+    geometry,
+    rounding_precision=-1,
+    trim=False,
+    output_dimension=2,
+    old_3d=False,
+    **kwargs,
+):
+    """
+    Converts to the Well-Known Text (WKT) representation of a  Geometry.
+
+    The Well-known Text format is defined in the `OGC Simple Features
+    Specification for SQL <http://www.opengis.org/techno/specs.htm>`__.
+
+    Parameters
+    ----------
+    geometry : Geometry or array_like
+    rounding_precision : int
+        The rounding precision when writing the WKT string. A value of -1
+        indicates the full precision.
+    trim : bool
+        Whether to trim unnecessary decimals (trailing zero's).
+    output_dimension : int
+        The output dimension for the WKT string. Supported values are 2 and 3.
+        Specifying 3 means that up to 3 dimensions will be written but 2D
+        geometries will still be represented as 2D in the WKT string.
+    old_3d : bool
+        Enable old style 3D/4D WKT generation. By default, new style 3D/4D WKT
+        (ie. "POINT Z (10 20 30)") is returned, but with ``old_3d=True``
+        the WKT will be formatted in the style "POINT (10 20 30)".
+
+    Examples
+    --------
+    >>> to_wkt(Geometry("POINT (0 0)"))
+    'POINT (0.0000000000000000 0.0000000000000000)'
+    >>> to_wkt(Geometry("POINT (0 0)"), trim=True)
+    'POINT (0 0)'
+    >>> to_wkt(Geometry("POINT (0 0)"), rounding_precision=3)
+    'POINT (0.000 0.000)'
+    >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True)
+    'POINT (1 2)'
+    >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True, output_dimension=3)
+    'POINT Z (1 2 3)'
+    >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True, output_dimension=3, old_3d=True)
+    'POINT (1 2 3)'
+
+    """
+    if not np.isscalar(rounding_precision):
+        raise TypeError("rounding_precision only accepts scalar values")
+    if not np.isscalar(trim):
+        raise TypeError("trim only accepts scalar values")
+    if not np.isscalar(output_dimension):
+        raise TypeError("output_dimension only accepts scalar values")
+    if not np.isscalar(old_3d):
+        raise TypeError("old_3d only accepts scalar values")
+
+    return ufuncs.to_wkt(
+        geometry,
+        np.intc(rounding_precision),
+        np.bool(trim),
+        np.intc(output_dimension),
+        np.bool(old_3d),
+        **kwargs,
+    )

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -12,7 +12,7 @@ def to_wkt(
     trim=False,
     output_dimension=2,
     old_3d=False,
-    **kwargs,
+    **kwargs
 ):
     """
     Converts to the Well-Known Text (WKT) representation of a  Geometry.

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -82,7 +82,7 @@ def to_wkt(
 
 
 def to_wkb(geometry, hex=False, output_dimension=3, byte_order=-1, include_srid=False, **kwargs):
-    """
+    r"""
     Converts to the Well-Known Binary (WKB) representation of a Geometry.
 
     The Well-Known Binary format is defined in the `OGC Simple Features
@@ -154,7 +154,7 @@ def from_wkt(geometry, **kwargs):
 
 
 def from_wkb(geometry, **kwargs):
-    """
+    r"""
     Creates geometries from the Well-Known Binary (WKB) representation.
 
     The Well-Known Binary format is defined in the `OGC Simple Features

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -9,9 +9,9 @@ __all__ = ["from_wkb", "from_wkt", "to_wkb", "to_wkt"]
 
 def to_wkt(
     geometry,
-    rounding_precision=-1,
-    trim=False,
-    output_dimension=2,
+    rounding_precision=6,
+    trim=True,
+    output_dimension=3,
     old_3d=False,
     **kwargs
 ):
@@ -24,16 +24,16 @@ def to_wkt(
     Parameters
     ----------
     geometry : Geometry or array_like
-    rounding_precision : int
-        The rounding precision when writing the WKT string. A value of -1
-        indicates the full precision.
-    trim : bool
+    rounding_precision : int, default 6
+        The rounding precision when writing the WKT string. Set to a value of
+        -1 to indicate the full precision.
+    trim : bool, default True
         Whether to trim unnecessary decimals (trailing zero's).
-    output_dimension : int
+    output_dimension : int, default 3
         The output dimension for the WKT string. Supported values are 2 and 3.
         Specifying 3 means that up to 3 dimensions will be written but 2D
         geometries will still be represented as 2D in the WKT string.
-    old_3d : bool
+    old_3d : bool, default False
         Enable old style 3D/4D WKT generation. By default, new style 3D/4D WKT
         (ie. "POINT Z (10 20 30)") is returned, but with ``old_3d=True``
         the WKT will be formatted in the style "POINT (10 20 30)".
@@ -41,17 +41,25 @@ def to_wkt(
     Examples
     --------
     >>> to_wkt(Geometry("POINT (0 0)"))
-    'POINT (0.0000000000000000 0.0000000000000000)'
-    >>> to_wkt(Geometry("POINT (0 0)"), trim=True)
     'POINT (0 0)'
-    >>> to_wkt(Geometry("POINT (0 0)"), rounding_precision=3)
+    >>> to_wkt(Geometry("POINT (0 0)"), rounding_precision=3, trim=False)
     'POINT (0.000 0.000)'
+    >>> to_wkt(Geometry("POINT (0 0)"), rounding_precision=-1, trim=False)
+    'POINT (0.0000000000000000 0.0000000000000000)'
+
     >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True)
-    'POINT (1 2)'
-    >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True, output_dimension=3)
     'POINT Z (1 2 3)'
-    >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True, output_dimension=3, old_3d=True)
+    >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True, output_dimension=2)
+    'POINT (1 2)'
+    >>> to_wkt(Geometry("POINT (1 2 3)"), trim=True, old_3d=True)
     'POINT (1 2 3)'
+
+    Notes
+    -----
+    The defaults differ from the default of the GEOS library. To mimic this,
+    use:
+
+    >>> to_wkt(geometry, rounding_precision=-1, trim=False, output_dimension=2)
 
     """
     if not np.isscalar(rounding_precision):

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -11,20 +11,20 @@ def box_tpl(x1, y1, x2, y2):
 
 def test_points_from_coords():
     actual = pygeos.points([[0, 0], [2, 2]])
-    assert actual[0].to_wkt() == "POINT (0 0)"
-    assert actual[1].to_wkt() == "POINT (2 2)"
+    assert str(actual[0]) == "POINT (0 0)"
+    assert str(actual[1])  == "POINT (2 2)"
 
 
 def test_points_from_xy():
     actual = pygeos.points(2, [0, 1])
-    assert actual[0].to_wkt() == "POINT (2 0)"
-    assert actual[1].to_wkt() == "POINT (2 1)"
+    assert str(actual[0]) == "POINT (2 0)"
+    assert str(actual[1]) == "POINT (2 1)"
 
 
 def test_points_from_xyz():
     actual = pygeos.points(1, 1, [0, 1])
-    assert actual[0].to_wkt() == "POINT Z (1 1 0)"
-    assert actual[1].to_wkt() == "POINT Z (1 1 1)"
+    assert str(actual[0]) == "POINT Z (1 1 0)"
+    assert str(actual[1]) == "POINT Z (1 1 1)"
 
 
 def test_points_invalid_ndim():
@@ -34,51 +34,51 @@ def test_points_invalid_ndim():
 
 def test_linestrings_from_coords():
     actual = pygeos.linestrings([[[0, 0], [1, 1]], [[0, 0], [2, 2]]])
-    assert actual[0].to_wkt() == "LINESTRING (0 0, 1 1)"
-    assert actual[1].to_wkt() == "LINESTRING (0 0, 2 2)"
+    assert str(actual[0]) == "LINESTRING (0 0, 1 1)"
+    assert str(actual[1]) == "LINESTRING (0 0, 2 2)"
 
 
 def test_linestrings_from_xy():
     actual = pygeos.linestrings([0, 1], [2, 3])
-    assert actual.to_wkt() == "LINESTRING (0 2, 1 3)"
+    assert str(actual) == "LINESTRING (0 2, 1 3)"
 
 
 def test_linestrings_from_xy_broadcast():
     x = [0, 1]  # the same X coordinates for both linestrings
     y = [2, 3], [4, 5]  # each linestring has a different set of Y coordinates
     actual = pygeos.linestrings(x, y)
-    assert actual[0].to_wkt() == "LINESTRING (0 2, 1 3)"
-    assert actual[1].to_wkt() == "LINESTRING (0 4, 1 5)"
+    assert str(actual[0]) == "LINESTRING (0 2, 1 3)"
+    assert str(actual[1]) == "LINESTRING (0 4, 1 5)"
 
 
 def test_linestrings_from_xyz():
     actual = pygeos.linestrings([0, 1], [2, 3], 0)
-    assert actual.to_wkt() == "LINESTRING Z (0 2 0, 1 3 0)"
+    assert str(actual) == "LINESTRING Z (0 2 0, 1 3 0)"
 
 
 def test_linearrings():
     actual = pygeos.linearrings(box_tpl(0, 0, 1, 1))
-    assert actual.to_wkt() == "LINEARRING (1 0, 1 1, 0 1, 0 0, 1 0)"
+    assert str(actual) == "LINEARRING (1 0, 1 1, 0 1, 0 0, 1 0)"
 
 
 def test_linearrings_from_xy():
     actual = pygeos.linearrings([0, 1, 2, 0], [3, 4, 5, 3])
-    assert actual.to_wkt() == "LINEARRING (0 3, 1 4, 2 5, 0 3)"
+    assert str(actual) == "LINEARRING (0 3, 1 4, 2 5, 0 3)"
 
 
 def test_linearrings_unclosed():
     actual = pygeos.linearrings(box_tpl(0, 0, 1, 1)[:-1])
-    assert actual.to_wkt() == "LINEARRING (1 0, 1 1, 0 1, 0 0, 1 0)"
+    assert str(actual) == "LINEARRING (1 0, 1 1, 0 1, 0 0, 1 0)"
 
 
 def test_polygon_from_linearring():
     actual = pygeos.polygons(pygeos.linearrings(box_tpl(0, 0, 1, 1)))
-    assert actual.to_wkt() == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
+    assert str(actual) == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
 
 
 def test_polygons():
     actual = pygeos.polygons(box_tpl(0, 0, 1, 1))
-    assert actual.to_wkt() == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
+    assert str(actual) == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
 
 
 def test_polygon_no_hole_list_raises():
@@ -123,20 +123,20 @@ def test_2_polygons_with_different_holes():
 
 def test_create_collection_only_none():
     actual = pygeos.multipoints(np.array([None], dtype=object))
-    assert actual.to_wkt() == "MULTIPOINT EMPTY"
+    assert str(actual) == "MULTIPOINT EMPTY"
 
 
 def test_create_collection_skips_none():
     actual = pygeos.multipoints([point, None, None, point])
-    assert actual.to_wkt() == "MULTIPOINT (2 3, 2 3)"
+    assert str(actual) == "MULTIPOINT (2 3, 2 3)"
 
 
 def test_box():
     actual = pygeos.box(0, 0, 1, 1)
-    assert actual.to_wkt() == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
+    assert str(actual) == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
 
 
 def test_box_multiple():
     actual = pygeos.box(0, 0, [1, 2], [1, 2])
-    assert actual[0].to_wkt() == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
-    assert actual[1].to_wkt() == "POLYGON ((2 0, 2 2, 0 2, 0 0, 2 0))"
+    assert str(actual[0]) == "POLYGON ((1 0, 1 1, 0 1, 0 0, 1 0))"
+    assert str(actual[1]) == "POLYGON ((2 0, 2 2, 0 2, 0 0, 2 0))"

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -156,107 +156,19 @@ def test_get_y():
     assert pygeos.get_y([point, point_z]).tolist() == [3.0, 1.0]
 
 
-def test_new_from_wkt():
-    geom = point
-    actual = pygeos.Geometry(geom.to_wkt())
+@pytest.mark.parametrize("geom", all_types)
+def test_new_from_wkt(geom):
+    actual = pygeos.Geometry(str(geom))
     assert pygeos.equals(actual, geom)
 
 
-def test_new_from_wkb():
-    geom = point
-    actual = pygeos.Geometry(geom.to_wkb())
+@pytest.mark.parametrize("geom", all_types)
+def test_new_from_wkb(geom):
+    actual = pygeos.Geometry(pygeos.to_wkb(geom))
     assert pygeos.equals(actual, geom)
 
 
 def test_adapt_ptr_raises():
-    point = pygeos.Geometry.from_wkt("POINT (2 2)")
+    point = pygeos.Geometry("POINT (2 2)")
     with pytest.raises(AttributeError):
         point._ptr += 1
-
-
-def test_to_wkt():
-    assert point.to_wkt() == "POINT (2 3)"
-    assert point.to_wkt(trim=False) == "POINT (2.000000 3.000000)"
-    assert point.to_wkt(trim=False, precision=3) == "POINT (2.000 3.000)"
-    assert point_z.to_wkt(dimension=2) == "POINT (1 1)"
-    assert point_z.to_wkt(dimension=3) == "POINT Z (1 1 1)"
-    assert point_z.to_wkt(dimension=3, use_old_3d=True) == "POINT (1 1 1)"
-
-
-def test_to_wkb():
-    be = b"\x00"
-    le = b"\x01"
-    point_type = b"\x01\x00\x00\x00"  # 1 as 32-bit uint (LE)
-    point_type_3d = b"\x01\x00\x00\x80"
-    coord = b"\x00\x00\x00\x00\x00\x00\xf0?"  # 1.0 as double (LE)
-
-    assert point_z.to_wkb(dimension=2) == le + point_type + 2 * coord
-    assert point_z.to_wkb(dimension=3) == le + point_type_3d + 3 * coord
-    assert (
-        point_z.to_wkb(dimension=2, byte_order=0)
-        == be + point_type[::-1] + 2 * coord[::-1]
-    )
-
-
-def test_to_wkb_with_srid():
-    point_with_srid = pygeos.set_srid(point, np.int32(4326))
-    result = point_with_srid.to_wkb(include_srid=True)
-    assert np.frombuffer(result[5:9], "<u4").item() == 4326
-
-
-def test_to_wkb_hex():
-    le = b"01"
-    point_type = b"01000000"
-    coord = b"000000000000F03F"  # 1.0 as double (LE)
-
-    assert point_z.to_wkb(hex=True, dimension=2) == le + point_type + 2 * coord
-
-
-@pytest.mark.parametrize("geom", all_types)
-def test_from_wkt(geom):
-    wkt = geom.to_wkt()
-    actual = pygeos.Geometry.from_wkt(wkt)
-    assert pygeos.equals(actual, geom)
-
-
-@pytest.mark.parametrize(
-    "wkt", ("POINT EMPTY", "LINESTRING EMPTY", "GEOMETRYCOLLECTION EMPTY")
-)
-def test_from_wkt_empty(wkt):
-    geom = pygeos.Geometry.from_wkt(wkt)
-    assert pygeos.is_geometry(geom).all()
-    assert pygeos.is_empty(geom).all()
-
-
-def test_from_wkt_bytes():
-    actual = pygeos.Geometry.from_wkt(b"POINT (2 3)")
-    assert pygeos.equals(actual, point)
-
-
-def test_from_wkt_exceptions():
-    with pytest.raises(TypeError):
-        pygeos.Geometry.from_wkt(list("POINT (2 2)"))
-    with pytest.raises(TypeError):
-        pygeos.Geometry.from_wkt(None)
-    with pytest.raises(pygeos.GEOSException):
-        pygeos.Geometry.from_wkt("")
-    with pytest.raises(pygeos.GEOSException):
-        pygeos.Geometry.from_wkt("NOT A WKT STRING")
-
-
-@pytest.mark.parametrize("geom", all_types)
-@pytest.mark.parametrize("use_hex", [False, True])
-@pytest.mark.parametrize("byte_order", [0, 1])
-def test_from_wkb(geom, use_hex, byte_order):
-    wkb = geom.to_wkb(hex=use_hex, byte_order=byte_order)
-    actual = pygeos.Geometry.from_wkb(wkb)
-    assert pygeos.equals(actual, geom)
-
-
-def test_from_wkb_typeerror():
-    with pytest.raises(TypeError):
-        pygeos.Geometry.from_wkb("\x01")
-    with pytest.raises(TypeError):
-        pygeos.Geometry.from_wkb(None)
-    with pytest.raises(pygeos.GEOSException):
-        pygeos.Geometry.from_wkb(b"POINT (2 2)")

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -162,12 +162,6 @@ def test_new_from_wkt(geom):
     assert pygeos.equals(actual, geom)
 
 
-@pytest.mark.parametrize("geom", all_types)
-def test_new_from_wkb(geom):
-    actual = pygeos.Geometry(pygeos.to_wkb(geom))
-    assert pygeos.equals(actual, geom)
-
-
 def test_adapt_ptr_raises():
     point = pygeos.Geometry("POINT (2 2)")
     with pytest.raises(AttributeError):

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -1,6 +1,8 @@
-import numpy
+import numpy as np
 import pygeos
 import pytest
+
+from .common import all_types
 
 
 POINT11_WKB = (
@@ -12,6 +14,7 @@ def test_from_wkt():
     expected = pygeos.points(1, 1)
     actual = pygeos.from_wkt("POINT (1 1)")
     assert pygeos.equals(actual, expected)
+    # also accept bytes
     actual = pygeos.from_wkt(b"POINT (1 1)")
     assert pygeos.equals(actual, expected)
 
@@ -22,7 +25,19 @@ def test_from_wkt():
         pygeos.from_wkt(1)
 
     with pytest.raises(pygeos.GEOSException):
-        pygeos.from_wkt("invalid")
+        pygeos.from_wkt("")
+
+    with pytest.raises(pygeos.GEOSException):
+        pygeos.from_wkt("NOT A WKT STRING")
+
+
+@pytest.mark.parametrize(
+    "wkt", ("POINT EMPTY", "LINESTRING EMPTY", "GEOMETRYCOLLECTION EMPTY")
+)
+def test_from_wkt_empty(wkt):
+    geom = pygeos.from_wkt(wkt)
+    assert pygeos.is_geometry(geom).all()
+    assert pygeos.is_empty(geom).all()
 
 
 def test_from_wkb():
@@ -43,13 +58,26 @@ def test_from_wkb():
         pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00")
 
 
+@pytest.mark.parametrize("geom", all_types)
+@pytest.mark.parametrize("use_hex", [False])  #, [False, True])
+@pytest.mark.parametrize("byte_order", [1])  # [0, 1])
+def test_from_wkb_all_types(geom, use_hex, byte_order):
+    wkb = pygeos.to_wkb(geom, hex=use_hex, byte_order=byte_order)
+    # TODO accept strings
+    actual = pygeos.from_wkb(wkb.encode() if use_hex else wkb)
+    assert pygeos.equals(actual, geom)
+
+
 def test_to_wkt():
     point = pygeos.points(1, 1)
     actual = pygeos.to_wkt(point)
     assert actual == "POINT (1 1)"
 
-    actual = pygeos.to_wkt(point, rounding_precision=2, trim=False)
-    assert actual == "POINT (1.00 1.00)"
+    actual = pygeos.to_wkt(point, trim=False)
+    assert actual == "POINT (1.000000 1.000000)"
+
+    actual = pygeos.to_wkt(point, rounding_precision=3, trim=False)
+    assert actual == "POINT (1.000 1.000)"
 
     # 3D points
     point_z = pygeos.points(1, 1, 1)
@@ -80,7 +108,10 @@ def test_to_wkb():
     assert actual == POINT11_WKB
 
     actual = pygeos.to_wkb(point, hex=True)
-    assert actual == '0101000000000000000000F03F000000000000F03F'
+    le = "01"
+    point_type = "01000000"
+    coord = "000000000000F03F"  # 1.0 as double (LE)
+    assert actual == le + point_type + 2 * coord
 
     point_z = pygeos.points(1, 1, 1)
     actual = pygeos.to_wkb(point_z)
@@ -98,7 +129,18 @@ def test_to_wkb():
         pygeos.to_wkb(point, output_dimension=4)
 
 
-def test_srid_roundtrip():
+def test_to_wkb_byte_order():
+    point = pygeos.points(1.0, 1.0)
+    be = b"\x00"
+    le = b"\x01"
+    point_type = b"\x01\x00\x00\x00"  # 1 as 32-bit uint (LE)
+    coord = b"\x00\x00\x00\x00\x00\x00\xf0?"  # 1.0 as double (LE)
+
+    assert pygeos.to_wkb(point, byte_order=1) == le + point_type + 2 * coord
+    assert pygeos.to_wkb(point, byte_order=0) == be + point_type[::-1] + 2 * coord[::-1]
+
+
+def test_to_wkb_srid():
     # hex representation of POINT (0 0) with SRID=4
     ewkb = "01010000200400000000000000000000000000000000000000"
     wkb = "010100000000000000000000000000000000000000"
@@ -108,3 +150,8 @@ def test_srid_roundtrip():
 
     assert pygeos.to_wkb(actual, hex=True) == wkb
     assert pygeos.to_wkb(actual, hex=True, include_srid=True) == ewkb
+
+    point = pygeos.points(1, 1)
+    point_with_srid = pygeos.set_srid(point, np.int32(4326))
+    result = pygeos.to_wkb(point_with_srid, include_srid=True)
+    assert np.frombuffer(result[5:9], "<u4").item() == 4326

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -45,6 +45,8 @@ def test_from_wkb():
     actual = pygeos.from_wkb(POINT11_WKB)
     assert pygeos.equals(actual, expected)
     # HEX form
+    actual = pygeos.from_wkb("0101000000000000000000F03F000000000000F03F")
+    assert pygeos.equals(actual, expected)
     actual = pygeos.from_wkb(b"0101000000000000000000F03F000000000000F03F")
     assert pygeos.equals(actual, expected)
 
@@ -59,12 +61,11 @@ def test_from_wkb():
 
 
 @pytest.mark.parametrize("geom", all_types)
-@pytest.mark.parametrize("use_hex", [False])  #, [False, True])
+@pytest.mark.parametrize("use_hex", [False])  # [False, True])
 @pytest.mark.parametrize("byte_order", [1])  # [0, 1])
 def test_from_wkb_all_types(geom, use_hex, byte_order):
     wkb = pygeos.to_wkb(geom, hex=use_hex, byte_order=byte_order)
-    # TODO accept strings
-    actual = pygeos.from_wkb(wkb.encode() if use_hex else wkb)
+    actual = pygeos.from_wkb(wkb)
     assert pygeos.equals(actual, geom)
 
 
@@ -145,8 +146,8 @@ def test_to_wkb_srid():
     ewkb = "01010000200400000000000000000000000000000000000000"
     wkb = "010100000000000000000000000000000000000000"
 
-    actual = pygeos.from_wkb(ewkb.encode())
-    assert pygeos.to_wkt(actual, trim=True) == 'POINT (0 0)'
+    actual = pygeos.from_wkb(ewkb)
+    assert pygeos.to_wkt(actual, trim=True) == "POINT (0 0)"
 
     assert pygeos.to_wkb(actual, hex=True) == wkb
     assert pygeos.to_wkb(actual, hex=True, include_srid=True) == ewkb

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -53,8 +53,8 @@ def test_from_wkb():
     # None propagates
     assert pygeos.from_wkb(None) is None
 
-    with pytest.raises(TypeError, match="Expected bytes, got str"):
-        pygeos.from_wkb("test")
+    with pytest.raises(TypeError, match="Expected bytes, got int"):
+        pygeos.from_wkb(1)
 
     with pytest.raises(pygeos.GEOSException):
         pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00")

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -103,8 +103,7 @@ def test_from_wkb_empty(wkt):
 
 def test_from_wkb_empty_point():
     geom = pygeos.from_wkt("POINT EMPTY")
-    # TODO make this a more specific error
-    with pytest.raises(Exception):
+    with pytest.raises(pygeos.GEOSException):
         pygeos.to_wkb(geom)
 
 

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -3,7 +3,7 @@ import pygeos
 import pytest
 
 from pygeos.lib import from_wkt, from_wkb, to_wkb
-from pygeos.io import to_wkt
+from pygeos.io import from_wkt, from_wkb, to_wkt, to_wkb
 
 
 POINT11_WKB = (
@@ -13,71 +13,71 @@ POINT11_WKB = (
 
 def test_from_wkt():
     expected = pygeos.points(1, 1)
-    actual = from_wkt("POINT (1 1)")
+    actual = pygeos.from_wkt("POINT (1 1)")
     assert pygeos.equals(actual, expected)
-    actual = from_wkt(b"POINT (1 1)")
+    actual = pygeos.from_wkt(b"POINT (1 1)")
     assert pygeos.equals(actual, expected)
 
     # None propagates
-    assert from_wkb(None) is None
+    assert pygeos.from_wkb(None) is None
 
     with pytest.raises(TypeError, match="Expected bytes, got int"):
-        from_wkt(1)
+        pygeos.from_wkt(1)
 
     with pytest.raises(pygeos.GEOSException):
-        from_wkt("invalid")
+        pygeos.from_wkt("invalid")
 
 
 def test_from_wkb():
     expected = pygeos.points(1, 1)
-    actual = from_wkb(POINT11_WKB)
+    actual = pygeos.from_wkb(POINT11_WKB)
     assert pygeos.equals(actual, expected)
     # HEX form
-    actual = from_wkb(b"0101000000000000000000F03F000000000000F03F")
+    actual = pygeos.from_wkb(b"0101000000000000000000F03F000000000000F03F")
     assert pygeos.equals(actual, expected)
 
     # None propagates
-    assert from_wkb(None) is None
+    assert pygeos.from_wkb(None) is None
 
     with pytest.raises(TypeError, match="Expected bytes, got str"):
-        from_wkb("test")
+        pygeos.from_wkb("test")
 
     with pytest.raises(pygeos.GEOSException):
-        from_wkb(b"\x01\x01\x00\x00\x00\x00")
+        pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00")
 
 
 def test_to_wkt():
     points = pygeos.points(1, 1, 1)
-    actual = to_wkt(points, trim=True)
+    actual = pygeos.to_wkt(points, trim=True)
     assert actual == "POINT (1 1)"
 
-    actual = to_wkt(points, rounding_precision=2)
+    actual = pygeos.to_wkt(points, rounding_precision=2)
     assert actual == "POINT (1.00 1.00)"
 
-    actual = to_wkt(points, trim=True, output_dimension=3)
+    actual = pygeos.to_wkt(points, trim=True, output_dimension=3)
     assert actual == "POINT Z (1 1 1)"
 
-    actual = to_wkt(points, trim=True, output_dimension=3, old_3d=True)
+    actual = pygeos.to_wkt(points, trim=True, output_dimension=3, old_3d=True)
     assert actual == "POINT (1 1 1)"
 
     # None propagates
-    assert to_wkt(None) is None
+    assert pygeos.to_wkt(None) is None
 
     with pytest.raises(TypeError):
-        to_wkt(1)
+        pygeos.to_wkt(1)
 
     with pytest.raises(pygeos.GEOSException):
-        to_wkt(points, output_dimension=4)
+        pygeos.to_wkt(points, output_dimension=4)
 
 
 def test_to_wkb():
     points = pygeos.points(1, 1)
-    actual = to_wkb(points)
+    actual = pygeos.to_wkb(points)
     assert actual == POINT11_WKB
 
     # None propagates
-    assert to_wkb(None) is None
+    assert pygeos.to_wkb(None) is None
 
     with pytest.raises(TypeError):
-        to_wkb(1)
+        pygeos.to_wkb(1)
 

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -16,7 +16,7 @@ def test_from_wkt():
     assert pygeos.equals(actual, expected)
 
     # None propagates
-    assert pygeos.from_wkb(None) is None
+    assert pygeos.from_wkt(None) is None
 
     with pytest.raises(TypeError, match="Expected bytes, got int"):
         pygeos.from_wkt(1)
@@ -44,17 +44,24 @@ def test_from_wkb():
 
 
 def test_to_wkt():
-    points = pygeos.points(1, 1, 1)
-    actual = pygeos.to_wkt(points, trim=True)
+    point = pygeos.points(1, 1)
+    actual = pygeos.to_wkt(point)
     assert actual == "POINT (1 1)"
 
-    actual = pygeos.to_wkt(points, rounding_precision=2)
+    actual = pygeos.to_wkt(point, rounding_precision=2, trim=False)
     assert actual == "POINT (1.00 1.00)"
 
-    actual = pygeos.to_wkt(points, trim=True, output_dimension=3)
+    # 3D points
+    point_z = pygeos.points(1, 1, 1)
+    actual = pygeos.to_wkt(point_z)
+    assert actual == "POINT Z (1 1 1)"
+    actual = pygeos.to_wkt(point_z, output_dimension=3)
     assert actual == "POINT Z (1 1 1)"
 
-    actual = pygeos.to_wkt(points, trim=True, output_dimension=3, old_3d=True)
+    actual = pygeos.to_wkt(point_z, output_dimension=2)
+    assert actual == "POINT (1 1)"
+
+    actual = pygeos.to_wkt(point_z, old_3d=True)
     assert actual == "POINT (1 1 1)"
 
     # None propagates
@@ -64,21 +71,21 @@ def test_to_wkt():
         pygeos.to_wkt(1)
 
     with pytest.raises(pygeos.GEOSException):
-        pygeos.to_wkt(points, output_dimension=4)
+        pygeos.to_wkt(point, output_dimension=4)
 
 
 def test_to_wkb():
-    points = pygeos.points(1, 1)
-    actual = pygeos.to_wkb(points)
+    point = pygeos.points(1, 1)
+    actual = pygeos.to_wkb(point)
     assert actual == POINT11_WKB
 
-    actual = pygeos.to_wkb(points, hex=True)
+    actual = pygeos.to_wkb(point, hex=True)
     assert actual == '0101000000000000000000F03F000000000000F03F'
 
-    points = pygeos.points(1, 1, 1)
-    actual = pygeos.to_wkb(points)
+    point_z = pygeos.points(1, 1, 1)
+    actual = pygeos.to_wkb(point_z)
     assert actual == b'\x01\x01\x00\x00\x80\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?'  # noqa
-    actual = pygeos.to_wkb(points, output_dimension=2)
+    actual = pygeos.to_wkb(point_z, output_dimension=2)
     assert actual == POINT11_WKB
 
     # None propagates
@@ -88,7 +95,7 @@ def test_to_wkb():
         pygeos.to_wkb(1)
 
     with pytest.raises(pygeos.GEOSException):
-        pygeos.to_wkb(points, output_dimension=4)
+        pygeos.to_wkb(point, output_dimension=4)
 
 
 def test_srid_roundtrip():

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -31,6 +31,13 @@ def test_from_wkt():
         pygeos.from_wkt("NOT A WKT STRING")
 
 
+@pytest.mark.parametrize("geom", all_types)
+def test_from_wkt_all_types(geom):
+    wkt = pygeos.to_wkt(geom)
+    actual = pygeos.from_wkt(wkt)
+    assert pygeos.equals(actual, geom)
+
+
 @pytest.mark.parametrize(
     "wkt", ("POINT EMPTY", "LINESTRING EMPTY", "GEOMETRYCOLLECTION EMPTY")
 )
@@ -61,8 +68,8 @@ def test_from_wkb():
 
 
 @pytest.mark.parametrize("geom", all_types)
-@pytest.mark.parametrize("use_hex", [False])  # [False, True])
-@pytest.mark.parametrize("byte_order", [1])  # [0, 1])
+@pytest.mark.parametrize("use_hex", [False, True])
+@pytest.mark.parametrize("byte_order", [0, 1])
 def test_from_wkb_all_types(geom, use_hex, byte_order):
     wkb = pygeos.to_wkb(geom, hex=use_hex, byte_order=byte_order)
     actual = pygeos.from_wkb(wkb)

--- a/pygeos/test/test_readers_writers.py
+++ b/pygeos/test/test_readers_writers.py
@@ -2,7 +2,8 @@ import numpy
 import pygeos
 import pytest
 
-from pygeos.ufuncs import from_wkt, from_wkb, to_wkt, to_wkb
+from pygeos.ufuncs import from_wkt, from_wkb, to_wkb
+from pygeos.io import to_wkt
 
 
 POINT11_WKB = (
@@ -46,15 +47,27 @@ def test_from_wkb():
 
 
 def test_to_wkt():
-    points = pygeos.points(1, 1)
-    actual = to_wkt(points)
+    points = pygeos.points(1, 1, 1)
+    actual = to_wkt(points, trim=True)
     assert actual == "POINT (1 1)"
+
+    actual = to_wkt(points, rounding_precision=2)
+    assert actual == "POINT (1.00 1.00)"
+
+    actual = to_wkt(points, trim=True, output_dimension=3)
+    assert actual == "POINT Z (1 1 1)"
+
+    actual = to_wkt(points, trim=True, output_dimension=3, old_3d=True)
+    assert actual == "POINT (1 1 1)"
 
     # None propagates
     assert to_wkt(None) is None
 
     with pytest.raises(TypeError):
         to_wkt(1)
+
+    with pytest.raises(pygeos.GEOSException):
+        to_wkt(points, output_dimension=4)
 
 
 def test_to_wkb():

--- a/pygeos/test/test_readers_writers.py
+++ b/pygeos/test/test_readers_writers.py
@@ -2,7 +2,7 @@ import numpy
 import pygeos
 import pytest
 
-from pygeos.ufuncs import from_wkt, from_wkb, to_wkb
+from pygeos.lib import from_wkt, from_wkb, to_wkb
 from pygeos.io import to_wkt
 
 

--- a/pygeos/test/test_readers_writers.py
+++ b/pygeos/test/test_readers_writers.py
@@ -17,7 +17,10 @@ def test_from_wkt():
     actual = from_wkt(b"POINT (1 1)")
     assert pygeos.equals(actual, expected)
 
-    with pytest.raises(TypeError, match="Expected bytes, found int"):
+    # None propagates
+    assert from_wkb(None) is None
+
+    with pytest.raises(TypeError, match="Expected bytes, got int"):
         from_wkt(1)
 
     with pytest.raises(pygeos.GEOSException):
@@ -32,7 +35,10 @@ def test_from_wkb():
     actual = from_wkb(b"0101000000000000000000F03F000000000000F03F")
     assert pygeos.equals(actual, expected)
 
-    with pytest.raises(TypeError, match="Expected bytes, found str"):
+    # None propagates
+    assert from_wkb(None) is None
+
+    with pytest.raises(TypeError, match="Expected bytes, got str"):
         from_wkb("test")
 
     with pytest.raises(pygeos.GEOSException):
@@ -44,9 +50,21 @@ def test_to_wkt():
     actual = to_wkt(points)
     assert actual == "POINT (1 1)"
 
+    # None propagates
+    assert to_wkt(None) is None
+
+    with pytest.raises(TypeError):
+        to_wkt(1)
+
 
 def test_to_wkb():
     points = pygeos.points(1, 1)
     actual = to_wkb(points)
     assert actual == POINT11_WKB
+
+    # None propagates
+    assert to_wkb(None) is None
+
+    with pytest.raises(TypeError):
+        to_wkb(1)
 

--- a/pygeos/test/test_readers_writers.py
+++ b/pygeos/test/test_readers_writers.py
@@ -2,35 +2,51 @@ import numpy
 import pygeos
 import pytest
 
-from pygeos.ufuncs import from_wkt, from_wkb
+from pygeos.ufuncs import from_wkt, from_wkb, to_wkt, to_wkb
+
+
+POINT11_WKB = (
+    b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?"
+)
 
 
 def test_from_wkt():
-
     expected = pygeos.points(1, 1)
-    actual = from_wkt('POINT (1 1)')
+    actual = from_wkt("POINT (1 1)")
     assert pygeos.equals(actual, expected)
-    actual = from_wkt(b'POINT (1 1)')
+    actual = from_wkt(b"POINT (1 1)")
     assert pygeos.equals(actual, expected)
-    
+
     with pytest.raises(TypeError, match="Expected bytes, found int"):
         from_wkt(1)
-    
+
     with pytest.raises(pygeos.GEOSException):
-        from_wkt('invalid')
+        from_wkt("invalid")
 
 
 def test_from_wkb():
-
     expected = pygeos.points(1, 1)
-    actual = from_wkb(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?')
+    actual = from_wkb(POINT11_WKB)
     assert pygeos.equals(actual, expected)
     # HEX form
-    actual = from_wkb(b'0101000000000000000000F03F000000000000F03F')
+    actual = from_wkb(b"0101000000000000000000F03F000000000000F03F")
     assert pygeos.equals(actual, expected)
 
     with pytest.raises(TypeError, match="Expected bytes, found str"):
         from_wkb("test")
 
     with pytest.raises(pygeos.GEOSException):
-        from_wkb(b'\x01\x01\x00\x00\x00\x00')
+        from_wkb(b"\x01\x01\x00\x00\x00\x00")
+
+
+def test_to_wkt():
+    points = pygeos.points(1, 1)
+    actual = to_wkt(points)
+    assert actual == "POINT (1 1)"
+
+
+def test_to_wkb():
+    points = pygeos.points(1, 1)
+    actual = to_wkb(points)
+    assert actual == POINT11_WKB
+

--- a/pygeos/test/test_readers_writers.py
+++ b/pygeos/test/test_readers_writers.py
@@ -1,0 +1,36 @@
+import numpy
+import pygeos
+import pytest
+
+from pygeos.ufuncs import from_wkt, from_wkb
+
+
+def test_from_wkt():
+
+    expected = pygeos.points(1, 1)
+    actual = from_wkt('POINT (1 1)')
+    assert pygeos.equals(actual, expected)
+    actual = from_wkt(b'POINT (1 1)')
+    assert pygeos.equals(actual, expected)
+    
+    with pytest.raises(TypeError, match="Expected bytes, found int"):
+        from_wkt(1)
+    
+    with pytest.raises(pygeos.GEOSException):
+        from_wkt('invalid')
+
+
+def test_from_wkb():
+
+    expected = pygeos.points(1, 1)
+    actual = from_wkb(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?')
+    assert pygeos.equals(actual, expected)
+    # HEX form
+    actual = from_wkb(b'0101000000000000000000F03F000000000000F03F')
+    assert pygeos.equals(actual, expected)
+
+    with pytest.raises(TypeError, match="Expected bytes, found str"):
+        from_wkb("test")
+
+    with pytest.raises(pygeos.GEOSException):
+        from_wkb(b'\x01\x01\x00\x00\x00\x00')

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -37,9 +37,7 @@ static PyMemberDef GeometryObject_members[] = {
     {NULL}  /* Sentinel */
 };
 
-
-static PyObject *to_wkt(GeometryObject *obj, char *format, char trim,
-                        int precision, int dimension, int use_old_3d)
+static PyObject *GeometryObject_ToWKT(GeometryObject *obj, char *format)
 {
     void *context_handle = geos_context[0];
     char *wkt;
@@ -52,6 +50,11 @@ static PyObject *to_wkt(GeometryObject *obj, char *format, char trim,
     if (writer == NULL) {
         return NULL;
     }
+
+    char trim = 1;
+    int precision = 3;
+    int dimension = 3;
+    int use_old_3d = 0;
     GEOSWKTWriter_setRoundingPrecision_r(context_handle, writer, precision);
     GEOSWKTWriter_setTrim_r(context_handle, writer, trim);
     GEOSWKTWriter_setOutputDimension_r(context_handle, writer, dimension);
@@ -63,72 +66,14 @@ static PyObject *to_wkt(GeometryObject *obj, char *format, char trim,
     return result;
 }
 
-
-static PyObject *GeometryObject_ToWKT(GeometryObject *self, PyObject *args, PyObject *kw)
-{
-    char trim = 1;
-    int precision = 6;
-    int dimension = 3;
-    int use_old_3d = 0;
-    static char *kwlist[] = {"precision", "trim", "dimension", "use_old_3d", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "|ibib", kwlist,
-                                     &precision, &trim, &dimension, &use_old_3d))
-    {
-        return NULL;
-    }
-    return to_wkt(self, "%s", trim, precision, dimension, use_old_3d);
-}
-
 static PyObject *GeometryObject_repr(GeometryObject *self)
 {
-    if (self->ptr == NULL) {
-        return PyUnicode_FromString("<pygeos.NaG>");
-    } else {
-        return to_wkt(self, "<pygeos.Geometry %s>", 1, 3, 3, 0);
-    }
+    return GeometryObject_ToWKT(self, "<pygeos.Geometry %s>");
 }
 
 static PyObject *GeometryObject_str(GeometryObject *self)
 {
-    return to_wkt(self, "%s", 1, 3, 3, 0);
-}
-
-static PyObject *GeometryObject_ToWKB(GeometryObject *self, PyObject *args, PyObject *kw)
-{
-    void *context_handle = geos_context[0];
-    unsigned char *wkb;
-    size_t size;
-    PyObject *result;
-    int dimension = 3;
-    int byte_order = 1;
-    char include_srid = 0;
-    char hex = 0;
-    static char *kwlist[] = {"dimension", "byte_order", "include_srid", "hex", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "|ibbb", kwlist,
-                                     &dimension, &byte_order, &include_srid, &hex))
-    {
-        return NULL;
-    }
-    if (self->ptr == NULL) {
-         Py_INCREF(Py_None);
-         return Py_None;
-    }
-    GEOSWKBWriter *writer = GEOSWKBWriter_create_r(context_handle);
-    if (writer == NULL) {
-        return NULL;
-    }
-    GEOSWKBWriter_setOutputDimension_r(context_handle, writer, dimension);
-    GEOSWKBWriter_setByteOrder_r(context_handle, writer, byte_order);
-    GEOSWKBWriter_setIncludeSRID_r(context_handle, writer, include_srid);
-    if (hex) {
-        wkb = GEOSWKBWriter_writeHEX_r(context_handle, writer, self->ptr, &size);
-    } else {
-        wkb = GEOSWKBWriter_write_r(context_handle, writer, self->ptr, &size);
-    }
-    result = PyBytes_FromStringAndSize((char *) wkb, size);
-    GEOSFree_r(context_handle, wkb);
-    GEOSWKBWriter_destroy_r(context_handle, writer);
-    return result;
+    return GeometryObject_ToWKT(self, "%s");
 }
 
 static PyObject *GeometryObject_FromWKT(PyTypeObject *type, PyObject *value)
@@ -169,57 +114,6 @@ static PyObject *GeometryObject_FromWKT(PyTypeObject *type, PyObject *value)
     return result;
 }
 
-static PyObject *GeometryObject_FromWKB(PyTypeObject *type, PyObject *value)
-{
-    void *context_handle = geos_context[0];
-    PyObject *result = NULL;
-    GEOSGeometry *geom;
-    GEOSWKBReader *reader;
-    char *wkb;
-    Py_ssize_t size;
-    char is_hex;
-
-    /* Cast the PyObject (only bytes) to char* */
-    if (!PyBytes_Check(value)) {
-        PyErr_Format(PyExc_TypeError, "Expected bytes, found %s", value->ob_type->tp_name);
-        return NULL;
-    }
-    size = PyBytes_Size(value);
-    wkb = PyBytes_AsString(value);
-    if (wkb == NULL) {
-        return NULL;
-    }
-
-    /* Check if this is a HEX WKB */
-    if (size != 0) {
-        is_hex = ((wkb[0] == 48) | (wkb[0] == 49));
-    } else {
-        is_hex = 0;
-    }
-
-    /* Create the reader and read the WKB */
-    reader = GEOSWKBReader_create_r(context_handle);
-    if (reader == NULL) {
-        return NULL;
-    }
-    if (is_hex) {
-        geom = GEOSWKBReader_readHEX_r(context_handle, reader, (unsigned char *) wkb, size);
-    } else {
-        geom = GEOSWKBReader_read_r(context_handle, reader, (unsigned char *) wkb, size);
-    }
-    GEOSWKBReader_destroy_r(context_handle, reader);
-    if (geom == NULL) {
-        return NULL;
-    }
-    result = GeometryObject_FromGEOS(type, geom);
-    if (result == NULL) {
-        GEOSGeom_destroy_r(context_handle, geom);
-        PyErr_Format(PyExc_RuntimeError, "Could not instantiate a new Geometry object");
-    }
-    return result;
-}
-
-
 static PyObject *GeometryObject_new(PyTypeObject *type, PyObject *args,
                                     PyObject *kwds)
 {
@@ -228,15 +122,11 @@ static PyObject *GeometryObject_new(PyTypeObject *type, PyObject *args,
     if (!PyArg_ParseTuple(args, "O", &value)) {
         return NULL;
     }
-
-    if (PyBytes_Check(value)) {
-        return GeometryObject_FromWKB(type, value);
-    }
     else if (PyUnicode_Check(value)) {
         return GeometryObject_FromWKT(type, value);
     }
     else {
-        PyErr_Format(PyExc_TypeError, "Expected string or bytes, found %s", value->ob_type->tp_name);
+        PyErr_Format(PyExc_TypeError, "Expected string, got %s", value->ob_type->tp_name);
         return NULL;
     }
 }
@@ -245,14 +135,8 @@ static PyMethodDef GeometryObject_methods[] = {
     {"to_wkt", (PyCFunction) GeometryObject_ToWKT, METH_VARARGS | METH_KEYWORDS,
      "Write the geometry to Well-Known Text (WKT) format"
     },
-    {"to_wkb", (PyCFunction) GeometryObject_ToWKB, METH_VARARGS | METH_KEYWORDS,
-     "Write the geometry to Well-Known Binary (WKB) format"
-    },
     {"from_wkt", (PyCFunction) GeometryObject_FromWKT, METH_CLASS | METH_O,
      "Read the geometry from Well-Known Text (WKT) format"
-    },
-    {"from_wkb", (PyCFunction) GeometryObject_FromWKB, METH_CLASS | METH_O,
-     "Read the geometry from Well-Known Binary (WKB) format"
     },
     {NULL}  /* Sentinel */
 };

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -132,12 +132,6 @@ static PyObject *GeometryObject_new(PyTypeObject *type, PyObject *args,
 }
 
 static PyMethodDef GeometryObject_methods[] = {
-    {"to_wkt", (PyCFunction) GeometryObject_ToWKT, METH_VARARGS | METH_KEYWORDS,
-     "Write the geometry to Well-Known Text (WKT) format"
-    },
-    {"from_wkt", (PyCFunction) GeometryObject_FromWKT, METH_CLASS | METH_O,
-     "Read the geometry from Well-Known Text (WKT) format"
-    },
     {NULL}  /* Sentinel */
 };
 

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -88,6 +88,11 @@ static PyObject *GeometryObject_repr(GeometryObject *self)
     }
 }
 
+static PyObject *GeometryObject_str(GeometryObject *self)
+{
+    return to_wkt(self, "%s", 1, 3, 3, 0);
+}
+
 static PyObject *GeometryObject_ToWKB(GeometryObject *self, PyObject *args, PyObject *kw)
 {
     void *context_handle = geos_context[0];
@@ -264,6 +269,7 @@ PyTypeObject GeometryType = {
     .tp_members = GeometryObject_members,
     .tp_methods = GeometryObject_methods,
     .tp_repr = (reprfunc) GeometryObject_repr,
+    .tp_str = (reprfunc) GeometryObject_str,
 };
 
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1116,7 +1116,6 @@ static void to_wkt_func(char **args, npy_intp *dimensions,
     GEOSGeometry *in1;
     GEOSWKTWriter *writer;
     char *wkt;
-    char *format = "%s";
 
     if ((is2 != 0) | (is3 != 0) | (is4 != 0) | (is5 != 0)) {
         PyErr_Format(PyExc_ValueError, "to_wkt function called with non-scalar parameters");
@@ -1144,7 +1143,7 @@ static void to_wkt_func(char **args, npy_intp *dimensions,
         } else {
             wkt = GEOSWKTWriter_write_r(context_handle, writer, in1);
             Py_XDECREF(*out);
-            *out = PyUnicode_FromFormat(format, wkt);
+            *out = PyUnicode_FromString(wkt);
             GEOSFree_r(context_handle, wkt);
         }
     }

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -933,13 +933,19 @@ static void from_wkb_func(char **args, npy_intp *dimensions,
         }
         else {
             /* Cast the PyObject (only bytes) to char* */
-            if (!PyBytes_Check(in1)) {
+            if (PyBytes_Check(in1)) {
+                size = PyBytes_Size(in1);
+                wkb = (unsigned char *)PyBytes_AsString(in1);
+                if (wkb == NULL) {
+                    goto finish;
+                }
+            } else if (PyUnicode_Check(in1)) {
+                wkb = (unsigned char *)PyUnicode_AsUTF8AndSize(in1, &size);
+                if (wkb == NULL) {
+                    goto finish;
+                }
+            } else {
                 PyErr_Format(PyExc_TypeError, "Expected bytes, got %s", Py_TYPE(in1)->tp_name);
-                goto finish;
-            }
-            size = PyBytes_Size(in1);
-            wkb = (unsigned char *)PyBytes_AsString(in1);
-            if (wkb == NULL) {
                 goto finish;
             }
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3,7 +3,6 @@
 
 #include <Python.h>
 #include <math.h>
-#include <stdio.h>
 
 #define NO_IMPORT_ARRAY
 #define NO_IMPORT_UFUNC

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -964,12 +964,12 @@ static void from_wkb_func(char **args, npy_intp *dimensions,
             /* Cast the PyObject (only bytes) to char* */
             if (!PyBytes_Check(in1)) {
                 PyErr_Format(PyExc_TypeError, "Expected bytes, got %s", Py_TYPE(in1)->tp_name);
-                return;
+                goto finish;
             }
             size = PyBytes_Size(in1);
             wkb = (unsigned char *)PyBytes_AsString(in1);
             if (wkb == NULL) {
-                return;
+                goto finish;
             }
 
             /* Check if this is a HEX WKB */
@@ -986,12 +986,14 @@ static void from_wkb_func(char **args, npy_intp *dimensions,
                 ret_ptr = GEOSWKBReader_read_r(context_handle, reader, wkb, size);
             }
             if (ret_ptr == NULL) {
-                return;
+                goto finish;
             }
         }
         OUTPUT_Y;
     }
-    GEOSWKBReader_destroy_r(context_handle, reader);
+    goto finish;
+
+    finish: GEOSWKBReader_destroy_r(context_handle, reader);
 }
 static PyUFuncGenericFunction from_wkb_funcs[1] = {&from_wkb_func};
 
@@ -1026,25 +1028,27 @@ static void from_wkt_func(char **args, npy_intp *dimensions,
             /* Cast the PyObject (bytes or str) to char* */
             if (PyBytes_Check(in1)) {
                 wkt = PyBytes_AsString(in1);
-                if (wkt == NULL) { return; }
+                if (wkt == NULL) { goto finish; }
             }
             else if (PyUnicode_Check(in1)) {
                 wkt = PyUnicode_AsUTF8(in1);
-                if (wkt == NULL) { return; }
+                if (wkt == NULL) { goto finish; }
             } else {
                 PyErr_Format(PyExc_TypeError, "Expected bytes, got %s", Py_TYPE(in1)->tp_name);
-                return;
+                goto finish;
             }
 
             /* Read the WKT */
             ret_ptr = GEOSWKTReader_read_r(context_handle, reader, wkt);
             if (ret_ptr == NULL) {
-                return;
+                goto finish;
             }
         }
         OUTPUT_Y;
     }
-    GEOSWKTReader_destroy_r(context_handle, reader);
+    goto finish;
+
+    finish: GEOSWKTReader_destroy_r(context_handle, reader);
 }
 static PyUFuncGenericFunction from_wkt_funcs[1] = {&from_wkt_func};
 
@@ -1075,7 +1079,7 @@ static void to_wkb_func(char **args, npy_intp *dimensions,
     GEOSWKBWriter_setIncludeSRID_r(context_handle, writer, include_srid);
 
     UNARY_LOOP {
-        if (!get_geom(*(GeometryObject **)ip1, &in1)) { return; }
+        if (!get_geom(*(GeometryObject **)ip1, &in1)) { goto finish; }
         PyObject **out = (PyObject **)op1;
 
         if (in1 == NULL) {  
@@ -1093,7 +1097,9 @@ static void to_wkb_func(char **args, npy_intp *dimensions,
             GEOSFree_r(context_handle, wkb);
         }
     }
-    GEOSWKBWriter_destroy_r(context_handle, writer);
+    goto finish;
+
+    finish: GEOSWKBWriter_destroy_r(context_handle, writer);
 }
 static PyUFuncGenericFunction to_wkb_funcs[1] = {&to_wkb_func};
 
@@ -1128,7 +1134,7 @@ static void to_wkt_func(char **args, npy_intp *dimensions,
     GEOSWKTWriter_setOld3D_r(context_handle, writer, *(npy_bool *) ip5);
 
     for(i = 0; i < n; i++, ip1 += is1, op1 += os1) {
-        if (!get_geom(*(GeometryObject **)ip1, &in1)) { return; }
+        if (!get_geom(*(GeometryObject **)ip1, &in1)) { goto finish; }
         PyObject **out = (PyObject **)op1;
 
         if (in1 == NULL) {  
@@ -1142,7 +1148,9 @@ static void to_wkt_func(char **args, npy_intp *dimensions,
             GEOSFree_r(context_handle, wkt);
         }
     }
-    GEOSWKTWriter_destroy_r(context_handle, writer);
+    goto finish;
+
+    finish: GEOSWKTWriter_destroy_r(context_handle, writer);
 }
 static PyUFuncGenericFunction to_wkt_funcs[1] = {&to_wkt_func};
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1076,6 +1076,9 @@ static void to_wkb_func(char **args, npy_intp *dimensions,
             } else {
                 wkb = GEOSWKBWriter_write_r(context_handle, writer, in1, &size);
             }
+            if (wkb == NULL) {
+                goto finish;
+            }
             Py_XDECREF(*out);
             if (hex) {
                 *out = PyUnicode_FromStringAndSize((char *) wkb, size);
@@ -1130,6 +1133,9 @@ static void to_wkt_func(char **args, npy_intp *dimensions,
             *out = Py_None;
         } else {
             wkt = GEOSWKTWriter_write_r(context_handle, writer, in1);
+            if (wkt == NULL) {
+                goto finish;
+            }
             Py_XDECREF(*out);
             *out = PyUnicode_FromString(wkt);
             GEOSFree_r(context_handle, wkt);


### PR DESCRIPTION
Start for adding from_wkt / to_wkt / from_wkb / to_wkt ufuncs.

They are right now already defined on the Geometry object, but those are useful as ufuncs as well. 
We can probably remove the implementation in pygeom.c to avoid duplication. But the question is whether we want to keep those as methods in the public API?

I should maybe also move this into a separate .c file, as the ufuncs.c is starting to become quite long? (although it are ufuncs)

Still need to make the nice Python functions, only the barebone ufuncs for now for the readers. 
Also still need to do proper error handling (ensure that I destroy the reader when there is an error)