### PR TITLE
Add release notes to the repo / docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+## Version 0.7 (2020-03-18)
+
+**Highlights of this release**
+
+* STRtree improvements for spatial indexing:
+  * Directly include predicate evaluation in `STRtree.query()` (#87)
+  * Query multiple input geometries (spatial join style) with `STRtree.query_bulk` (#108)
+* Addition of a `total_bounds()` function (#107)
+* Geometries are now hashable, and can be compared with `==` or `!=` (#102)
+* Fixed bug in `create_collections()` with wrong types (#86) 
+* Fixed a reference counting bug in STRtree (#97, #100) 
+* Start of a benchmarking suite using ASV (#96)
+* This is the first release that will provide wheels!
+
+**Acknowledgments**
+
+Thanks to everyone who contributed to this release!
+People with a  "+" by their names contributed a patch for the first time.
+
+* Brendan Ward +
+* Casper van der Wel
+* Joris Van den Bossche
+* Mike Taves +
+
+## Version 0.6 (2020-01-31)
+
+Highlights of this release:
+
+- Addition of the STRtree class for spatial indexing (#58)
+- Addition of a `bounds` function (#69)
+- A new `from_shapely` function to convert Shapely geometries to pygeos.Geometry (#61) 
+- Reintroduction of the `shared_paths` function (#77) 
+
+Contributors:
+
+* Casper van der Wel
+* Joris Van den Bossche
+* mattijn +
+
+
+## Version 0.5 (2019-10-25)
+
+Highlights of this release:
+
+- Moved to the pygeos GitHub organization.
+- Addition of functionality to get and transform all coordinates (eg for reprojections or affine transformations) [#44]
+- Ufuncs for converting to and from the WKT and WKB formats [#45]
+- `equals_exact` has been added [PR #57]
+
+## Version 0.4 (2019-09-16)
+
+This is a major release of PyGEOS and the first one with actual release notes. Most important features of this release are:
+
+ - `buffer` and `haussdorff_distance` were completed  [#15] 
+ - `voronoi_polygons` and `delaunay_triangles` have been added [#17]
+ - The PyGEOS documentation is now mostly complete and available on http://pygeos.readthedocs.io .
+ - The concepts of "empty" and "missing" geometries have been separated. The `pygeos.Empty` and `pygeos.NaG` objects has been removed. Empty geometries are handled the same as normal geometries. Missing geometries are denoted by `None` and are handled by every pygeos function. `NaN` values cannot be used anymore to denote missing geometries. [PR #36]
+ - Added `pygeos.__version__` and `pygeos.geos_version`. [PR #43]
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Changelog
+Changelog
+=========
 
-## Version 0.7 (2020-03-18)
+Version 0.7 (2020-03-18)
+------------------------
 
 **Highlights of this release**
 
@@ -24,7 +26,8 @@ People with a  "+" by their names contributed a patch for the first time.
 * Joris Van den Bossche
 * Mike Taves +
 
-## Version 0.6 (2020-01-31)
+Version 0.6 (2020-01-31)
+------------------------
 
 Highlights of this release:
 
@@ -40,7 +43,8 @@ Contributors:
 * mattijn +
 
 
-## Version 0.5 (2019-10-25)
+Version 0.5 (2019-10-25)
+------------------------
 
 Highlights of this release:
 
@@ -49,7 +53,8 @@ Highlights of this release:
 - Ufuncs for converting to and from the WKT and WKB formats [#45]
 - `equals_exact` has been added [PR #57]
 
-## Version 0.4 (2019-09-16)
+Version 0.4 (2019-09-16)
+------------------------
 
 This is a major release of PyGEOS and the first one with actual release notes. Most important features of this release are:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ API Reference
    predicates
    set_operations
    strtree
+   changelog
 
 
 Indices and tables


### PR DESCRIPTION
Trying one possible way to do this (cfr https://github.com/pygeos/pygeos/issues/114#issuecomment-600866024), have the actual content in a top-level file (easily accessible when browsing on github) and including that content in the docs (easily accessible when browsing the docs).

Currently it doesn't yet render well (since the markdown is interpreted as rst). 
Options are to use rst-compatible syntax in the markdown file (eg convert single backticks to double backticks), just make CHANGELOG an rst file, or use the recommonmark sphinx extension to parse markdown (but then we still need a symbolic link to include the markdown file into the toctree, because sphinx cannot link to a file outside its root, see eg https://github.com/readthedocs/recommonmark/tree/master/docs). cfr https://github.com/sphinx-doc/sphinx/issues/7000