### PR TITLE
DOC: add missing modules

### DIFF
--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -1,0 +1,9 @@
+:mod:`pygeos.creation`
+======================
+
+.. automodule:: pygeos.creation
+   :members:
+   :exclude-members:
+   :special-members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,9 +54,11 @@ API Reference
    :maxdepth: 2
    :caption: Contents:
 
+   creation
    constructive
    coordinates
    geometry
+   io
    linear
    measurement
    predicates

--- a/docs/io.rst
+++ b/docs/io.rst
@@ -1,0 +1,9 @@
+:mod:`pygeos.io`
+================
+
+.. automodule:: pygeos.io
+   :members:
+   :exclude-members:
+   :special-members:
+   :inherited-members:
+   :show-inheritance:


### PR DESCRIPTION
Added `pygeos.creation` and `pygeos.io` modules to API reference.

Closes #133