### PR TITLE
ENH: query tree with multiple input geometries

### DIFF
--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -109,8 +109,8 @@ class STRtree:
 
         return self._tree.query(geometry, predicate)
 
-    def query_bulk(self, geometries, predicate=None):
-        """Returns all combinations of input geometries and geometries in the tree
+    def query_bulk(self, geometry, predicate=None):
+        """Returns all combinations of each input geometry and geometries in the tree
         where the envelope of each input geometry intersects with the envelope of a
         tree geometry.
 
@@ -135,9 +135,9 @@ class STRtree:
 
         Parameters
         ----------
-        geometry : Geometry
-            The envelope of each geometry is taken automatically for
-            querying the tree.
+        geometry : Geometry or array_like
+            Input geometries to query the tree.  The envelope of each geometry
+            is automatically calculated for querying the tree.
         predicate : {None, 'intersects', 'within', 'contains', 'overlaps', 'crosses', 'touches'}, optional
             The predicate to use for testing geometries from the tree
             that are within the input geometry's envelope.
@@ -176,4 +176,4 @@ class STRtree:
 
             predicate = BinaryPredicate[predicate].value
 
-        return self._tree.query_bulk(np.asarray(geometries), predicate)
+        return self._tree.query_bulk(np.asarray(geometry), predicate)

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -44,8 +44,8 @@ class STRtree:
     >>> tree.query(pygeos.box(2, 2, 4, 4), predicate='contains').tolist()
     [3]
     >>> # Query geometries that overlap envelopes of `geoms`
-    >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)])
-    (array([0, 0, 0, 1, 1]), array([2, 3, 4, 5, 6]))
+    >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)]).tolist()
+    [[0, 0, 0, 1, 1], [2, 3, 4, 5, 6]]
     """
 
     def __init__(self, geometries, leafsize=5):
@@ -151,11 +151,15 @@ class STRtree:
         --------
         >>> import pygeos
         >>> tree = pygeos.STRtree(pygeos.points(np.arange(10), np.arange(10)))
-        >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)])
-        (array([0, 0, 0, 1, 1]), array([2, 3, 4, 5, 6]))
+        >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)]).tolist()
+        [[0, 0, 0, 1, 1], [2, 3, 4, 5, 6]]
         >>> # Query for geometries that contain tree geometries
-        >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)], predicate='contains')
-        (array([0]), array([3]))
+        >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)], predicate='contains').tolist()
+        [[0], [3]]
+        >>> # To get an array of pairs of index of input geometry, index of tree geometry,
+        >>> # transpose the output:
+        >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)]).T.tolist()
+        [[0, 2], [0, 3], [0, 4], [1, 5], [1, 6]]
         """
 
         if predicate is None:

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -119,9 +119,10 @@ class STRtree:
         extent intersects the envelope of the input geometry:
         predicate(geometry, tree_geometry).
 
-        This returns two arrays of equal length, which correspond to the indexes
-        of the input geometries and indexes of the tree geometries associated
-        each.
+        This returns an array with shape (2,n) where the subarrays correspond
+        to the indexes of the input geometries and indexes of the tree geometries
+        associated with each.  To generate an array of pairs of input geometry
+        index and tree geometry index, simply transpose the results.
 
         In the context of a spatial join, input geometries are the "left" geometries
         that determine the order of the results, and tree geometries are "right" geometries
@@ -143,9 +144,9 @@ class STRtree:
 
         Returns
         -------
-        ndarray, ndarray
-            The first array contains input geometry indexes.
-            The second array contains tree geometry indexes.
+        ndarray with shape (2, n)
+            The first subarray contains input geometry indexes.
+            The second subarray contains tree geometry indexes.
 
         Examples
         --------

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -93,6 +93,24 @@ class STRtree:
 
         return self._tree.query(geometry, predicate)
 
