### PR TITLE
ENH: add equals_exact predicate

### DIFF
--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -24,6 +24,7 @@ __all__ = [
     "overlaps",
     "touches",
     "within",
+    "equals_exact",
 ]
 
 
@@ -490,7 +491,6 @@ def equals(a, b, tolerance=0.0, **kwargs):
     a, b : Geometry or array_like
     tolerance : float or array_like
 
-
     Examples
     --------
     >>> line = Geometry("LINESTRING(0 0, 5 5, 10 10)")
@@ -635,3 +635,43 @@ def within(a, b, **kwargs):
     False
     """
     return lib.within(a, b, **kwargs)
+
+
+def equals_exact(a, b, tolerance=0.0, **kwargs):
+    """Returns True if A and B are structurally equal.
+
+    This method uses exact coordinate equality, which requires coordinates
+    to be equal (within specified tolerance) and and in the same order for all
+    components of a geometry. This is in contrast with the `equals` function
+    which uses spatial (topological) equality.
+
+    Parameters
+    ----------
+    a, b : Geometry or array_like
+    tolerance : float or array_like
+
+    See Also
+    --------
+    equals : Check if A and B are spatially equal.
+
+    Examples
+    --------
+    >>> point1 = Geometry("POINT(50 50)")
+    >>> point2 = Geometry("POINT(50.1 50.1)")
+    >>> equals_exact(point1, point2)
+    False
+    >>> equals_exact(point1, point2, tolerance=0.2)
+    True
+    >>> equals_exact(point1, None, tolerance=0.2)
+    True
+
+    Difference between structucal and spatial equality:
+
+    >>> polygon1 = Geometry("POLYGON((0 0, 1 1, 0 1, 0 0))")
+    >>> polygon2 = Geometry("POLYGON((0 0, 0 1, 1 1, 0 0))")
+    >>> equals_exact(polygon1, polygon2)
+    False
+    >>> equals(polygon1, polygon2)
+    True
+    """
+    return lib.equals_exact(a, b, tolerance, **kwargs)

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -479,34 +479,32 @@ def disjoint(a, b, **kwargs):
     return lib.disjoint(a, b, **kwargs)
 
 
-def equals(a, b, tolerance=0.0, **kwargs):
+def equals(a, b, **kwargs):
     """Returns True if A and B are spatially equal.
 
     If A is within B and B is within A, A and B are considered equal. The
-    ordering of points can be different. Optionally, a tolerance can be
-    provided for comparing vertices.
+    ordering of points can be different.
 
     Parameters
     ----------
     a, b : Geometry or array_like
-    tolerance : float or array_like
+
+    See Also
+    --------
+    equals_exact : Check if A and B are structurally equal given a specified
+        tolerance.
 
     Examples
     --------
     >>> line = Geometry("LINESTRING(0 0, 5 5, 10 10)")
     >>> equals(line, Geometry("LINESTRING(0 0, 10 10)"))
     True
-    >>> equals(Geometry("POINT (5 5)"), Geometry("POINT (5.1 5)"), tolerance=0.1)
-    True
     >>> equals(Geometry("POLYGON EMPTY"), Geometry("GEOMETRYCOLLECTION EMPTY"))
     True
     >>> equals(None, None)
     False
     """
-    if tolerance > 0.0:
-        return lib.equals_exact(a, b, tolerance, **kwargs)
-    else:
-        return lib.equals(a, b, **kwargs)
+    return lib.equals(a, b, **kwargs)
 
 
 def intersects(a, b, **kwargs):

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -661,7 +661,7 @@ def equals_exact(a, b, tolerance=0.0, **kwargs):
     >>> equals_exact(point1, point2, tolerance=0.2)
     True
     >>> equals_exact(point1, None, tolerance=0.2)
-    True
+    False
 
     Difference between structucal and spatial equality:
 

--- a/pygeos/test/test_predicates.py
+++ b/pygeos/test/test_predicates.py
@@ -26,6 +26,7 @@ BINARY_PREDICATES = (
     pygeos.equals,
     pygeos.covers,
     pygeos.covered_by,
+    pygeos.equals_exact,
 )
 
 
@@ -73,3 +74,19 @@ def test_binary_with_kwargs(func):
 def test_binary_missing(func):
     actual = func(np.array([point, None, None]), np.array([None, point, None]))
     assert (~actual).all()
+
+
+def test_equals_exact_tolerance():
+    # specifying tolerance
+    p1 = pygeos.points(50, 4)
+    p2 = pygeos.points(50.1, 4.1)
+    actual = pygeos.equals_exact([p1, p2, None], p1, tolerance=0.05)
+    np.testing.assert_allclose(actual, [True, False, False])
+    assert actual.dtype == np.bool
+    actual = pygeos.equals_exact([p1, p2, None], p1, tolerance=0.2)
+    np.testing.assert_allclose(actual, [True, True, False])
+    assert actual.dtype == np.bool
+
+    # default value for tolerance
+    assert pygeos.equals_exact(p1, p1).item() is True
+    assert pygeos.equals_exact(p1, p2).item() is False


### PR DESCRIPTION
This adds a `equals_exact` predicate. 
I thought the python wrapper for the ufunc was missing for this one, so added it to `predicates.py`, but only then saw that it is actually exposed through `equals` with a tolerance argument. 
But since I already did the work, directly opening the PR instead of an issue.

I would argue that it is better to have a separate `equals_exact` instead of combining it in `equals`:

- There are doing something different: spatial equality (based on the DE-9IM model) vs exact coordinate equality. Therefore, there are some differences between both functions to be aware of as a user (eg different ordering of interiors or different direction of the ring). It's not just adding `tolerance` to the `equals` (eg `equals_exact(.., tolerance=0)` is not the same as `equals(..)`)
- Other libraries also seem to make this distinction. Starting with GEOS of course, but also shapely and postgis do