### PR TITLE
Remove header include that makes clang complain

### DIFF
--- a/src/lib.c
+++ b/src/lib.c
@@ -13,7 +13,6 @@
 #include "pygeom.h"
 #include "coords.h"
 #include "ufuncs.h"
-#include "strtree.h"
 
 
 /* This tells Python what methods this module has. */


### PR DESCRIPTION
With this include in place, the build fails and clang reports "duplicate symbol" _STRTreeType. The project builds when I remove the header include and all the tests pass on my macbook.

Here are my gcc version details:

```
$ gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/c++/4.2.1
Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```