+    def query_bulk(self, geometries, predicate=None):
+
+        if predicate is None:
+            predicate = 0
+
+        else:
+            if not predicate in VALID_PREDICATES:
+                raise ValueError(
+                    "Predicate {} is not valid; must be one of {}".format(
+                        predicate, ", ".join(VALID_PREDICATES)
+                    )
+                )
+
+            predicate = BinaryPredicate[predicate].value
+
+        results = self._tree.query_bulk(np.asarray(geometries), predicate)
+        return results[0], results[1]
+
     @property
     def geometries(self):
         """Return the array_like of geometries used to construct the STRtree."""

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -163,6 +163,10 @@ class STRtree:
         [[0, 2], [0, 3], [0, 4], [1, 5], [1, 6]]
         """
 
+        geometry = np.asarray(geometry)
+        if geometry.ndim == 0:
+            geometry = np.expand_dims(geometry, 0)
+
         if predicate is None:
             predicate = 0
 
@@ -176,4 +180,4 @@ class STRtree:
 
             predicate = BinaryPredicate[predicate].value
 
-        return self._tree.query_bulk(np.asarray(geometry), predicate)
+        return self._tree.query_bulk(geometry, predicate)

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -36,16 +36,16 @@ class STRtree:
     Examples
     --------
     >>> import pygeos
-    >>> geoms = pygeos.points(np.arange(10), np.arange(10))
-    >>> tree = pygeos.STRtree(geoms)
-    >>> geom = pygeos.box(2, 2, 4, 4)
-    >>> # Query geometries that overlap envelope of `geom`:
-    >>> tree.query(geom).tolist()
+    >>> tree = pygeos.STRtree(pygeos.points(np.arange(10), np.arange(10)))
+    >>> # Query geometries that overlap envelope of input geometries:
+    >>> tree.query(pygeos.box(2, 2, 4, 4)).tolist()
     [2, 3, 4]
-    >>> # Query geometries that overlap envelope of `geom`
-    >>> # and are contained by `geom`:
-    >>> tree.query(geom, predicate='contains').tolist()
+    >>> # Query geometries that are contained by input geometry:
+    >>> tree.query(pygeos.box(2, 2, 4, 4), predicate='contains').tolist()
     [3]
+    >>> # Query geometries that overlap envelopes of `geoms`
+    >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)])
+    (array([0, 0, 0, 1, 1]), array([2, 3, 4, 5, 6]))
     """
 
     def __init__(self, geometries, leafsize=5):
@@ -55,8 +55,8 @@ class STRtree:
         return self._tree.count
 
     def query(self, geometry, predicate=None):
-        """Return all items whose extent intersect the envelope of the input
-        geometry.
+        """Return the index of all geometries in the tree with extents that
+        intersect the envelope of the input geometry.
 
         If predicate is provided, a prepared version of the input geometry
         is tested using the predicate function against each item whose
@@ -73,6 +73,21 @@ class STRtree:
         predicate : {None, 'intersects', 'within', 'contains', 'overlaps', 'crosses', 'touches'}, optional
             The predicate to use for testing geometries from the tree
             that are within the input geometry's envelope.
