### PR TITLE
Release the GIL within the ufuncs where possible

### DIFF
--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -150,7 +150,6 @@ PyTypeObject GeometryType = {
     .tp_str = (reprfunc) GeometryObject_str,
 };
 
-
 /* Get a GEOSGeometry pointer from a GeometryObject, or NULL if the input is
 Py_None. Returns 0 on error, 1 on success. */
 char get_geom(GeometryObject *obj, GEOSGeometry **out) {
@@ -162,6 +161,32 @@ char get_geom(GeometryObject *obj, GEOSGeometry **out) {
             PyErr_Format(PyExc_TypeError, "One of the arguments is of incorrect type. Please provide only Geometry objects.");
             return 0;
         }
+    } else {
+        *out = obj->ptr;
+        return 1;
+    }
+}
+
+/* Check if the input is a GeometryObject or Py_None. Returns 0 on error, 1 on success. */
+char check_geom(GeometryObject *obj) {
+    if (!PyObject_IsInstance((PyObject *) obj, (PyObject *) &GeometryType)) {
+        if ((PyObject *) obj == Py_None) {
+            return 1;
+        } else {
+            PyErr_Format(PyExc_TypeError, "One of the arguments is of incorrect type. Please provide only Geometry objects.");
+            return 0;
+        }
+    } else {
+        return 1;
+    }
+}
+
+/* Get a GEOSGeometry pointer from a GeometryObject, or NULL if the input is
+Py_None. Does no checking of the input, assumes this is already done. */
+char get_geom_nogil(GeometryObject *obj, GEOSGeometry **out) {
+    if (obj == Py_None) {
+        *out = NULL;
+        return 1;
     } else {
         *out = obj->ptr;
         return 1;

--- a/src/pygeom.h
+++ b/src/pygeom.h
@@ -17,6 +17,8 @@ extern PyTypeObject GeometryType;
 extern PyObject *GeometryObject_FromGEOS(PyTypeObject *type, GEOSGeometry *ptr);
 /* Get a GEOSGeometry from a GeometryObject */
 extern char get_geom(GeometryObject *obj, GEOSGeometry **out);
+extern char check_geom(GeometryObject *obj);
+extern char get_geom_nogil(GeometryObject *obj, GEOSGeometry **out);
 
 extern int init_geom_type(PyObject *m);
 


### PR DESCRIPTION
xref https://github.com/pygeos/pygeos/issues/7

@caspervdw I cleaned up my previous experiment with releasing the GIL (and added handling of None), and pushed it here. This is only doing it for the "YY_d" (eg distance) for testing the approach.

Tested with:

```python
import numpy as np
import pygeos

N = 1_000_000
arr = pygeos.points(np.random.rand(N, 2))
arr[np.random.randint(0, N, size=100)] = None
poly = pygeos.box(0, 0, 0.2, 0.2)

res1 = pygeos.distance(poly, arr)
```
and it doesn't give a noticeable slowdown in a single thread. Testing it with dask with multi-threading, then it gives a speed-up of around 3x on my 4-core laptop:

```python
import dask.array
arr_dask = dask.array.from_array(arr, chunks=100_000)

res2 = arr_dask.map_blocks(pygeos.distance, poly, dtype=float)
assert np.allclose(res1, res2.compute(), equal_nan=True)
%timeit res2.compute()
```

Now, some things / questions about the approach:

- I do a first pass to check the data, and then in a second nogil pass I get the pointers out without checking. 
  A problem might be that in the meantime, those objects could have changes, if the array gets modified while the ufunc is running.
- An alternative is probably what I did in https://github.com/pygeos/pygeos/issues/7#issuecomment-522708942, which is copying the pointers into a new array in a first pass and looping over that in a second nogil pass. However, with the other approach I wanted to avoid the copying of the pointers. Also, in this approach, we will probably need to increase the reference count on all objects to avoid they get released while the nogil loop is running in case someone modifies the array.
- I still need to check how this works with the geos context and geos exceptions being raised (does each function needs its own context? xref https://github.com/pygeos/pygeos/issues/31). To test this, I need to find a code example where GEOS actually raises an error. In principle the GEOSDistance function "Return 0 on exception", but not sure how to trigger this with an example (we also don't have tests for this, only in the IO tests, but for those it is more difficult to release the gil).

Since for both approaches, the fact that the array might get modified while the ufunc is running is problematic, I am wondering if we can do something about that? Like making the array non writeable when passing to the ufunc (but, how does that work with slices and views? How does that work if the same array is passed to multiple ufuncs? ..)