### PR TITLE
Fix segfault in strtree test_flush_geometries

### DIFF
--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -53,7 +53,7 @@ class STRtree:
         self._tree = lib.STRtree(self.geometries, leafsize)
 
     def __len__(self):
-        return self._tree.get_size()
+        return self._tree.count
 
     def query(self, geometry, predicate=None):
         """Return all items whose extent intersect the envelope of the input

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -49,10 +49,11 @@ class STRtree:
     """
 
     def __init__(self, geometries, leafsize=5):
-        self._tree = lib.STRtree(np.asarray(geometries, dtype=np.object), leafsize)
+        self.geometries = np.asarray(geometries, dtype=np.object)
+        self._tree = lib.STRtree(self.geometries, leafsize)
 
     def __len__(self):
-        return self._tree.count
+        return self._tree.get_size()
 
     def query(self, geometry, predicate=None):
         """Return all items whose extent intersect the envelope of the input
@@ -92,8 +93,3 @@ class STRtree:
             predicate = BinaryPredicate[predicate].value
 
         return self._tree.query(geometry, predicate)
-
-    @property
-    def geometries(self):
-        """Return the array_like of geometries used to construct the STRtree."""
-        return self._tree.geometries

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -66,7 +66,8 @@ def test_geometries_property():
     assert arr is tree.geometries
 
 
-def test_flush_geometries(tree):
+@pytest.mark.parametrize("repeats", [None] * 1000)
+def test_flush_geometries(repeats):
     arr = pygeos.points(np.arange(10), np.arange(10))
     tree = pygeos.STRtree(arr)
     # Dereference geometries

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -60,6 +60,12 @@ def test_del_decreases_refcount():
         del tree
 
 
+def test_len():
+    arr = np.array([point, None, point])
+    tree = pygeos.STRtree(arr)
+    assert len(tree) == 2
+
+
 def test_geometries_property():
     arr = np.array([point])
     tree = pygeos.STRtree(arr)

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -60,6 +60,16 @@ def test_del_decreases_refcount():
         del tree
 
 
+def test_flush_geometries():
+    arr = pygeos.points(np.arange(10), np.arange(10))
+    tree = pygeos.STRtree(arr)
+    # Dereference geometries
+    arr[:] = None
+    import gc; gc.collect()
+    # Still it does not lead to a segfault
+    tree.query(point)
+
+
 def test_len():
     arr = np.array([point, None, point])
     tree = pygeos.STRtree(arr)
@@ -70,16 +80,6 @@ def test_geometries_property():
     arr = np.array([point])
     tree = pygeos.STRtree(arr)
     assert arr is tree.geometries
-
-
-@pytest.mark.parametrize("repeats", [None] * 1000)
-def test_flush_geometries(repeats):
-    arr = pygeos.points(np.arange(10), np.arange(10))
-    tree = pygeos.STRtree(arr)
-    # Dereference geometries
-    arr[:] = None
-    # Still it does not lead to a segfault
-    tree.query(point)
 
 
 def test_query_no_geom(tree):

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -172,6 +172,14 @@ def test_query_unsupported_predicate(tree):
         tree.query(pygeos.points(1, 1), predicate="disjoint")
 
 
+def test_query_tree_with_none():
+    # valid GEOS binary predicate, but not supported for query
+    tree = pygeos.STRtree([
+        pygeos.Geometry("POINT (0 0)"), None, pygeos.Geometry("POINT (2 2)")
+    ])
+    assert tree.query(pygeos.points(2, 2), predicate="intersects") == [2]
+
+
 ### predicate == 'intersects'
 
 # TEMPORARY xfail: MultiPoint intersects with prepared geometries does not work
@@ -192,11 +200,11 @@ def test_query_unsupported_predicate(tree):
         # same points as envelope
         (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [2, 3, 4]),
         # multipoints intersect
-        pytest.param(pygeos.multipoints([[5, 5], [7, 7]]), [5, 7], marks=pytest.mark.xfail(reason="GEOS 3.5")),
+        pytest.param(pygeos.multipoints([[5, 5], [7, 7]]), [5, 7], marks=pytest.mark.xfail(pygeos.geos_version<(3, 6, 0), reason="GEOS 3.5")),
         # envelope of points contains points, but points do not intersect
         (pygeos.multipoints([[5, 7], [7, 5]]), []),
         # only one point of multipoint intersects
-        pytest.param(pygeos.multipoints([[5, 7], [7, 7]]), [7], marks=pytest.mark.xfail(reason="GEOS 3.5")),
+        pytest.param(pygeos.multipoints([[5, 7], [7, 7]]), [7], marks=pytest.mark.xfail(pygeos.geos_version<(3, 6, 0), reason="GEOS 3.5")),
     ],
 )
 def test_query_intersects_points(tree, geometry, expected):

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -49,14 +49,14 @@ def test_init_with_no_geometry():
 
 def test_init_increases_refcount():
     arr = np.array([point])
-    with assert_increases_refcount(arr):
+    with assert_increases_refcount(point):
         _ = pygeos.STRtree(arr)
 
 
 def test_del_decreases_refcount():
     arr = np.array([point])
     tree = pygeos.STRtree(arr)
-    with assert_decreases_refcount(arr):
+    with assert_decreases_refcount(point):
         del tree
 
 

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -73,7 +73,7 @@ static PyObject *STRtree_new(PyTypeObject *type, PyObject *args,
     void *tree, *ptr;
     npy_intp n, i, count = 0;
     GEOSGeometry *geom;
-    goes_geom_vec _geoms;
+    geom_obj_vec _geoms;
     GeometryObject *obj;
     GEOSContextHandle_t context = geos_context[0];
 

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -240,12 +240,8 @@ static PyArrayObject *STRtree_query(STRtreeObject *self, PyObject *args) {
         // get index for right geometries from arr
         index = kv_A(arr, i);
 
-        // get pygeos geometries from tree at index (not i)
-        geom_ptr = PyArray_GETPTR1((PyArrayObject *) self->geometries, index);
-
-        // get GEOS geometry from pygeos geometry
-        target_geometry = *(GeometryObject **) geom_ptr;
-        get_geom(target_geometry, &target_geom);
+        // get GEOS geometry
+        target_geom = kv_A(self->_geoms, index);
 
         // keep the index value if it passes the predicate
         if (predicate_func(context, pgeom, target_geom)) {

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -49,11 +49,6 @@ static PyArrayObject *copy_kvec_to_npy(npy_intp_vec *arr)
     return (PyArrayObject *) result;
 }
 
-void strtree_iter_destroy_callback(void *item, void *user_data)
-{
-    kv_push(npy_intp, *(npy_intp_vec *)user_data, (npy_intp) item);
-}
-
 static void STRtree_dealloc(STRtreeObject *self)
 {
     void *context = geos_context[0];

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -169,7 +169,7 @@ static PyObject *STRtree_query(STRtreeObject *self, PyObject *args) {
         PyErr_SetString(PyExc_RuntimeError, "Tree is uninitialized");
         return NULL;
     }
-    if (kv_size(self->_geoms) == 0) {
+    if (self->count == 0) {
         npy_intp dims[1] = {0};
         return PyArray_SimpleNew(1, dims, NPY_INTP);
     }

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -24,6 +24,7 @@ typedef struct
 typedef struct {
     PyObject_HEAD
     void *ptr;
+    npy_intp count;
     goes_geom_vec _geoms;
 } STRtreeObject;
 

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -3,6 +3,7 @@
 
 #include <Python.h>
 #include "geos.h"
+#include "pygeom.h"
 
 
 /* A resizable vector with numpy indices */
@@ -13,11 +14,11 @@ typedef struct
 } npy_intp_vec;
 
 
-/* A resizable vector with GEOSGeometry pointers */
+/* A resizable vector with pointers */
 typedef struct
 {
     size_t n, m;
-    GEOSGeometry **a;
+    GeometryObject **a;
 } goes_geom_vec;
 
 typedef struct {

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -19,13 +19,13 @@ typedef struct
 {
     size_t n, m;
     GeometryObject **a;
-} goes_geom_vec;
+} geom_obj_vec;
 
 typedef struct {
     PyObject_HEAD
     void *ptr;
     npy_intp count;
-    goes_geom_vec _geoms;
+    geom_obj_vec _geoms;
 } STRtreeObject;
 
 

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -5,19 +5,27 @@
 #include "geos.h"
 
 
-typedef struct {
-    PyObject_HEAD
-    void *ptr;
-    PyObject *geometries;
-    long count;
-} STRtreeObject;
-
 /* A resizable vector with numpy indices */
 typedef struct
 {
     size_t n, m;
     npy_intp *a;
 } npy_intp_vec;
+
+
+/* A resizable vector with GEOSGeometry pointers */
+typedef struct
+{
+    size_t n, m;
+    GEOSGeometry **a;
+} goes_geom_vec;
+
+typedef struct {
+    PyObject_HEAD
+    void *ptr;
+    goes_geom_vec _geoms;
+} STRtreeObject;
+
 
 extern PyTypeObject STRtreeType;
 


### PR DESCRIPTION
This reproduces #97  locally

It seems like we need to keep references to the geometries that were used to construct an STRTree.