### PR TITLE
Reintroduce shared_paths

### DIFF
--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -88,7 +88,7 @@ def line_merge(line):
     """
     return lib.line_merge(line)
 
-def shared_paths(geom1, geom2=None, axis=0):
+def shared_paths(geom1, geom2, axis=0):
     """Returns the shared paths between geom1 and geom2, where both geometries
     are linestrings or arrays of linestrings. A geometrycollection or array of
     geometrycollections is returned with each geometrycollection two elements.
@@ -99,10 +99,7 @@ def shared_paths(geom1, geom2=None, axis=0):
     Parameters
     ----------
     geom1 : Geometry or array_like
-    geom2 : Geometry or array_like, optional
-    axis : int, optional
-        The axis along which to apply the function, by default 0
-        Only applies when geom2 is None.
+    geom2 : Geometry or array_like
     
     Examples
     --------
@@ -111,7 +108,4 @@ def shared_paths(geom1, geom2=None, axis=0):
     >>> shared_paths(geom1, geom2)
     <pygeos.Geometry GEOMETRYCOLLECTION (MULTILINESTRING EMPTY, MULTILINESTRING ((1 0, 1 1)))>
     """    
-    if geom2 is None:
-        return lib.shared_paths.reduce(geom1, axis=axis)
-    else:		
-        return lib.shared_paths(geom1, geom2)
+    return lib.shared_paths(geom1, geom2)

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -88,24 +88,26 @@ def line_merge(line):
     """
     return lib.line_merge(line)
 
-def shared_paths(geom1, geom2, axis=0):
-    """Returns the shared paths between geom1 and geom2, where both geometries
-    are linestrings or arrays of linestrings. A geometrycollection or array of
-    geometrycollections is returned with each geometrycollection two elements.
-    The first element is a multilinestring containing shared paths with the
-    same direction for both inputs. The second element is a multilinestring
-    containing shared paths with the opposite direction for the two inputs.
-    
+def shared_paths(geom1, geom2):
+    """Returns the shared paths between geom1 and geom2.
+
+    Both geometries should be linestrings or arrays of linestrings.
+    A geometrycollection or array of geometrycollections is returned
+    with each geometrycollection two elements. The first element is a
+    multilinestring containing shared paths with the same direction
+    for both inputs. The second element is a multilinestring containing
+    shared paths with the opposite direction for the two inputs.
+
     Parameters
     ----------
     geom1 : Geometry or array_like
     geom2 : Geometry or array_like
-    
+
     Examples
     --------
     >>> geom1 = Geometry("LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)")
     >>> geom2 = Geometry("LINESTRING (1 0, 2 0, 2 1, 1 1, 1 0)")
     >>> shared_paths(geom1, geom2)
     <pygeos.Geometry GEOMETRYCOLLECTION (MULTILINESTRING EMPTY, MULTILINESTRING ((1 0, 1 1)))>
-    """    
+    """
     return lib.shared_paths(geom1, geom2)

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -1,7 +1,7 @@
 from . import lib
 from . import Geometry  # NOQA
 
-__all__ = ["line_interpolate_point", "line_locate_point", "line_merge"]
+__all__ = ["line_interpolate_point", "line_locate_point", "line_merge", "shared_paths"]
 
 
 def line_interpolate_point(line, distance, normalize=False):
@@ -87,3 +87,9 @@ def line_merge(line):
     <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>
     """
     return lib.line_merge(line)
+
+def shared_paths(a, b=None, axis=0):
+     if b is None:
+         return lib.shared_paths.reduce(a, axis=axis)
+     else:		
+         return lib.shared_paths(a, b)

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -88,6 +88,7 @@ def line_merge(line):
     """
     return lib.line_merge(line)
 
+
 def shared_paths(geom1, geom2):
     """Returns the shared paths between geom1 and geom2.
 

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -88,8 +88,30 @@ def line_merge(line):
     """
     return lib.line_merge(line)
 
