### PR TITLE
Fix strtree header file 

### DIFF
--- a/src/strtree.h
+++ b/src/strtree.h
@@ -19,8 +19,8 @@ typedef struct
     npy_intp *a;
 } npy_intp_vec;
 
-PyTypeObject STRtreeType;
+extern PyTypeObject STRtreeType;
 
-int init_strtree_type(PyObject *m);
+extern int init_strtree_type(PyObject *m);
 
 #endif


### PR DESCRIPTION
This fixes #89 theoretically.

The `strtree.h` file currently *defines* the symbol STRtreeType. Adding `extern` instead just *declares* STRtreeType, which is what you should do in a header file. Same issue as in #79 

I was looking for a gcc / ld flag that would detect this issue, to add on Travis so that I don't keep making this mistake. 

@sgillies please check if this works for you