### PR TITLE
Ensure to only use GEOS reentrant API

### DIFF
--- a/src/coords.h
+++ b/src/coords.h
@@ -2,7 +2,6 @@
 #define _PYGEOSCOORDS_H
 
 #include <Python.h>
-#include <geos_c.h>
 
 extern PyObject *PyCountCoords(PyObject *self, PyObject *args);
 extern PyObject *PyGetCoords(PyObject *self, PyObject *args);

--- a/src/geos.h
+++ b/src/geos.h
@@ -2,6 +2,10 @@
 #define _GEOS_H
 
 #include <Python.h>
+
+/* To avoid accidental use of non reentrant GEOS API. */
+#define GEOS_USE_ONLY_R_API
+
 #include <geos_c.h>
 
 #define RAISE_ILLEGAL_GEOS if (!PyErr_Occurred()) {PyErr_Format(PyExc_RuntimeError, "Uncaught GEOS exception");}


### PR DESCRIPTION
This also reduces the number of warnings a bit, as many of the "function declaration isn’t a prototype" were coming from the non-reentrant declarations in geoc_c.h