### PR TITLE
Remove compiler warnings

### DIFF
--- a/src/geos.h
+++ b/src/geos.h
@@ -6,7 +6,12 @@
 /* To avoid accidental use of non reentrant GEOS API. */
 #define GEOS_USE_ONLY_R_API
 
+// wrap geos.h import to silence geos gcc warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
 #include <geos_c.h>
+#pragma GCC diagnostic pop
+
 
 #define RAISE_ILLEGAL_GEOS if (!PyErr_Occurred()) {PyErr_Format(PyExc_RuntimeError, "Uncaught GEOS exception");}
 #define GEOS_SINCE_350 ((GEOS_VERSION_MAJOR >= 3) && (GEOS_VERSION_MINOR >= 5))

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -144,7 +144,7 @@ static PyObject *GeometryObject_FromWKT(PyTypeObject *type, PyObject *value)
 {
     void *context_handle = geos_context[0];
     PyObject *result = NULL;
-    char *wkt;
+    const char *wkt;
     GEOSGeometry *geom;
     GEOSWKTReader *reader;
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -767,7 +767,7 @@ static void is_valid_reason_func(char **args, npy_intp *dimensions,
         PyObject **out = (PyObject **)op1;
         /* get the geometry return on error */
         if (!get_geom(*(GeometryObject **)ip1, &in1)) { return; }
-        if ((in1 == NULL)) {
+        if (in1 == NULL) {
             /* Missing geometries give None */
             Py_XDECREF(*out);
             Py_INCREF(Py_None);


### PR DESCRIPTION
This wraps the import of `geos_c.h` to silence GCC warnings coming from GEOS (not under our control).

It also fixed 2 minor compiler warnings in code here.