### PR TITLE
Bump minimum required version of GEOS to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,29 @@
 language: minimal
 
 matrix:
-  include:
-  - os: linux  # 2015
-    env: PYTHON_VERSION="3.5" RESTORE_FREE_CHANNEL=1 DEPS="numpy=1.10 geos=3.5"
-  - os: linux  # 2017
-    env: PYTHON_VERSION="3.6" DEPS="numpy=1.13 geos=3.6"
-  - os: linux  # 2018
-    env: PYTHON_VERSION="3.7" DEPS="numpy=1.15 geos=3.7"
-  - os: linux  # 2019
-    env: PYTHON_VERSION="3.8" DEPS="numpy=1.17 geos=3.8"
-  - os: linux  # now
-    env: PYTHON_VERSION="3.8" CONDA_FORGE=1 DEPS="numpy geos"
-  - os: osx
-    env: PYTHON_VERSION="3.8" DEPS="numpy geos"
+    include:
+        - os: linux # 2017
+          env: PYTHON_VERSION="3.6" DEPS="numpy=1.13 geos=3.6"
+        - os: linux # 2018
+          env: PYTHON_VERSION="3.7" DEPS="numpy=1.15 geos=3.7"
+        - os: linux # 2019
+          env: PYTHON_VERSION="3.8" DEPS="numpy=1.17 geos=3.8"
+        - os: linux # now
+          env: PYTHON_VERSION="3.8" CONDA_FORGE=1 DEPS="numpy geos"
+        - os: osx
+          env: PYTHON_VERSION="3.8" DEPS="numpy geos"
 
 install:
-  - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe
-  - chmod +x conda.exe
-  - export CONDA_ALWAYS_YES=1
-  - if [ $RESTORE_FREE_CHANNEL ]; then ./conda.exe config --set restore_free_channel true; fi
-  - if [ $CONDA_FORGE ]; then ./conda.exe config --add channels conda-forge; fi
-  - ./conda.exe create --prefix $HOME/miniconda python=$PYTHON_VERSION conda pytest $DEPS
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - python setup.py build_ext --inplace
-  - pip install . --no-deps
+    - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe
+    - chmod +x conda.exe
+    - export CONDA_ALWAYS_YES=1
+    - if [ $RESTORE_FREE_CHANNEL ]; then ./conda.exe config --set restore_free_channel true; fi
+    - if [ $CONDA_FORGE ]; then ./conda.exe config --add channels conda-forge; fi
+    - ./conda.exe create --prefix $HOME/miniconda python=$PYTHON_VERSION conda pytest $DEPS
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - python setup.py build_ext --inplace
+    - pip install . --no-deps
 
 script:
-  - if [[ "$PYTHON_VERSION" == "3.5" ]];
-    then pytest;
-    else pytest --doctest-modules;
-    fi;
+    - pytest --doctest-modules;

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ operations are done in the open-source geometry library GEOS. PyGEOS wraps
 these operations in NumPy ufuncs providing a performance improvement when
 operating on arrays of geometries.
 
+Requires GEOS >= 3.6.
+
 Note: PyGEOS is a very young package. While the available functionality should
 be stable and working correctly, it's still possible that APIs change in upcoming
 releases. But we would love for you to try it out, give feedback or contribute!
@@ -110,7 +112,7 @@ See the documentation for more: https://pygeos.readthedocs.io
 Installation using conda
 ------------------------
 
-Pygeos requires the presence of NumPy and GEOS >= 3.5. It is recommended to install
+Pygeos requires the presence of NumPy and GEOS >= 3.6. It is recommended to install
 these using Anaconda from the conda-forge channel (which provides pre-compiled
 binaries)::
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 ch = logging.StreamHandler()
 log.addHandler(ch)
 
-MIN_GEOS_VERSION = "3.5"
+MIN_GEOS_VERSION = "3.6"
 
 if "all" in sys.warnoptions:
     # show GEOS messages in console with: python -W all
@@ -109,7 +109,14 @@ class build_ext(_build_ext):
 
 module_lib = Extension(
     "pygeos.lib",
-    sources=["src/lib.c", "src/geos.c", "src/pygeom.c", "src/ufuncs.c", "src/coords.c", "src/strtree.c"],
+    sources=[
+        "src/lib.c",
+        "src/geos.c",
+        "src/pygeom.c",
+        "src/ufuncs.c",
+        "src/coords.c",
+        "src/strtree.c",
+    ],
     **get_geos_paths()
 )
 
@@ -122,7 +129,7 @@ except IOError:
 
 version = versioneer.get_version()
 cmdclass = versioneer.get_cmdclass()
-cmdclass['build_ext'] = build_ext
+cmdclass["build_ext"] = build_ext
 
 setup(
     name="pygeos",
@@ -135,10 +142,7 @@ setup(
     packages=["pygeos"],
     setup_requires=["numpy"],
     install_requires=["numpy>=1.10"],
-    extras_require={
-        "test": ["pytest"],
-        "docs": ["sphinx", "numpydoc"],
-    },
+    extras_require={"test": ["pytest"], "docs": ["sphinx", "numpydoc"],},
     python_requires=">=3",
     include_package_data=True,
     ext_modules=[module_lib],


### PR DESCRIPTION
Updates test matrix to support only GEOS >= 3.6.  Also drops tests for Python 3.5, but that is probably OK.

Drops the xfail for `STRtree` tests that failed on GEOS 3.5.