### PR TITLE
Duplicate symbol error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import sysconfig
 from distutils.version import LooseVersion
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext as _build_ext
@@ -110,7 +111,8 @@ class build_ext(_build_ext):
 module_lib = Extension(
     "pygeos.lib",
     sources=["src/lib.c", "src/geos.c", "src/pygeom.c", "src/ufuncs.c", "src/coords.c"],
-    **get_geos_paths()
+    **get_geos_paths(),
+    extra_compile_args=sysconfig.get_config_var('CFLAGS').split() + ["-fcommon"]
 )
 
 


### PR DESCRIPTION
Hi everyone,

When compiling on macOS 10.14 with Python 3.7 and GEOS 3.8 in a clean virtual env, I got a compiler/linker error:

```
duplicate symbol '_GeometryType' in:
    build/temp.macosx-10.14-x86_64-3.7/src/lib.o
    build/temp.macosx-10.14-x86_64-3.7/src/pygeom.o
```

I am not very well-versed in linker intricacies, so I looked around and it seems that the process can be fixed by declaring `-fcommon`. Not sure whether this is a macOS-only or newer clang problem and if this is the only viable solution, but it worked for me.