-def shared_paths(a, b=None, axis=0):
-     if b is None:
-         return lib.shared_paths.reduce(a, axis=axis)
-     else:		
-         return lib.shared_paths(a, b)
+def shared_paths(geom1, geom2=None, axis=0):
+    """Returns the shared paths between geom1 and geom2, where both geometries
+    are linestrings or arrays of linestrings. A geometrycollection or array of
+    geometrycollections is returned with each geometrycollection two elements.
+    The first element is a multilinestring containing shared paths with the
+    same direction for both inputs. The second element is a multilinestring
+    containing shared paths with the opposite direction for the two inputs.
+    
+    Parameters
+    ----------
+    geom1 : Geometry or array_like
+    geom2 : Geometry or array_like, optional
+    axis : int, optional
+        The axis along which to apply the function, by default 0
+        Only applies when geom2 is None.
+    
+    Examples
+    --------
+    >>> geom1 = Geometry("LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)")
+    >>> geom2 = Geometry("LINESTRING (1 0, 2 0, 2 1, 1 1, 1 0)")
+    >>> shared_paths(geom1, geom2)
+    <pygeos.Geometry GEOMETRYCOLLECTION (MULTILINESTRING EMPTY, MULTILINESTRING ((1 0, 1 1)))>
+    """    
+    if geom2 is None:
+        return lib.shared_paths.reduce(geom1, axis=axis)
+    else:		
+        return lib.shared_paths(geom1, geom2)

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -70,5 +70,4 @@ def test_shared_paths_linestring():
     g2 = pygeos.linestrings([(0, 0), (1, 0)])
     actual1 = pygeos.shared_paths(g1, g2)
     assert pygeos.equals(pygeos.get_geometry(actual1, 0), g2)
-    assert pygeos.shared_paths(None, None) == None
-    assert len(pygeos.shared_paths([[g1, g2], [g1, g2]], axis=1)) == 2
+    assert pygeos.shared_paths(None, None) is None

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -65,6 +65,7 @@ def test_line_merge_geom_array():
     assert pygeos.equals(actual[0], line_string)
     assert pygeos.equals(actual[1], multi_line_string)
 
+
 def test_shared_paths_linestring():
     g1 = pygeos.linestrings([(0, 0), (1, 0), (1, 1)])
     g2 = pygeos.linestrings([(0, 0), (1, 0)])

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -64,3 +64,9 @@ def test_line_merge_geom_array():
     actual = pygeos.line_merge([line_string, multi_line_string])
     assert pygeos.equals(actual[0], line_string)
     assert pygeos.equals(actual[1], multi_line_string)
+
+def test_shared_paths_linestring():
+    g1 = pygeos.linestrings([(0, 0), (1, 0), (1, 1)])
+    g2 = pygeos.linestrings([(0, 0), (1, 0)])
+    actual = pygeos.shared_paths(g1, g2)
+    assert pygeos.equals(pygeos.get_geometry(actual, 0), g2)

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -68,5 +68,7 @@ def test_line_merge_geom_array():
 def test_shared_paths_linestring():
     g1 = pygeos.linestrings([(0, 0), (1, 0), (1, 1)])
     g2 = pygeos.linestrings([(0, 0), (1, 0)])
-    actual = pygeos.shared_paths(g1, g2)
-    assert pygeos.equals(pygeos.get_geometry(actual, 0), g2)
+    actual1 = pygeos.shared_paths(g1, g2)
+    assert pygeos.equals(pygeos.get_geometry(actual1, 0), g2)
+    assert pygeos.shared_paths(None, None) == None
+    assert len(pygeos.shared_paths([[g1, g2], [g1, g2]], axis=1)) == 2

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -70,4 +70,9 @@ def test_shared_paths_linestring():
     g2 = pygeos.linestrings([(0, 0), (1, 0)])
     actual1 = pygeos.shared_paths(g1, g2)
     assert pygeos.equals(pygeos.get_geometry(actual1, 0), g2)
+
+
+def test_shared_paths_none():
+    assert pygeos.shared_paths(line_string, None) is None
+    assert pygeos.shared_paths(None, line_string) is None
     assert pygeos.shared_paths(None, None) is None

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -391,6 +391,7 @@ static void *intersection_data[1] = {GEOSIntersection_r};
 static void *difference_data[1] = {GEOSDifference_r};
 static void *symmetric_difference_data[1] = {GEOSSymDifference_r};
 static void *union_data[1] = {GEOSUnion_r};
+static void *shared_paths_data[1] = {GEOSSharedPaths_r};
 typedef void *FuncGEOS_YY_Y(void *context, void *a, void *b);
 static char YY_Y_dtypes[3] = {NPY_OBJECT, NPY_OBJECT, NPY_OBJECT};
 static void YY_Y_func(char **args, npy_intp *dimensions,
@@ -1293,6 +1294,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
     DEFINE_YY_Y (difference);
     DEFINE_YY_Y (symmetric_difference);
     DEFINE_YY_Y (union);
+    DEFINE_YY_Y (shared_paths);
 
     DEFINE_Y_d (get_x);
     DEFINE_Y_d (get_y);


### PR DESCRIPTION
This PR reintroduce the function `pygeos.shared_paths()` as was discussed in https://github.com/pygeos/pygeos/issues/73.

The `shared_paths()` function returns a `pygeos.Geometry GEOMETRYCOLLECTION`. 

To access the shared paths that have the same direction in both inputs use index 0 in `pygeos.get_geometry()` using the result of `shared_paths()` and use index 1 to access the shared paths that have the opposite direction.

