### PR TITLE
WIP: support for prepared geometries

### DIFF
--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -20,6 +20,7 @@ __all__ = [
     "get_point",
     "get_interior_ring",
     "get_geometry",
+    "prepare",
 ]
 
 
@@ -434,3 +435,7 @@ def get_num_geometries(geometry):
     1
     """
     return lib.get_num_geometries(geometry)
+
+
+def prepare(geometry):
+    return lib.prepare(geometry)

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -166,3 +166,9 @@ def test_adapt_ptr_raises():
     point = pygeos.Geometry("POINT (2 2)")
     with pytest.raises(AttributeError):
         point._ptr += 1
+
+
+def test_prepare():
+    point = pygeos.Geometry("POINT (2 2)")
+    prepared = pygeos.prepare(point)
+    print(type(prepared))

--- a/src/pygeom.h
+++ b/src/pygeom.h
@@ -4,20 +4,37 @@
 #include <Python.h>
 #include "geos.h"
 
-
-typedef struct {
-    PyObject_HEAD
-    void *ptr;
+typedef struct
+{
+    PyObject_HEAD void *ptr;
 } GeometryObject;
-
 
 extern PyTypeObject GeometryType;
 
-/* Initializes a new geometry object */
+/* Initializes a new geometry object from a GEOSGeometry */
 extern PyObject *GeometryObject_FromGEOS(PyTypeObject *type, GEOSGeometry *ptr);
+
 /* Get a GEOSGeometry from a GeometryObject */
 extern char get_geom(GeometryObject *obj, GEOSGeometry **out);
 
 extern int init_geom_type(PyObject *m);
+
+
+/*****  Prepared Geometries *****/
+
+typedef struct
+{
+    PyObject_HEAD void *ptr;
+} PreparedGeometryObject;
+
+extern PyTypeObject PreparedGeometryType;
+
+/* Initializes a new geometry object from a GEOSPreparedGeometry */
+extern PyObject *PreparedGeometryObject_FromGEOSPreparedGeometry(PyTypeObject *type, GEOSPreparedGeometry *ptr);
+
+/* Get a GEOSPreparedGeometry from a PreparedGeometryObject */
+extern char get_geom_prepared(PreparedGeometryObject *obj, GEOSPreparedGeometry **out);
+
+
 
 #endif


### PR DESCRIPTION
Work toward supporting `GEOSPreparedGeometry` created from `GEOSGeometry` objects.

I'm new to doing Python C extensions with ufuncs, so I could be doing something obviously incorrect here.

This doesn't yet have the prepared geometry predicates, pending some questions / issues (and some segfaults I haven't been able to sort out):

1. This approach has `GEOSPreparedGeometry` as a companion object to `GEOSGeometry` objects, with all of the associated wrappings and types.  This roughly follows `shapely`'s approach of having a [`PreparedGeometry`](https://github.com/Toblerity/Shapely/blob/master/shapely/prepared.py)  object.  For usage, this means that the user needs to specifically create prepared geometries before running a spatial operation that uses them (related questions below).  Given how those operations are performed as ufuncs, I don't see an easy way to do just-in-time prepared geometries, but I could be missing something.

2. It seems like there are implications around tracking references to the underlying geometry, and deallocating them when appropriate, that seem potentially problematic here.  I'm new enough to how we are handling references here that I don't feel I can fully identify those issues.

3. Is there a way to identify a prepared geometry from a regular geometry, so that in the higher-level API, we don't need to add specific API functions for prepared geometries - we just leverage the prepared geometry and run the associated predicate if we a passed a prepared geometry (this is what shapely does)?  E.g., keep one `intersects` function, instead of adding a `intersects_prepared` function at the high level.  Internally, we'd have separate functions.

4. should conversion to prepared geometries be one way or two way?  Meaning, should we allow the user to convert back from or otherwise get the underlying unprepared geometry?  Or should prepared geometries basically be a dead end, only used as inputs for prepared geometry predicates?