+
+        Returns
+        -------
+        ndarray
+            Indexes of geometries in tree
+
+        Examples
+        --------
+        >>> import pygeos
+        >>> tree = pygeos.STRtree(pygeos.points(np.arange(10), np.arange(10)))
+        >>> tree.query(pygeos.box(1,1, 3,3)).tolist()
+        [1, 2, 3]
+        >>> # Query geometries that are contained by input geometry
+        >>> tree.query(pygeos.box(2, 2, 4, 4), predicate='contains').tolist()
+        [3]
         """
 
         if geometry is None:
@@ -94,6 +109,53 @@ class STRtree:
         return self._tree.query(geometry, predicate)
 
     def query_bulk(self, geometries, predicate=None):
+        """Returns all combinations of input geometries and geometries in the tree
+        where the envelope of each input geometry intersects with the envelope of a
+        tree geometry.
+
+        If predicate is provided, a prepared version of each input geometry
+        is tested using the predicate function against each item whose
+        extent intersects the envelope of the input geometry:
+        predicate(geometry, tree_geometry).
+
+        This returns two arrays of equal length, which correspond to the indexes
+        of the input geometries and indexes of the tree geometries associated
+        each.
+
+        In the context of a spatial join, input geometries are the "left" geometries
+        that determine the order of the results, and tree geometries are "right" geometries
+        that are joined against the left geometries.  This effectively performs
+        an inner join, where only those combinations of geometries that can be joined
+        based on envelope overlap or optional predicate are returned.
+
+        Any geometry that is None or empty in the input geometries is omitted from
+        the output.
+
+        Parameters
+        ----------
+        geometry : Geometry
+            The envelope of each geometry is taken automatically for
+            querying the tree.
+        predicate : {None, 'intersects', 'within', 'contains', 'overlaps', 'crosses', 'touches'}, optional
+            The predicate to use for testing geometries from the tree
+            that are within the input geometry's envelope.
+
+        Returns
+        -------
+        ndarray, ndarray
+            The first array contains input geometry indexes.
+            The second array contains tree geometry indexes.
+
+        Examples
+        --------
+        >>> import pygeos
+        >>> tree = pygeos.STRtree(pygeos.points(np.arange(10), np.arange(10)))
+        >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)])
+        (array([0, 0, 0, 1, 1]), array([2, 3, 4, 5, 6]))
+        >>> # Query for geometries that contain tree geometries
+        >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)], predicate='contains')
+        (array([0]), array([3]))
+        """
 
         if predicate is None:
             predicate = 0
@@ -108,8 +170,7 @@ class STRtree:
 
             predicate = BinaryPredicate[predicate].value
 
-        results = self._tree.query_bulk(np.asarray(geometries), predicate)
-        return results[0], results[1]
+        return self._tree.query_bulk(np.asarray(geometries), predicate)
 
     @property
     def geometries(self):

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -666,6 +666,8 @@ def test_query_bulk_wrong_type(tree, geometry):
         ([pygeos.buffer(pygeos.points(3, 3), 1)], [[0, 0, 0], [2, 3, 4]]),
         # envelope of points contains points
         ([pygeos.multipoints([[5, 7], [7, 5]])], [[0, 0, 0], [5, 6, 7]]),
+        # nulls and empty should be skipped
+        ([None, empty, pygeos.points(1, 1)], [[2], [1]]),
     ],
 )
 def test_query_bulk_points(tree, geometry, expected):

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -631,7 +631,7 @@ def test_query_touches_polygons(poly_tree, geometry, expected):
 
 ### Bulk query tests
 def test_query_bulk_wrong_dimensions(tree):
-    with pytest.raises(TypeError, match="Array should be one dimensional") as ex:
+    with pytest.raises(TypeError, match="Array should be one dimensional"):
         tree.query_bulk([[pygeos.points(0.5, 0.5)]])
 
 

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -185,11 +185,19 @@ def test_query_unsupported_predicate(tree):
         # same points as envelope
         (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [2, 3, 4]),
         # multipoints intersect
-        pytest.param(pygeos.multipoints([[5, 5], [7, 7]]), [5, 7], marks=pytest.mark.xfail(reason="GEOS 3.5")),
+        pytest.param(
+            pygeos.multipoints([[5, 5], [7, 7]]),
+            [5, 7],
+            marks=pytest.mark.xfail(reason="GEOS 3.5"),
+        ),
         # envelope of points contains points, but points do not intersect
         (pygeos.multipoints([[5, 7], [7, 5]]), []),
         # only one point of multipoint intersects
-        pytest.param(pygeos.multipoints([[5, 7], [7, 7]]), [7], marks=pytest.mark.xfail(reason="GEOS 3.5")),
+        pytest.param(
+            pygeos.multipoints([[5, 7], [7, 7]]),
+            [7],
+            marks=pytest.mark.xfail(reason="GEOS 3.5"),
+        ),
     ],
 )
 def test_query_intersects_points(tree, geometry, expected):
@@ -404,7 +412,6 @@ def test_query_contains_polygons(poly_tree, geometry, expected):
     assert_array_equal(poly_tree.query(geometry, predicate="contains"), expected)
 
 
-
 ### predicate == 'overlaps'
 # Overlaps only returns results where geometries are of same dimensions
 # and do not completely contain each other.
@@ -464,18 +471,17 @@ def test_query_overlaps_lines(line_tree, geometry, expected):
         # box overlaps 2 polygons
         (box(0, 0, 1, 1), [0, 1]),
         # larger box intersects 3 polygons and contains one
-        (box(0, 0, 2, 2), [0,2]),
+        (box(0, 0, 2, 2), [0, 2]),
         # buffer overlaps 3 polygons and contains 1
-        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG), [2,4]),
+        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG), [2, 4]),
         # larger buffer overlaps 6 polygons (touches midpoints) but contains one
-        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [1,2,4,5]),
+        (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [1, 2, 4, 5]),
         # one of two points intersects but different dimensions
         (pygeos.multipoints([[5, 7], [7, 7]]), []),
     ],
 )
 def test_query_overlaps_polygons(poly_tree, geometry, expected):
     assert_array_equal(poly_tree.query(geometry, predicate="overlaps"), expected)
-
 
 
 ### predicate == 'crosses'
@@ -591,16 +597,238 @@ def test_query_touches_lines(line_tree, geometry, expected):
         # point within first polygon
         (pygeos.points(0, 0.5), []),
         # point is at edge of first polygon
-        (pygeos.points(HALF_UNIT_DIAG+EPS, 0), [0]),
+        (pygeos.points(HALF_UNIT_DIAG + EPS, 0), [0]),
         # box overlaps envelope of 2 polygons does not touch any at edge
         (box(0, 0, 1, 1), []),
         # box overlaps 2 polygons and touches edge of first
-        (box(HALF_UNIT_DIAG+EPS, 0, 2, 2), [0]),
+        (box(HALF_UNIT_DIAG + EPS, 0, 2, 2), [0]),
         # buffer overlaps 3 polygons but does not touch any at edge
-        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG+EPS), []),
+        (pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG + EPS), []),
         # only one point of multipoint within polygon but does not touch
-        (pygeos.multipoints([[0, 0], [7,7], [7, 8]]), []),
+        (pygeos.multipoints([[0, 0], [7, 7], [7, 8]]), []),
     ],
 )
 def test_query_touches_polygons(poly_tree, geometry, expected):
     assert_array_equal(poly_tree.query(geometry, predicate="touches"), expected)
+
+
+### Bulk query tests
+@pytest.mark.parametrize(
+    "geometry", [None, pygeos.points(0.5, 0.5), [[pygeos.points(0.5, 0.5)]]]
+)
+def test_query_bulk_wrong_dimemsions(tree, geometry):
+    with pytest.raises(TypeError) as ex:
+        tree.query_bulk(geometry)
+
+    assert str(ex.value) == "Array should be one dimensional"
+
+
+@pytest.mark.parametrize("geometry", [[], "foo", 1])
+def test_query_bulk_wrong_type(tree, geometry):
+    with pytest.raises(TypeError) as ex:
+        tree.query_bulk(geometry)
+
+    assert str(ex.value) == "Array should be of object dtype"
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # points do not intersect
+        ([pygeos.points(0.5, 0.5)], [[], []]),
+        # points intersect
+        ([pygeos.points(1, 1)], [[0], [1]]),
+        # first and last points intersect
+        (
+            [pygeos.points(1, 1), pygeos.points(-1, -1), pygeos.points(2, 2)],
+            [[0, 2], [1, 2]],
+        ),
+        # box contains points
+        ([box(0, 0, 1, 1)], [[0, 0], [0, 1]]),
+        # bigger box contains more points
+        ([box(5, 5, 15, 15)], [[0, 0, 0, 0, 0], [5, 6, 7, 8, 9]]),
+        # first and last boxes contains points
+        (
+            [box(0, 0, 1, 1), box(100, 100, 110, 110), box(5, 5, 15, 15)],
+            [[0, 0, 2, 2, 2, 2, 2], [0, 1, 5, 6, 7, 8, 9]],
+        ),
+        # envelope of buffer contains points
+        ([pygeos.buffer(pygeos.points(3, 3), 1)], [[0, 0, 0], [2, 3, 4]]),
+        # envelope of points contains points
+        ([pygeos.multipoints([[5, 7], [7, 5]])], [[0, 0, 0], [5, 6, 7]]),
+    ],
+)
+def test_query_bulk_points(tree, geometry, expected):
+    assert_array_equal(tree.query_bulk(geometry), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point intersects first line
+        ([pygeos.points(0, 0)], [[0], [0]]),
+        ([pygeos.points(0.5, 0.5)], [[0], [0]]),
+        # point within envelope of first line
+        ([pygeos.points(0, 0.5)], [[0], [0]]),
+        # point at shared vertex between 2 lines
+        ([pygeos.points(1, 1)], [[0, 0], [0, 1]]),
+        # box overlaps envelope of first 2 lines (touches edge of 1)
+        ([box(0, 0, 1, 1)], [[0, 0], [0, 1]]),
+        # envelope of buffer overlaps envelope of 2 lines
+        ([pygeos.buffer(pygeos.points(3, 3), 0.5)], [[0, 0], [2, 3]]),
+        # envelope of points overlaps 5 lines (touches edge of 2 envelopes)
+        ([pygeos.multipoints([[5, 7], [7, 5]])], [[0, 0, 0, 0], [4, 5, 6, 7]]),
+    ],
+)
+def test_query_bulk_lines(line_tree, geometry, expected):
+    assert_array_equal(line_tree.query_bulk(geometry), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point intersects edge of envelopes of 2 polygons
+        ([pygeos.points(0.5, 0.5)], [[0, 0], [0, 1]]),
+        # point intersects single polygon
+        ([pygeos.points(1, 1)], [[0], [1]]),
+        # box overlaps envelope of 2 polygons
+        ([box(0, 0, 1, 1)], [[0, 0], [0, 1]]),
+        # first and last boxes overlap envelope of 2 polyons
+        (
+            [box(0, 0, 1, 1), box(100, 100, 110, 110), box(2, 2, 3, 3)],
+            [[0, 0, 2, 2], [0, 1, 2, 3]],
+        ),
+        # larger box overlaps envelope of 3 polygons
+        ([box(0, 0, 1.5, 1.5)], [[0, 0, 0], [0, 1, 2]]),
+        # envelope of buffer overlaps envelope of 3 polygons
+        ([pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG)], [[0, 0, 0], [2, 3, 4]]),
+        # envelope of larger buffer overlaps envelope of 6 polygons
+        (
+            [pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG)],
+            [[0, 0, 0, 0, 0], [1, 2, 3, 4, 5]],
+        ),
+        # envelope of points overlaps 3 polygons
+        ([pygeos.multipoints([[5, 7], [7, 5]])], [[0, 0, 0], [5, 6, 7]]),
+    ],
+)
+def test_query_bulk_polygons(poly_tree, geometry, expected):
+    assert_array_equal(poly_tree.query_bulk(geometry), expected)
+
+
+def test_query_invalid_predicate(tree):
+    with pytest.raises(ValueError):
+        tree.query_bulk(pygeos.points(1, 1), predicate="bad_predicate")
+
+
+### predicate == 'intersects'
+
+# TEMPORARY xfail: MultiPoint intersects with prepared geometries does not work
+# properly on GEOS 3.5.x; it was fixed in 3.6+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # points do not intersect
+        ([pygeos.points(0.5, 0.5)], [[], []]),
+        # points intersect
+        ([pygeos.points(1, 1)], [[0], [1]]),
+        # box contains points
+        ([box(3, 3, 6, 6)], [[0, 0, 0, 0], [3, 4, 5, 6]]),
+        # first and last boxes contain points
+        (
+            [box(0, 0, 1, 1), box(100, 100, 110, 110), box(3, 3, 6, 6)],
+            [[0, 0, 2, 2, 2, 2], [0, 1, 3, 4, 5, 6]],
+        ),
+        # envelope of buffer contains more points than intersect buffer
+        # due to diagonal distance
+        ([pygeos.buffer(pygeos.points(3, 3), 1)], [[0], [3]]),
+        # envelope of buffer with 1/2 distance between points should intersect
+        # same points as envelope
+        (
+            [pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG)],
+            [[0, 0, 0], [2, 3, 4]],
+        ),
+        # multipoints intersect
+        pytest.param(
+            [pygeos.multipoints([[5, 5], [7, 7]])],
+            [[0, 0], [5, 7]],
+            marks=pytest.mark.xfail(reason="GEOS 3.5"),
+        ),
+        # envelope of points contains points, but points do not intersect
+        ([pygeos.multipoints([[5, 7], [7, 5]])], [[], []]),
+        # only one point of multipoint intersects
+        pytest.param(
+            [pygeos.multipoints([[5, 7], [7, 7]])],
+            [[0], [7]],
+            marks=pytest.mark.xfail(reason="GEOS 3.5"),
+        ),
+    ],
+)
+def test_query_bulk_intersects_points(tree, geometry, expected):
+    assert_array_equal(tree.query_bulk(geometry, predicate="intersects"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point intersects first line
+        ([pygeos.points(0, 0)], [[0], [0]]),
+        ([pygeos.points(0.5, 0.5)], [[0], [0]]),
+        # point within envelope of first line but does not intersect
+        ([pygeos.points(0, 0.5)], [[], []]),
+        # point at shared vertex between 2 lines
+        ([pygeos.points(1, 1)], [[0, 0], [0, 1]]),
+        # box overlaps envelope of first 2 lines (touches edge of 1)
+        ([box(0, 0, 1, 1)], [[0, 0], [0, 1]]),
+        # first and last boxes overlap multiple lines each
+        (
+            [box(0, 0, 1, 1), box(100, 100, 110, 110), box(2, 2, 3, 3)],
+            [[0, 0, 2, 2, 2], [0, 1, 1, 2, 3]],
+        ),
+        # buffer intersects 2 lines
+        ([pygeos.buffer(pygeos.points(3, 3), 0.5)], [[0, 0], [2, 3]]),
+        # buffer intersects midpoint of line at tangent
+        ([pygeos.buffer(pygeos.points(2, 1), HALF_UNIT_DIAG)], [[0], [1]]),
+        # envelope of points overlaps lines but intersects none
+        ([pygeos.multipoints([[5, 7], [7, 5]])], [[], []]),
+        # only one point of multipoint intersects
+        ([pygeos.multipoints([[5, 7], [7, 7]])], [[0, 0], [6, 7]]),
+    ],
+)
+def test_query_bulk_intersects_lines(line_tree, geometry, expected):
+    assert_array_equal(line_tree.query_bulk(geometry, predicate="intersects"), expected)
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        # point within first polygon
+        ([pygeos.points(0, 0.5)], [[0], [0]]),
+        ([pygeos.points(0.5, 0)], [[0], [0]]),
+        # midpoint between two polygons intersects both
+        ([pygeos.points(0.5, 0.5)], [[0, 0], [0, 1]]),
+        # point intersects single polygon
+        ([pygeos.points(1, 1)], [[0], [1]]),
+        # box overlaps envelope of 2 polygons
+        ([box(0, 0, 1, 1)], [[0, 0], [0, 1]]),
+        # first and last boxes overlap
+        (
+            [box(0, 0, 1, 1), box(100, 100, 110, 110), box(2, 2, 3, 3)],
+            [[0, 0, 2, 2], [0, 1, 2, 3]],
+        ),
+        # larger box intersects 3 polygons
+        ([box(0, 0, 1.5, 1.5)], [[0, 0, 0], [0, 1, 2]]),
+        # buffer overlaps 3 polygons
+        ([pygeos.buffer(pygeos.points(3, 3), HALF_UNIT_DIAG)], [[0, 0, 0], [2, 3, 4]]),
+        # larger buffer overlaps 6 polygons (touches midpoints)
+        (
+            [pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG)],
+            [[0, 0, 0, 0, 0], [1, 2, 3, 4, 5]],
+        ),
+        # envelope of points overlaps polygons, but points do not intersect
+        ([pygeos.multipoints([[5, 7], [7, 5]])], [[], []]),
+        # only one point of multipoint within polygon
+        ([pygeos.multipoints([[5, 7], [7, 7]])], [[0], [7]]),
+    ],
+)
+def test_query_bulk_intersects_polygons(poly_tree, geometry, expected):
+    assert_array_equal(poly_tree.query_bulk(geometry, predicate="intersects"), expected)

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -637,7 +637,7 @@ def test_query_bulk_wrong_dimensions(tree):
 
 @pytest.mark.parametrize("geometry", [[], "foo", 1])
 def test_query_bulk_wrong_type(tree, geometry):
-    with pytest.raises(TypeError, match="Array should be of object dtype") as ex:
+    with pytest.raises(TypeError, match="Array should be of object dtype"):
         tree.query_bulk(geometry)
 
 

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -65,7 +65,9 @@ def test_flush_geometries():
     tree = pygeos.STRtree(arr)
     # Dereference geometries
     arr[:] = None
-    import gc; gc.collect()
+    import gc
+
+    gc.collect()
     # Still it does not lead to a segfault
     tree.query(point)
 
@@ -174,9 +176,9 @@ def test_query_unsupported_predicate(tree):
 
 def test_query_tree_with_none():
     # valid GEOS binary predicate, but not supported for query
-    tree = pygeos.STRtree([
-        pygeos.Geometry("POINT (0 0)"), None, pygeos.Geometry("POINT (2 2)")
-    ])
+    tree = pygeos.STRtree(
+        [pygeos.Geometry("POINT (0 0)"), None, pygeos.Geometry("POINT (2 2)")]
+    )
     assert tree.query(pygeos.points(2, 2), predicate="intersects") == [2]
 
 
@@ -200,11 +202,19 @@ def test_query_tree_with_none():
         # same points as envelope
         (pygeos.buffer(pygeos.points(3, 3), 3 * HALF_UNIT_DIAG), [2, 3, 4]),
         # multipoints intersect
-        pytest.param(pygeos.multipoints([[5, 5], [7, 7]]), [5, 7], marks=pytest.mark.xfail(pygeos.geos_version<(3, 6, 0), reason="GEOS 3.5")),
+        pytest.param(
+            pygeos.multipoints([[5, 5], [7, 7]]),
+            [5, 7],
+            marks=pytest.mark.xfail(pygeos.geos_version < (3, 6, 0), reason="GEOS 3.5"),
+        ),
         # envelope of points contains points, but points do not intersect
         (pygeos.multipoints([[5, 7], [7, 5]]), []),
         # only one point of multipoint intersects
-        pytest.param(pygeos.multipoints([[5, 7], [7, 7]]), [7], marks=pytest.mark.xfail(pygeos.geos_version<(3, 6, 0), reason="GEOS 3.5")),
+        pytest.param(
+            pygeos.multipoints([[5, 7], [7, 7]]),
+            [7],
+            marks=pytest.mark.xfail(pygeos.geos_version < (3, 6, 0), reason="GEOS 3.5"),
+        ),
     ],
 )
 def test_query_intersects_points(tree, geometry, expected):
@@ -620,12 +630,9 @@ def test_query_touches_polygons(poly_tree, geometry, expected):
 
 
 ### Bulk query tests
-@pytest.mark.parametrize(
-    "geometry", [None, pygeos.points(0.5, 0.5), [[pygeos.points(0.5, 0.5)]]]
-)
-def test_query_bulk_wrong_dimemsions(tree, geometry):
+def test_query_bulk_wrong_dimensions(tree):
     with pytest.raises(TypeError, match="Array should be one dimensional") as ex:
-        tree.query_bulk(geometry)
+        tree.query_bulk([[pygeos.points(0.5, 0.5)]])
 
 
 @pytest.mark.parametrize("geometry", [[], "foo", 1])

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -617,18 +617,14 @@ def test_query_touches_polygons(poly_tree, geometry, expected):
     "geometry", [None, pygeos.points(0.5, 0.5), [[pygeos.points(0.5, 0.5)]]]
 )
 def test_query_bulk_wrong_dimemsions(tree, geometry):
-    with pytest.raises(TypeError) as ex:
+    with pytest.raises(TypeError, match="Array should be one dimensional") as ex:
         tree.query_bulk(geometry)
-
-    assert str(ex.value) == "Array should be one dimensional"
 
 
 @pytest.mark.parametrize("geometry", [[], "foo", 1])
 def test_query_bulk_wrong_type(tree, geometry):
-    with pytest.raises(TypeError) as ex:
+    with pytest.raises(TypeError, match="Array should be of object dtype") as ex:
         tree.query_bulk(geometry)
-
-    assert str(ex.value) == "Array should be of object dtype"
 
 
 @pytest.mark.parametrize(

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -181,13 +181,13 @@ static PyObject *STRtree_new(PyTypeObject *type, PyObject *args,
  *
  * Parameters
  * ----------
- * index: index of intersected geometry in the tree
- * vector: pointer to dynamic vector; index is pushed onto this vector
+ * item: index of intersected geometry in the tree
+ * user_data: pointer to dynamic vector; index is pushed onto this vector
  * */
 
-void query_callback(void *index, void *vector)
+void query_callback(void *item, void *user_data)
 {
-    kv_push(npy_intp, *(npy_intp_vec *)vector, (npy_intp) index);
+    kv_push(npy_intp, *(npy_intp_vec *)user_data, (npy_intp) item);
 }
 
 /* Evaluate the predicate function against a prepared version of geom
@@ -349,7 +349,7 @@ static PyObject *STRtree_query_bulk(STRtreeObject *self, PyObject *args) {
     GEOSGeometry *geom;
     npy_intp_vec query_indexes, src_indexes, target_indexes;
     npy_intp i, j, n, size;
-    FuncGEOS_YpY_b *predicate_func;
+    FuncGEOS_YpY_b *predicate_func = NULL;
     PyArrayObject *result;
 
     if (self->ptr == NULL) {


### PR DESCRIPTION
This adds a first pass at bulk query against `STRtree` instance, as the core of a spatial join function for #52.

This extends the functionality of the existing `STRtree::query()` method to handle multiple input geometries.  It returns a tuple of source (left) indexes and target (right) indexes that either overlap the windows of the sources, or also meet the predicate function provided.

Example:
```
tree = pygeos.STRtree(pygeos.points(np.arange(10), np.arange(10)))
tree.query_bulk([pygeos.points(1, 1)])
# returns: (array([0]), array([1]))
```

Multiple source geometries, first and third boxes overlap windows:
```
tree.query_bulk([
    pygeos.box(0,0, 1,1), 
    pygeos.box(100,100,110,110), 
    pygeos.box(2,2,4,4)
])
# returns: (array([0, 0, 2, 2, 2]), array([0, 1, 2, 3, 4]))
```

This preserves the original `query()` function as a singular operation.

/cc: @jorisvandenbossche 
