### PR TITLE
ENH: include predicates in STRtree.query()

### DIFF
--- a/docs/strtree.rst
+++ b/docs/strtree.rst
@@ -2,8 +2,5 @@
 =====================
 
 .. automodule:: pygeos.strtree
-   :members:
-   :exclude-members:
-   :special-members:
-   :inherited-members:
-   :show-inheritance:
+   :members: STRtree
+   :exclude-members: BinaryPredicate

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -54,6 +54,8 @@ class STRtree:
         that satisfy the predicate operation when compared against the input
         geometry.
 
+        If geometry is None, an empty array is returned.
+
         Parameters
         ----------
         geometry : Geometry
@@ -63,6 +65,9 @@ class STRtree:
             The predicate to use for testing geometries from the tree
             that are within the input geometry's envelope.
         """
+
+        if geometry is None:
+            return np.array([], dtype="int")
 
         if predicate is None:
             predicate = 0

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -6,8 +6,8 @@ from pygeos import lib
 __all__ = ["STRtree"]
 
 
-class UnaryPredicate(IntEnum):
-    """The enumeration of GEOS unary predicates types"""
+class BinaryPredicate(IntEnum):
+    """The enumeration of GEOS binary predicates types"""
 
     intersects = 1
     within = 2
@@ -17,7 +17,7 @@ class UnaryPredicate(IntEnum):
     touches = 6
 
 
-VALID_PREDICATES = {e.name for e in UnaryPredicate}
+VALID_PREDICATES = {e.name for e in BinaryPredicate}
 
 
 class STRtree:
@@ -50,9 +50,12 @@ class STRtree:
 
     def query(self, geometry, predicate=None):
         """Return all items whose extent intersect the envelope of the input
-        geometry.  If predicate is provided, these items are limited to those
-        that satisfy the predicate operation when compared against the input
         geometry.
+
+        If predicate is provided, a prepared version of the input geometry
+        is tested using that predicate function against each item whose
+        extent intersects the envelope of the input geometry:
+        predicate(geometry, tree_geometry).
 
         If geometry is None, an empty array is returned.
 
@@ -67,7 +70,7 @@ class STRtree:
         """
 
         if geometry is None:
-            return np.array([], dtype="int")
+            return np.array([], dtype=np.intp)
 
         if predicate is None:
             predicate = 0
@@ -80,7 +83,7 @@ class STRtree:
                     )
                 )
 
-            predicate = UnaryPredicate[predicate].value
+            predicate = BinaryPredicate[predicate].value
 
         return self._tree.query(geometry, predicate)
 

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -38,8 +38,14 @@ class STRtree:
     >>> import pygeos
     >>> geoms = pygeos.points(np.arange(10), np.arange(10))
     >>> tree = pygeos.STRtree(geoms)
-    >>> tree.query(pygeos.box(2, 2, 4, 4)).tolist()
+    >>> geom = pygeos.box(2, 2, 4, 4)
+    >>> # Query geometries that overlap envelope of `geom`:
+    >>> tree.query(geom).tolist()
     [2, 3, 4]
+    >>> # Query geometries that overlap envelope of `geom`
+    >>> # and are contained by `geom`:
+    >>> tree.query(geom, predicate='contains').tolist()
+    [3]
     """
 
     def __init__(self, geometries, leafsize=5):
@@ -53,7 +59,7 @@ class STRtree:
         geometry.
 
         If predicate is provided, a prepared version of the input geometry
-        is tested using that predicate function against each item whose
+        is tested using the predicate function against each item whose
         extent intersects the envelope of the input geometry:
         predicate(geometry, tree_geometry).
 
@@ -64,7 +70,7 @@ class STRtree:
         geometry : Geometry
             The envelope of the geometry is taken automatically for
             querying the tree.
