### PR TITLE
WIP: get parts of a geometry collection or multi* geometries

### DIFF
--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -20,6 +20,7 @@ __all__ = [
     "get_point",
     "get_interior_ring",
     "get_geometry",
+    "get_parts",
 ]
 
 
@@ -434,3 +435,33 @@ def get_num_geometries(geometry):
     1
     """
     return lib.get_num_geometries(geometry)
+
+
+def get_parts(geometry):
+    """Gets parts of each GeometryCollection or Multi* geometry object; returns
+    a copy of each singular geometry type.
+
+    Parameters
+    ----------
+    geometry : Geometry or array_like
+
+    Returns
+    -------
+    tuple of (indexes, parts)
+        Returns ndarray of indexes into the source geometry array and ndarray
+        of new geometries for parts or copies of the original geometries.  Arrays
+        are of equal length.
+
+    Examples
+    --------
+    >>> idx, parts = get_parts(Geometry("MULTIPOLYGON (((0 0, 0 10, 10 10, 0 0)), ((1 1, 1 10, 10 10, 1 1)))"))
+    >>> idx.tolist()
+    [0, 0]
+    >>> parts.tolist()
+    [<pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 0 0))>, <pygeos.Geometry POLYGON ((1 1, 1 10, 10 10, 1 1))>]
+    """
+    geometry = np.asarray(geometry, dtype=np.object)
+    if geometry.ndim == 0:
+        geometry = np.expand_dims(geometry, 0)
+
+    return lib.get_parts(geometry)

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,16 @@ class build_ext(_build_ext):
 
 module_lib = Extension(
     "pygeos.lib",
-    sources=["src/lib.c", "src/geos.c", "src/pygeom.c", "src/ufuncs.c", "src/coords.c", "src/strtree.c"],
+    sources=[
+        "src/lib.c",
+        "src/geos.c",
+        "src/geom_op.c",
+        "src/pygeom.c",
+        "src/ufuncs.c",
+        "src/coords.c",
+        "src/strtree.c",
+        "src/vector.c",
+    ],
     **get_geos_paths()
 )
 
@@ -122,7 +131,7 @@ except IOError:
 
 version = versioneer.get_version()
 cmdclass = versioneer.get_cmdclass()
-cmdclass['build_ext'] = build_ext
+cmdclass["build_ext"] = build_ext
 
 setup(
     name="pygeos",
@@ -136,13 +145,10 @@ setup(
     packages=["pygeos"],
     setup_requires=["numpy"],
     install_requires=["numpy>=1.10"],
-    extras_require={
-        "test": ["pytest"],
-        "docs": ["sphinx", "numpydoc"],
-    },
+    extras_require={"test": ["pytest"], "docs": ["sphinx", "numpydoc"],},
     python_requires=">=3",
     include_package_data=True,
-    data_files=[('geos_license', ['GEOS_LICENSE'])],
+    data_files=[("geos_license", ["GEOS_LICENSE"])],
     ext_modules=[module_lib],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/geom_op.c
+++ b/src/geom_op.c
@@ -1,0 +1,218 @@
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <Python.h>
+#include <structmember.h>
+
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+
+#include <numpy/arrayobject.h>
+#include <numpy/ndarraytypes.h>
+#include <numpy/npy_3kcompat.h>
+
+
+#include "geos.h"
+#include "kvec.h"
+#include "pygeom.h"
+#include "vector.h"
+
+/* Get a GEOS geometry at position N within a collection of geometries.
+ * Only valid for GeometryCollection or Multi* geometries.
+ *
+ * Negative indexing is supported.
+ *
+ * Parameters
+ * ----------
+ * context: GEOS context
+ * geom: GEOSGeometry, must be GeometryCollection or Multi*
+ * n: position within collection of geometries to return.
+ *
+ * Returns
+ * -------
+ * a clone of the geometry, or NULL if geometry does not have geometries
+ * or position n resolves to an index that is out of bounds.
+ */
+
+void *GetGeometryN(void *context, void *geom, int n)
+{
+    int size, i;
+    size = GEOSGetNumGeometries_r(context, geom);
+    if (size == -1) {
+        return NULL;
+    }
+    if (n < 0) {
+        /* Negative indexing: we get it for free */
+        i = size + n;
+    } else {
+        i = n;
+    }
+    if ((i < 0) | (i >= size)) {
+        /* Important, could give segfaults else */
+        return NULL;
+    }
+    void *ret = (void *) GEOSGetGeometryN_r(context, geom, i);
+    /* Create a copy of the obtained geometry */
+    if (ret != NULL) {
+        ret = GEOSGeom_clone_r(context, ret);
+    }
+    return ret;
+}
+
+/* Add all geometries in a GEOS geometry to a resizable vector.
+ * Only valid for GeometryCollection or Multi* geometries.
+ *
+ * Parameters
+ * ----------
+ * context: GEOS context
+ * geom: GEOSGeometry, must be GeometryCollection or Multi*
+ * geometries: resizable vector of GEOSGeometry (for parts)
+ */
+static int GetGeometries(void *context, void *geom, geom_obj_vec *geometries)
+{
+    GEOSGeometry *ret;
+    int count, i;
+
+    if (geom == NULL) {
+        return NULL;
+    }
+
+    count = GEOSGetNumGeometries_r(context, geom);
+
+    if (count == -1) {
+        return -1;
+    }
+    for (i=0; i<count; i++) {
+        // This also clones the underlying geometry part
+        kv_push(GEOSGeometry *, *geometries, GetGeometryN(context, geom, i));
+    }
+
+    return count;
+}
+
+/* Python interface function to get all parts for each geometry in an
+ * array of geometries.  If a given geometry is NULL, empty, or has no parts,
+ * it will be returned as is (as a clone, if a geometry).
+ *
+ * Parameters
+ * ----------
+ * arr: 1d array of pygeos Geometry objects
+ *
+ * Returns
+ * -------
+ * tuple of (indexes, geometries)
+ *
+ */
+PyObject *PyGetParts(PyObject *self, PyObject *arr) {
+    GEOSContextHandle_t context = geos_context[0];
+    PyArrayObject *pg_geoms;
+    GeometryObject *pg_geom;
+    GEOSGeometry *geom, *part;
+    npy_intp_vec src_indexes;
+    geom_obj_vec geom_parts;
+    npy_intp i, j, n, size;
+    int geom_type;
+    PyArrayObject *out_indexes, *out_pgeoms;
+    PyObject *result;
+
+    if (!PyArray_Check(arr)) {
+        PyErr_SetString(PyExc_TypeError, "Not an ndarray");
+        return NULL;
+    }
+
+    pg_geoms = (PyArrayObject *) arr;
+    if (!PyArray_ISOBJECT(pg_geoms)) {
+        PyErr_SetString(PyExc_TypeError, "Array should be of object dtype");
+        return NULL;
+    }
+
+    if (PyArray_NDIM(pg_geoms) != 1) {
+        PyErr_SetString(PyExc_TypeError, "Array should be one dimensional");
+        return NULL;
+    }
+
+    kv_init(src_indexes);
+    kv_init(geom_parts);
+    n = PyArray_SIZE(pg_geoms);
+
+    for(i = 0; i < n; i++) {
+        // get pygeos geometry from input geometry array
+        pg_geom = *(GeometryObject **) PyArray_GETPTR1(pg_geoms, i);
+
+        // get GEOSGeometry from pygeos geometry
+        if (!get_geom(pg_geom, &geom)) {
+            PyErr_SetString(PyExc_TypeError, "Invalid geometry");
+            return NULL;
+        }
+        if (geom == NULL) {
+            continue;
+        }
+        if (GEOSisEmpty_r(context, geom)) {
+            continue;
+        }
+
+        geom_type = GEOSGeomTypeId_r(context, geom);
+        if (geom_type == -1) {
+            RAISE_ILLEGAL_GEOS;
+        }
+        if (geom_type == 7) {
+            // geometry collection
+            // TODO: recursively expand geometry
+            PyErr_SetString(PyExc_TypeError, "GeometryCollection: not yet implemented");
+        }
+        else if (geom_type >= 4 && geom_type <= 6) {
+            // Multi* geometry
+            size = GetGeometries(context, geom, &geom_parts);
+            if (size == -1) {
+                PyErr_SetString(PyExc_RuntimeError, "Error extracting parts from geometry");
+                return NULL;
+            }
+            for (j=0; j<size; j++) {
+                kv_push(npy_intp, src_indexes, i);
+            }
+        }
+        else {
+            // singular geometry
+            part = GEOSGeom_clone_r(context, geom);
+            kv_push(GEOSGeometry *, geom_parts, part);
+            kv_push(npy_intp, src_indexes, i);
+        }
+    }
+
+    // make tuple by converting vectors to ndarrays
+    result = PyTuple_New(2);
+    PyTuple_SetItem(result, 0, (PyObject *)npy_intp_vec_to_npy_arr(&src_indexes));
+    PyTuple_SetItem(result, 1, (PyObject *)geom_obj_vec_to_npy_arr(&geom_parts));
+
+    kv_destroy(src_indexes);
+    kv_destroy(geom_parts);
+
+    return result;
+}
+
+
+// static char Y_Y_dtypes[2] = {NPY_OBJECT, NPY_OBJECT};
+// static void Y_Y_func(char **args, npy_intp *dimensions,
+//                      npy_intp *steps, void *data)
+// {
+//     FuncGEOS_Y_Y *func = (FuncGEOS_Y_Y *)data;
+//     void *context_handle = geos_context[0];
+//     GEOSGeometry *in1, *ret_ptr;
+
+//     UNARY_LOOP {
+//         /* get the geometry: return on error */
+//         if (!get_geom(*(GeometryObject **)ip1, &in1)) { return; }
+//         if (in1 == NULL) {
+//             /* in case of a missing value: return NULL (NaG) */
+//             ret_ptr = NULL;
+//         } else {
+//             ret_ptr = func(context_handle, in1);
+//             /* trust that GEOS calls HandleGEOSError on error */
+//         }
+//         OUTPUT_Y;
+//     }
+// }
+// static PyUFuncGenericFunction Y_Y_funcs[1] = {&Y_Y_func};
+// #define DEFINE_Y_Y(NAME)\
+//     ufunc = PyUFunc_FromFuncAndData(Y_Y_funcs, NAME ##_data, Y_Y_dtypes, 1, 1, 1, PyUFunc_None, # NAME, "", 0);\
+//     PyDict_SetItemString(d, # NAME, ufunc)

--- a/src/geom_op.c
+++ b/src/geom_op.c
@@ -189,30 +189,3 @@ PyObject *PyGetParts(PyObject *self, PyObject *arr) {
 
     return result;
 }
-
-
-// static char Y_Y_dtypes[2] = {NPY_OBJECT, NPY_OBJECT};
-// static void Y_Y_func(char **args, npy_intp *dimensions,
-//                      npy_intp *steps, void *data)
-// {
-//     FuncGEOS_Y_Y *func = (FuncGEOS_Y_Y *)data;
-//     void *context_handle = geos_context[0];
-//     GEOSGeometry *in1, *ret_ptr;
-
-//     UNARY_LOOP {
-//         /* get the geometry: return on error */
-//         if (!get_geom(*(GeometryObject **)ip1, &in1)) { return; }
-//         if (in1 == NULL) {
-//             /* in case of a missing value: return NULL (NaG) */
-//             ret_ptr = NULL;
-//         } else {
-//             ret_ptr = func(context_handle, in1);
-//             /* trust that GEOS calls HandleGEOSError on error */
-//         }
-//         OUTPUT_Y;
-//     }
-// }
-// static PyUFuncGenericFunction Y_Y_funcs[1] = {&Y_Y_func};
-// #define DEFINE_Y_Y(NAME)\
-//     ufunc = PyUFunc_FromFuncAndData(Y_Y_funcs, NAME ##_data, Y_Y_dtypes, 1, 1, 1, PyUFunc_None, # NAME, "", 0);\
-//     PyDict_SetItemString(d, # NAME, ufunc)

--- a/src/geom_op.h
+++ b/src/geom_op.h
@@ -1,0 +1,8 @@
+#ifndef _GEOM_OP_H
+#define _GEOM_OP_H
+
+extern void *GetGeometryN(void *context, void *geom, int n);
+
+extern PyObject *PyGetParts(PyObject *self, PyObject *arr);
+
+#endif

--- a/src/lib.c
+++ b/src/lib.c
@@ -9,11 +9,12 @@
 #include <numpy/ufuncobject.h>
 #include <numpy/npy_3kcompat.h>
 
+#include "coords.h"
+#include "geom_op.h"
 #include "geos.h"
 #include "pygeom.h"
-#include "coords.h"
-#include "ufuncs.h"
 #include "strtree.h"
+#include "ufuncs.h"
 
 
 /* This tells Python what methods this module has. */
@@ -21,6 +22,7 @@ static PyMethodDef GeosModule[] = {
     {"count_coordinates", PyCountCoords, METH_VARARGS, "Counts the total amount of coordinates in a array with geometry objects"},
     {"get_coordinates", PyGetCoords, METH_VARARGS, "Gets the coordinates as an (N, 2) shaped ndarray of floats"},
     {"set_coordinates", PySetCoords, METH_VARARGS, "Sets coordinates to a geometry array"},
+    {"get_parts", PyGetParts, METH_O, "Get parts of each GeometryCollection or Multi* geometry"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -6,6 +6,7 @@
 
 #include "pygeom.h"
 #include "geos.h"
+#include "geom_op.h"
 
 /* Initializes a new geometry object */
 PyObject *GeometryObject_FromGEOS(PyTypeObject *type, GEOSGeometry *ptr)

--- a/src/pygeom.h
+++ b/src/pygeom.h
@@ -11,6 +11,7 @@ typedef struct {
 } GeometryObject;
 
 
+
 extern PyTypeObject GeometryType;
 
 /* Initializes a new geometry object */

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -4,22 +4,8 @@
 #include <Python.h>
 #include "geos.h"
 #include "pygeom.h"
+#include "vector.h"
 
-
-/* A resizable vector with numpy indices */
-typedef struct
-{
-    size_t n, m;
-    npy_intp *a;
-} npy_intp_vec;
-
-
-/* A resizable vector with pointers to pygeos GeometryObjects */
-typedef struct
-{
-    size_t n, m;
-    GeometryObject **a;
-} pg_geom_obj_vec;
 
 typedef struct {
     PyObject_HEAD

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -13,6 +13,7 @@
 #include <numpy/npy_3kcompat.h>
 
 #include "geos.h"
+#include "geom_op.h"
 #include "pygeom.h"
 #include "fast_loop_macros.h"
 
@@ -330,29 +331,6 @@ static void *GetInteriorRingN(void *context, void *geom, int n) {
     return ret;
 }
 static void *get_interior_ring_data[1] = {GetInteriorRingN};
-static void *GetGeometryN(void *context, void *geom, int n) {
-    int size, i;
-    size = GEOSGetNumGeometries_r(context, geom);
-    if (size == -1) {
-        return NULL;
-    }
-    if (n < 0) {
-        /* Negative indexing: we get it for free */
-        i = size + n;
-    } else {
-        i = n;
-    }
-    if ((i < 0) | (i >= size)) {
-        /* Important, could give segfaults else */
-        return NULL;
-    }
-    void *ret = (void *) GEOSGetGeometryN_r(context, geom, i);
-    /* Create a copy of the obtained geometry */
-    if (ret != NULL) {
-        ret = GEOSGeom_clone_r(context, ret);
-    }
-    return ret;
-}
 static void *get_geometry_data[1] = {GetGeometryN};
 /* the set srid funcion acts inplace */
 static void *GEOSSetSRID_r_with_clone(void *context, void *geom, int srid) {

--- a/src/vector.c
+++ b/src/vector.c
@@ -1,0 +1,81 @@
+
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <Python.h>
+#include <structmember.h>
+
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+
+#include <numpy/arrayobject.h>
+#include <numpy/ndarraytypes.h>
+#include <numpy/npy_3kcompat.h>
+
+#include "strtree.h"
+#include "geos.h"
+#include "pygeom.h"
+#include "kvec.h"
+#include "vector.h"
+
+/* Copy values from arr of indexes to a new numpy integer array.
+ *
+ * Parameters
+ * ----------
+ * arr: dynamic vector array to convert to ndarray
+ */
+
+PyArrayObject *npy_intp_vec_to_npy_arr(npy_intp_vec *arr)
+{
+    npy_intp i;
+    npy_intp size = kv_size(*arr);
+
+    npy_intp dims[1] = {size};
+    // the following raises a compiler warning based on how the macro is defined
+    // in numpy.  There doesn't appear to be anything we can do to avoid it.
+    PyArrayObject *result = (PyArrayObject *) PyArray_SimpleNew(1, dims, NPY_INTP);
+    if (result == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "could not allocate numpy array");
+        return NULL;
+    }
+
+    for (i = 0; i<size; i++) {
+        // assign value into numpy array
+        *(npy_intp *)PyArray_GETPTR1(result, i) = kv_A(*arr, i);
+    }
+
+    return (PyArrayObject *) result;
+}
+
+/* Copy values from arr of GEOSGeometry to numpy array of pygeos geometries.
+ *
+ * Parameters
+ * ----------
+ * arr: dynamic vector array to convert to ndarray
+ */
+
+PyArrayObject *geom_obj_vec_to_npy_arr(geom_obj_vec *arr)
+{
+    npy_intp i;
+    npy_intp size = kv_size(*arr);
+    GEOSGeometry *geom;
+    GeometryObject *pgeom;
+
+    npy_intp dims[1] = {size};
+    // the following raises a compiler warning based on how the macro is defined
+    // in numpy.  There doesn't appear to be anything we can do to avoid it.
+    PyArrayObject *result = (PyArrayObject *) PyArray_SimpleNew(1, dims, NPY_OBJECT);
+    if (result == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "could not allocate numpy array");
+        return NULL;
+    }
+
+    for (i = 0; i<size; i++) {
+        // assign value into numpy array
+        geom = kv_A(*arr, i);
+        pgeom = GeometryObject_FromGEOS(&GeometryType, geom);
+        *(PyObject **)PyArray_GETPTR1(result, i) = pgeom;
+    }
+
+    return (PyArrayObject *) result;
+}

--- a/src/vector.h
+++ b/src/vector.h
@@ -1,0 +1,57 @@
+#ifndef _VECTOR_H
+#define _VECTOR_H
+
+#include <Python.h>
+#include <numpy/ndarraytypes.h>
+#include "geos.h"
+#include "pygeom.h"
+#include "kvec.h"
+
+/* A resizable vector with numpy indices.
+ * Wraps the vector implementation in kvec.h as a type.
+ */
+typedef struct
+{
+    size_t n, m;
+    npy_intp *a;
+} npy_intp_vec;
+
+
+/* A resizable vector with pointers to GEOSGeometry objects.
+ * Wraps the vector implementation in kvec.h as a type.
+ */
+typedef struct
+{
+    size_t n, m;
+    GEOSGeometry **a;
+} geom_obj_vec;
+
+
+/* A resizable vector with pointers to pygeos GeometryObjects.
+ * Wraps the vector implementation in kvec.h as a type.
+ */
+typedef struct
+{
+    size_t n, m;
+    GeometryObject **a;
+} pg_geom_obj_vec;
+
+
+/* Copy values from arr to a new numpy integer array.
+ *
+ * Parameters
+ * ----------
+ * arr: dynamic vector array to convert to ndarray
+ */
+extern PyArrayObject *npy_intp_vec_to_npy_arr(npy_intp_vec *arr);
+
+
+/* Copy values from arr of GEOSGeometry to numpy array of pygeos geometries.
+ *
+ * Parameters
+ * ----------
+ * arr: dynamic vector array to convert to ndarray
+ */
+extern PyArrayObject *geom_obj_vec_to_npy_arr(geom_obj_vec *arr);
+
+#endif


### PR DESCRIPTION
Closes #127, closes #128 

This includes a bit of refactoring to make it easier to reuse our functions and types in C.

`vector`: types and functions for working with resizable vectors
`geom_op`: arbitrary place to put operations on geometries that are not ufuncs and not at the core of creating / converting geometries

This lifted the `GetGeometryN` from `ufuncs.c` to `geom_op.c` for reusibility in both.  There are a few other C functions in `ufuncs` that could move here as well (to keep the ufunc code focused on ufuncs), but weren't directly related to changes here.

We clearly need a better name for this function, `get_parts` is just a placeholder for now.

This takes as input a geometry or 1d array of geometry, and returns a tuple of indexes and new geometries for the parts.

GeometryCollection is not yet implemented.  There are recursive aspects of that which will require a bit more refactoring here.

I did not implement the single geometry case.  There might be a better way to handle that in a different function or method.

Key things to focus on here:
* function name
* return values