-        predicate : str, optional (default: None)
+        predicate : {None, 'intersects', 'within', 'contains', 'overlaps', 'crosses', 'touches'}, optional
             The predicate to use for testing geometries from the tree
             that are within the input geometry's envelope.
         """
@@ -89,4 +95,5 @@ class STRtree:
 
     @property
     def geometries(self):
+        """Return the array_like of geometries used to construct the STRtree."""
         return self._tree.geometries

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -166,6 +166,9 @@ def test_query_unsupported_predicate(tree):
 
 
 ### predicate == 'intersects'
+
+# TEMPORARY xfail: MultiPoint intersects with prepared geometries does not work
+# properly on GEOS 3.5.x; it was fixed in 3.6+
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -182,11 +185,11 @@ def test_query_unsupported_predicate(tree):
         # same points as envelope
         (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [2, 3, 4]),
         # multipoints intersect
-        (pygeos.multipoints([[5, 5], [7, 7]]), [5, 7]),
+        pytest.param(pygeos.multipoints([[5, 5], [7, 7]]), [5, 7], marks=pytest.mark.xfail(reason="GEOS 3.5")),
         # envelope of points contains points, but points do not intersect
         (pygeos.multipoints([[5, 7], [7, 5]]), []),
         # only one point of multipoint intersects
-        (pygeos.multipoints([[5, 7], [7, 7]]), [7]),
+        pytest.param(pygeos.multipoints([[5, 7], [7, 7]]), [7], marks=pytest.mark.xfail(reason="GEOS 3.5")),
     ],
 )
 def test_query_intersects_points(tree, geometry, expected):

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -165,6 +165,7 @@ def test_query_unsupported_predicate(tree):
         tree.query(pygeos.points(1, 1), predicate="disjoint")
 
 
+### predicate == 'intersects'
 @pytest.mark.parametrize(
     "geometry,expected",
     [
@@ -208,7 +209,7 @@ def test_query_intersects_points(tree, geometry, expected):
         (pygeos.buffer(pygeos.points(3, 3), 0.5), [2, 3]),
         # buffer intersects midpoint of line at tangent
         (pygeos.buffer(pygeos.points(2, 1), HALF_UNIT_DIAG), [1]),
-        # envelope of points overlaps 5 lines but intersects none
+        # envelope of points overlaps lines but intersects none
         (pygeos.multipoints([[5, 7], [7, 5]]), []),
         # only one point of multipoint intersects
         (pygeos.multipoints([[5, 7], [7, 7]]), [6, 7]),
@@ -238,9 +239,163 @@ def test_query_intersects_lines(line_tree, geometry, expected):
         (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [1, 2, 3, 4, 5]),
         # envelope of points overlaps polygons, but points do not intersect
         (pygeos.multipoints([[5, 7], [7, 5]]), []),
-        # only one point of multipoint intersects at vertex of 2 lines
+        # only one point of multipoint within polygon
         (pygeos.multipoints([[5, 7], [7, 7]]), [7]),
     ],
 )
 def test_query_intersects_polygons(poly_tree, geometry, expected):
     assert_array_equal(poly_tree.query(geometry, predicate="intersects"), expected)
+
+
+### predicate == 'within'
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # points do not intersect
+        (pygeos.points(0.5, 0.5), []),
+        # points intersect
+        (pygeos.points(1, 1), [1]),
+        # box not within points
+        (box(3, 3, 6, 6), []),
+        # envelope of buffer not within points
+        (pygeos.buffer(pygeos.points(3, 3), 1), []),
+        # multipoints intersect but are not within points in tree
+        (pygeos.multipoints([[5, 5], [7, 7]]), []),
+        # only one point of multipoint intersects, but multipoints are not
+        # within any points in tree
+        (pygeos.multipoints([[5, 7], [7, 7]]), []),
+        # envelope of points contains points, but points do not intersect
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+    ],
+)
+def test_query_within_points(tree, geometry, expected):
+    assert_array_equal(tree.query(geometry, predicate="within"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # endpoint not within first line
+        (pygeos.points(0, 0), []),
+        # point within first line
+        (pygeos.points(0.5, 0.5), [0]),
+        # point within envelope of first line but does not intersect
+        (pygeos.points(0, 0.5), []),
+        # point at shared vertex between 2 lines (but within neither)
+        (pygeos.points(1, 1), []),
+        # box not within line
+        (box(0, 0, 1, 1), []),
+        # buffer intersects 2 lines but not within either
+        (pygeos.buffer(pygeos.points(3, 3), 0.5), []),
+        # envelope of points overlaps lines but intersects none
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+        # only one point of multipoint intersects, but both are not within line
+        (pygeos.multipoints([[5, 7], [7, 7]]), []),
+        (pygeos.multipoints([[6.5, 6.5], [7, 7]]), [6]),
+    ],
+)
+def test_query_within_lines(line_tree, geometry, expected):
+    assert_array_equal(line_tree.query(geometry, predicate="within"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point within first polygon
+        (pygeos.points(0, 0.5), [0]),
+        (pygeos.points(0.5, 0), [0]),
+        # midpoint between two polygons intersects both
+        (pygeos.points(0.5, 0.5), [0, 1]),
+        # point intersects single polygon
+        (pygeos.points(1, 1), [1]),
+        # box overlaps envelope of 2 polygons but within neither
+        (box(0, 0, 1, 1), []),
+        # box within polygon
+        (box(0, 0, 0.5, 0.5), [0]),
+        # larger box intersects 3 polygons but within none
+        (box(0, 0, 1.5, 1.5), []),
+        # buffer intersects 3 polygons but only within one
+        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG), [3]),
+        # larger buffer overlaps 6 polygons (touches midpoints) but within none
+        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), []),
+        # envelope of points overlaps polygons, but points do not intersect
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+        # only one point of multipoint within polygon
+        (pygeos.multipoints([[5, 7], [7, 7]]), []),
+        # both points in multipoint within polygon
+        (pygeos.multipoints([[5.25, 5.5], [5.25, 5.0]]), [5]),
+    ],
+)
+def test_query_within_polygons(poly_tree, geometry, expected):
+    assert_array_equal(poly_tree.query(geometry, predicate="within"), expected)
+
+
+### predicate == 'contains'
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # points do not intersect
+        (pygeos.points(0.5, 0.5), []),
+        # points intersect
+        (pygeos.points(1, 1), [1]),
+        # box contains points (2 are at edges and not contained)
+        (box(3, 3, 6, 6), [4, 5]),
+        # envelope of buffer contains more points than within buffer
+        # due to diagonal distance
+        (pygeos.buffer(pygeos.points(3, 3), 1), [3]),
+        # envelope of buffer with 1/2 distance between points should intersect
+        # same points as envelope
+        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [2, 3, 4]),
+        # multipoints intersect
+        (pygeos.multipoints([[5, 5], [7, 7]]), [5, 7]),
+        # envelope of points contains points, but points do not intersect
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+        # only one point of multipoint intersects
+        (pygeos.multipoints([[5, 7], [7, 7]]), [7]),
+    ],
+)
+def test_query_contains_points(tree, geometry, expected):
+    assert_array_equal(tree.query(geometry, predicate="contains"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point does not contain any lines (not valid relation)
+        (pygeos.points(0, 0), []),
+        # box contains first line (touches edge of 1 but does not contain it)
+        (box(0, 0, 1, 1), [0]),
+        # buffer intersects 2 lines but contains neither
+        (pygeos.buffer(pygeos.points(3, 3), 0.5), []),
+        # envelope of points overlaps lines but intersects none
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+        # only one point of multipoint intersects
+        (pygeos.multipoints([[5, 7], [7, 7]]), []),
+        # both points intersect but do not contain any lines (not valid relation)
+        (pygeos.multipoints([[5, 5], [6, 6]]), []),
+    ],
+)
+def test_query_contains_lines(line_tree, geometry, expected):
+    assert_array_equal(line_tree.query(geometry, predicate="contains"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point does not contain any lines (not valid relation)
+        (pygeos.points(0, 0), []),
+        # box overlaps envelope of 2 polygons but contains neither
+        (box(0, 0, 1, 1), []),
+        # larger box intersects 3 polygons but contains only one
+        (box(0, 0, 2, 2), [1]),
+        # buffer overlaps 3 polygons but contains none
+        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG), []),
+        # larger buffer overlaps 6 polygons (touches midpoints) but contains one
+        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [3]),
+        # envelope of points overlaps polygons, but points do not intersect
+        # (not valid relation)
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+    ],
+)
+def test_query_contains_polygons(poly_tree, geometry, expected):
+    assert_array_equal(poly_tree.query(geometry, predicate="contains"), expected)

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -1,3 +1,4 @@
+import math
 import pygeos
 from pygeos import box
 import pytest
@@ -6,9 +7,33 @@ from numpy.testing import assert_array_equal
 from .common import point, empty, assert_increases_refcount, assert_decreases_refcount
 
 
+# the distance between 2 points spaced at whole numbers along a diagonal
+HALF_UNIT_DIAG = math.sqrt(2) / 2
+EPS = 1e-9
+
+
 @pytest.fixture
 def tree():
     geoms = pygeos.points(np.arange(10), np.arange(10))
+    yield pygeos.STRtree(geoms)
+
+
+@pytest.fixture
+def line_tree():
+    x = np.arange(10)
+    y = np.arange(10)
+    offset = 1
+    geoms = pygeos.linestrings(np.array([[x, x + offset], [y, y + offset]]).T)
+    yield pygeos.STRtree(geoms)
+
+
+@pytest.fixture
+def poly_tree():
+    # create buffers so that midpoint between two buffers intersects
+    # each buffer.  NOTE: add EPS to help mitigate rounding errors at midpoint.
+    geoms = pygeos.buffer(
+        pygeos.points(np.arange(10), np.arange(10)), HALF_UNIT_DIAG + EPS, quadsegs=64
+    )
     yield pygeos.STRtree(geoms)
 
 
@@ -63,11 +88,159 @@ def test_query_empty(tree):
     assert tree.query(empty).size == 0
 
 
-@pytest.mark.parametrize("envelope,expected", [
-    (pygeos.points(1, 1), [1]),
-    (box(0, 0, 1, 1), [0, 1]),
-    (box(5, 5, 15, 15), [5, 6, 7, 8, 9]),
-    (pygeos.multipoints([[5, 7], [7, 5]]), [5, 6, 7]),  # query by envelope
-])
-def test_query(tree, envelope, expected):
-    assert_array_equal(tree.query(envelope), expected)
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # points do not intersect
+        (pygeos.points(0.5, 0.5), []),
+        # points intersect
+        (pygeos.points(1, 1), [1]),
+        # box contains points
+        (box(0, 0, 1, 1), [0, 1]),
+        # box contains points
+        (box(5, 5, 15, 15), [5, 6, 7, 8, 9]),
+        # envelope of buffer contains points
+        (pygeos.buffer(pygeos.points(3, 3), 1), [2, 3, 4]),
+        # envelope of points contains points
+        (pygeos.multipoints([[5, 7], [7, 5]]), [5, 6, 7]),
+    ],
+)
+def test_query_points(tree, geometry, expected):
+    assert_array_equal(tree.query(geometry), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point intersects first line
+        (pygeos.points(0, 0), [0]),
+        (pygeos.points(0.5, 0.5), [0]),
+        # point within envelope of first line
+        (pygeos.points(0, 0.5), [0]),
+        # point at shared vertex between 2 lines
+        (pygeos.points(1, 1), [0, 1]),
+        # box overlaps envelope of first 2 lines (touches edge of 1)
+        (box(0, 0, 1, 1), [0, 1]),
+        # envelope of buffer overlaps envelope of 2 lines
+        (pygeos.buffer(pygeos.points(3, 3), 0.5), [2, 3]),
+        # envelope of points overlaps 5 lines (touches edge of 2 envelopes)
+        (pygeos.multipoints([[5, 7], [7, 5]]), [4, 5, 6, 7]),
+    ],
+)
+def test_query_lines(line_tree, geometry, expected):
+    assert_array_equal(line_tree.query(geometry), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point intersects edge of envelopes of 2 polygons
+        (pygeos.points(0.5, 0.5), [0, 1]),
+        # point intersects single polygon
+        (pygeos.points(1, 1), [1]),
+        # box overlaps envelope of 2 polygons
+        (box(0, 0, 1, 1), [0, 1]),
+        # larger box overlaps envelope of 3 polygons
+        (box(0, 0, 1.5, 1.5), [0, 1, 2]),
+        # envelope of buffer overlaps envelope of 3 polygons
+        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG), [2, 3, 4]),
+        # envelope of larger buffer overlaps envelope of 6 polygons
+        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [1, 2, 3, 4, 5]),
+        # envelope of points overlaps 3 polygons
+        (pygeos.multipoints([[5, 7], [7, 5]]), [5, 6, 7]),
+    ],
+)
+def test_query_polygons(poly_tree, geometry, expected):
+    assert_array_equal(poly_tree.query(geometry), expected)
+
+
+def test_query_invalid_predicate(tree):
+    with pytest.raises(ValueError):
+        tree.query(pygeos.points(1, 1), predicate="bad_predicate")
+
+
+def test_query_unsupported_predicate(tree):
+    # valid GEOS binary predicate, but not supported for query
+    with pytest.raises(ValueError):
+        tree.query(pygeos.points(1, 1), predicate="disjoint")
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # points do not intersect
+        (pygeos.points(0.5, 0.5), []),
+        # points intersect
+        (pygeos.points(1, 1), [1]),
+        # box contains points
+        (box(3, 3, 6, 6), [3, 4, 5, 6]),
+        # envelope of buffer contains more points than intersect buffer
+        # due to diagonal distance
+        (pygeos.buffer(pygeos.points(3, 3), 1), [3]),
+        # envelope of buffer with 1/2 distance between points should intersect
+        # same points as envelope
+        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [2, 3, 4]),
+        # multipoints intersect
+        (pygeos.multipoints([[5, 5], [7, 7]]), [5, 7]),
+        # envelope of points contains points, but points do not intersect
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+        # only one point of multipoint intersects
+        (pygeos.multipoints([[5, 7], [7, 7]]), [7]),
+    ],
+)
+def test_query_intersects_points(tree, geometry, expected):
+    assert_array_equal(tree.query(geometry, predicate="intersects"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point intersects first line
+        (pygeos.points(0, 0), [0]),
+        (pygeos.points(0.5, 0.5), [0]),
+        # point within envelope of first line but does not intersect
+        (pygeos.points(0, 0.5), []),
+        # point at shared vertex between 2 lines
+        (pygeos.points(1, 1), [0, 1]),
+        # box overlaps envelope of first 2 lines (touches edge of 1)
+        (box(0, 0, 1, 1), [0, 1]),
+        # buffer intersects 2 lines
+        (pygeos.buffer(pygeos.points(3, 3), 0.5), [2, 3]),
+        # buffer intersects midpoint of line at tangent
+        (pygeos.buffer(pygeos.points(2, 1), HALF_UNIT_DIAG), [1]),
+        # envelope of points overlaps 5 lines but intersects none
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+        # only one point of multipoint intersects
+        (pygeos.multipoints([[5, 7], [7, 7]]), [6, 7]),
+    ],
+)
+def test_query_intersects_lines(line_tree, geometry, expected):
+    assert_array_equal(line_tree.query(geometry, predicate="intersects"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point within first polygon
+        (pygeos.points(0, 0.5), [0]),
+        (pygeos.points(0.5, 0), [0]),
+        # midpoint between two polygons intersects both
+        (pygeos.points(0.5, 0.5), [0, 1]),
+        # point intersects single polygon
+        (pygeos.points(1, 1), [1]),
+        # box overlaps envelope of 2 polygons
+        (box(0, 0, 1, 1), [0, 1]),
+        # larger box intersects 3 polygons
+        (box(0, 0, 1.5, 1.5), [0, 1, 2]),
+        # buffer overlaps 3 polygons
+        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG), [2, 3, 4]),
+        # larger buffer overlaps 6 polygons (touches midpoints)
+        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [1, 2, 3, 4, 5]),
+        # envelope of points overlaps polygons, but points do not intersect
+        (pygeos.multipoints([[5, 7], [7, 5]]), []),
+        # only one point of multipoint intersects at vertex of 2 lines
+        (pygeos.multipoints([[5, 7], [7, 7]]), [7]),
+    ],
+)
+def test_query_intersects_polygons(poly_tree, geometry, expected):
+    assert_array_equal(poly_tree.query(geometry, predicate="intersects"), expected)

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -41,10 +41,9 @@ static PyArrayObject *copy_kvec_to_npy(npy_intp_vec *arr)
         return NULL;
     }
 
-    // iterate from last value to first to get back original order
-    for (i = size - 1; i >= 0; i--) {
+    for (i = 0; i<size; i++) {
         ptr = PyArray_GETPTR1(result, i);
-        *ptr = (npy_intp)kv_a(npy_intp, *arr, i);
+        *ptr = kv_A(*arr, i);
     }
 
     return (PyArrayObject *) result;
@@ -222,6 +221,7 @@ static PyArrayObject *STRtree_query(STRtreeObject *self, PyObject *args) {
 
     size = kv_size(arr);
     kv_init(arr2);
+
     for (i = 0; i < size; i++) {
         // get index for right geometries from arr
         index = kv_A(arr, i);

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -16,6 +16,36 @@
 #include "pygeom.h"
 #include "kvec.h"
 
+/* GEOS function that takes two geometries and returns bool value */
+
+typedef char FuncGEOS_YY_b(void *context, void *a, void *b);
+
+
+/* Copy values from arr to a new numpy integer array.
+ * The order of values from arr is inverted, because arr is created by pushing
+ * values onto the end. */
+
+static PyObject *copy_kvec_to_npy(npy_intp_vec *arr)
+{
+    npy_intp i;
+    npy_intp size = kv_size(*arr);
+    npy_intp *ptr;
+
+    // size = kv_size(arr2);
+    npy_intp dims[1] = {size};
+    PyArrayObject *result = (PyArrayObject *) PyArray_SimpleNew(1, dims, NPY_INTP);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    // iterate from last value to first to get back original order
+    for (i = size - 1; i >= 0; i--) {
+        ptr = PyArray_GETPTR1(result, i);
+        *ptr = (npy_intp)kv_a(npy_intp, *arr, i);
+    }
+
+    return (PyObject *) result;
+}
 
 static void STRtree_dealloc(STRtreeObject *self)
 {
@@ -87,21 +117,34 @@ static PyObject *STRtree_new(PyTypeObject *type, PyObject *args,
     return (PyObject *) self;
 }
 
+
 /* Callback to give to strtree_query
  * Given the value returned from each intersecting geometry it inserts that
  * value (the index) into the given size_vector */
 
-void strtree_query_callback(void *item, void *user_data)
+void query_callback(void *item, void *user_data)
 {
     kv_push(npy_intp, *(npy_intp_vec *)user_data, (npy_intp) item);
 }
 
-static PyObject *STRtree_query(STRtreeObject *self, PyObject *envelope) {
+
+/* Query the tree based on input geometry and predicate function.
+ * The index of each geometry in the tree whose envelope intersects the
+ * envelope of the input geometry is returned by default.
+ * If predicate function is provided, only the index of those geometries that
+ * satisfy the predicate function are returned. */
+
+static PyObject *STRtree_query(STRtreeObject *self, PyObject *args) {
     GEOSContextHandle_t context = geos_context[0];
-    GEOSGeometry *geom;
-    npy_intp_vec arr; // Resizable array for matches for each geometry
+    GeometryObject *geometry, *target_geometry;
+    const int predicate;
+    GEOSGeometry *geom, *target_geom;
+    npy_intp_vec arr, arr2; // Resizable array for matches for each geometry
     npy_intp i, size;
-    npy_intp *ptr;
+    npy_intp *geom_ptr, *index_ptr;
+    FuncGEOS_YY_b *predicate_func;
+    char passes;
+    PyArrayObject *result;
 
     if (self->ptr == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "Tree is uninitialized");
@@ -111,30 +154,88 @@ static PyObject *STRtree_query(STRtreeObject *self, PyObject *envelope) {
         npy_intp dims[1] = {0};
         return PyArray_SimpleNew(1, dims, NPY_INTP);
     }
-    if (!get_geom((GeometryObject *) envelope, &geom)) {
+
+    if (!PyArg_ParseTuple(args, "O!i", &GeometryType, &geometry, &predicate)){
+        return NULL;
+    }
+
+    if (!get_geom(geometry, &geom)) {
         PyErr_SetString(PyExc_TypeError, "Invalid geometry");
         return NULL;
     }
 
+    // query the tree for indices of geometries in the tree with
+    // envelopes that intersect the geometry.
     kv_init(arr);
     if (geom != NULL) {
-        GEOSSTRtree_query_r(context, self->ptr, geom, strtree_query_callback, &arr);
+        GEOSSTRtree_query_r(context, self->ptr, geom, query_callback, &arr);
     }
 
-    /* create an index array with the appropriate dimensions */
-    size = kv_size(arr);
-    npy_intp dims[1] = {size};
-    PyArrayObject *result = (PyArrayObject *) PyArray_SimpleNew(1, dims, NPY_INTP);
-    if (result == NULL) { kv_destroy(arr); return NULL; }
-    /* insert values starting from array end to preserve order */
-    for (i = size - 1; i >= 0; i--) {
-        ptr = PyArray_GETPTR1(result, i);
-        *ptr = kv_pop(arr);
+    if (predicate == 0) {
+        // No predicate function provided, return all geometry indexes from
+        // query
+        result = copy_kvec_to_npy(&arr);
+        kv_destroy(arr);
+        return (PyObject *) result;
     }
+
+    switch (predicate) {
+        case 1: {  // intersects
+            predicate_func = (FuncGEOS_YY_b *)GEOSIntersects_r;
+            break;
+        }
+        case 2: { // within
+            predicate_func = (FuncGEOS_YY_b *)GEOSWithin_r;
+            break;
+        }
+        case 3: { // contains
+            predicate_func = (FuncGEOS_YY_b *)GEOSContains_r;
+            break;
+        }
+        case 4: { // overlaps
+            predicate_func = (FuncGEOS_YY_b *)GEOSOverlaps_r;
+            break;
+        }
+        case 5: { // crosses
+            predicate_func = (FuncGEOS_YY_b *)GEOSCrosses_r;
+            break;
+        }
+        case 6: { // touches
+            predicate_func = (FuncGEOS_YY_b *)GEOSTouches_r;
+            break;
+        }
+        default: { // unknown predicate
+            PyErr_SetString(PyExc_ValueError, "Invalid query predicate");
+            return NULL;
+        }
+    }
+
+    size = kv_size(arr);
+    kv_init(arr2);
+    for (i = 0; i < size; i++) {
+        index_ptr = (npy_intp)kv_a(npy_intp, arr, i);
+
+        // get pygeos geometries from tree at position from index_ptr (not i)
+        geom_ptr = PyArray_GETPTR1((PyArrayObject *) self->geometries,
+                                   (npy_intp)index_ptr);
+
+        // get GEOS geometry from pygeos geometry
+        target_geometry = *(GeometryObject **) geom_ptr;
+        get_geom(target_geometry, &target_geom);
+
+        // keep the index value if it passes the predicate
+        if (predicate_func(context, geom, target_geom)) {
+            kv_push(npy_intp, arr2, index_ptr);
+        }
+    }
+
     kv_destroy(arr);
+
+    result = copy_kvec_to_npy(&arr2);
+    kv_destroy(arr2);
+
     return (PyObject *) result;
 }
-
 
 
 static PyMemberDef STRtree_members[] = {
@@ -145,8 +246,9 @@ static PyMemberDef STRtree_members[] = {
 };
 
 static PyMethodDef STRtree_methods[] = {
-    {"query", (PyCFunction) STRtree_query, METH_O,
-     "Queries the index for all items whose extents intersect the given search envelope. "
+    {"query", (PyCFunction) STRtree_query, METH_VARARGS,
+     "Queries the index for all items whose extents intersect the given search geometry, and optionally tests them "
+     "against predicate function if provided. "
     },
     {NULL}  /* Sentinel */
 };


### PR DESCRIPTION
This PR adds support for several geometric predicates into the STRtree `query()` function.  In addition to querying geometries from the tree that have envelopes that intersect the envelope of the input geometry, this now allows you to test the predicate relationships between the input geometry and the returned geometries from the tree:
* `intersects`
* `within`
* `contains`
* `overlaps`
* `crosses`
* `touches`

This intentionally does not include other binary predicates, since they don't seem useful in this context (e.g., `disjoint`).

This should make it easier to implement spatial joins on top of `pygeos`.

This could be further improved by using prepared geometries and vectorizing the query function, but those should be handled in a separate PR.

Most of the code here is in tests, to verify that the predicates are being evaluated correctly.  These could be improved further by adding more combinations of geometry types.


In order to preserve the existing behavior where querying the tree with a geometry of `None` returns an empty array, I specifically handle that in the wrapper function since there is no need to step into C code for that.