### PR TITLE
Implement GEOSBuildArea_r under constructive.build_area (GEOS 3.8.0+)

### DIFF
--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -15,6 +15,7 @@ __all__ = [
     "delaunay_triangles",
     "envelope",
     "extract_unique_points",
+    "build_area",
     "make_valid",
     "normalize",
     "point_on_surface",
@@ -286,6 +287,26 @@ def extract_unique_points(geometry, **kwargs):
     <pygeos.Geometry MULTIPOINT EMPTY>
     """
     return lib.extract_unique_points(geometry, **kwargs)
+
+
+@requires_geos("3.8.0")
+def build_area(geometry, **kwargs):
+    """Creates an areal geometry formed by the constituent linework of given geometry.
+
+    Equivalent of the PostGIS ST_BuildArea() function.
+
+    Requires at least GEOS 3.8.0.
+
+    Parameters
+    ----------
+    geometry : Geometry or array_like
+
+    Examples
+    --------
+    >>> build_area(Geometry("GEOMETRYCOLLECTION(POLYGON((0 0, 3 0, 3 3, 0 3, 0 0)), POLYGON((1 1, 1 2, 2 2, 1 1)))"))
+    <pygeos.Geometry POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,2 2,1 2,1 1))>
+    """
+    return lib.build_area(geometry, **kwargs)
 
 
 @requires_geos("3.8.0")

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -304,7 +304,7 @@ def build_area(geometry, **kwargs):
     Examples
     --------
     >>> build_area(Geometry("GEOMETRYCOLLECTION(POLYGON((0 0, 3 0, 3 3, 0 3, 0 0)), POLYGON((1 1, 1 2, 2 2, 1 1)))"))
-    <pygeos.Geometry POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,2 2,1 2,1 1))>
+    <pygeos.Geometry POLYGON ((0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 2 2, 1 2, 1 1))>
     """
     return lib.build_area(geometry, **kwargs)
 

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -93,7 +93,7 @@ def test_build_area_none():
         # geometry collection of two polygons are combined into one
         (
             Geometry("GEOMETRYCOLLECTION(POLYGON((0 0, 3 0, 3 3, 0 3, 0 0)), POLYGON((1 1, 1 2, 2 2, 1 1)))"),
-            Geometry("POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,2 2,1 2,1 1))"),
+            Geometry("POLYGON ((0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 2 2, 1 2, 1 1))"),
         ),
         (empty, empty),
         ([empty], [empty])

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -4,7 +4,7 @@ import pytest
 
 from pygeos import Geometry, GEOSException
 
-from .common import point, all_types, empty
+from .common import point, line_string, all_types, empty
 
 CONSTRUCTIVE_NO_ARGS = (
     pygeos.boundary,
@@ -76,6 +76,33 @@ def test_snap_none():
 def test_snap_nan_float(geometry):
     actual = pygeos.snap(geometry, point, tolerance=np.nan)
     assert actual is None
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
+def test_build_area_none():
+    actual = pygeos.build_area(None)
+    assert actual is None
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
+@pytest.mark.parametrize(
+    "geom,expected",
+    [
+        (point, empty),  # a point has no area
+        (line_string, empty),  # a line string has no area
+        # geometry collection of two polygons are combined into one
+        (
+            Geometry("GEOMETRYCOLLECTION(POLYGON((0 0, 3 0, 3 3, 0 3, 0 0)), POLYGON((1 1, 1 2, 2 2, 1 1)))"),
+            Geometry("POLYGON((0 0,0 3,3 3,3 0,0 0),(1 1,2 2,1 2,1 1))"),
+        ),
+        (empty, empty),
+        ([empty], [empty])
+    ],
+)
+def test_build_area(geom, expected):
+    actual = pygeos.build_area(geom)
+    assert actual is not expected
+    assert actual == expected
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -213,6 +213,7 @@ static void *GEOSLinearRingToPolygon(void *context, void *geom) {
 }
 static void *polygons_without_holes_data[1] = {GEOSLinearRingToPolygon};
 #if GEOS_SINCE_380
+  static void *build_area_data[1] = {GEOSBuildArea_r};
   static void *make_valid_data[1] = {GEOSMakeValid_r};
 #endif
 typedef void *FuncGEOS_Y_Y(void *context, void *a);
@@ -1487,6 +1488,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
 
     #if GEOS_SINCE_380
       DEFINE_Y_Y (make_valid);
+      DEFINE_Y_Y (build_area);
     #endif
 
     Py_DECREF(ufunc);


### PR DESCRIPTION
Firstly, great work with the project, team! I am excited about the Shapely 2.0 project, wanted to contribute where I can, and learn something along the way. @jorisvandenbossche suggested that https://github.com/pygeos/pygeos/issues/126 is good place to start. So this PR is me taking a stab at implementing one of the functions from the list. If this looks good, I can work on others too. Would love your feedback.

**Some relevant links**

- GEOS BuildArea documentation - https://geos.osgeo.org/doxygen/classgeos_1_1operation_1_1polygonize_1_1BuildArea.html#details
- PostGIS ST_BuildArea - https://postgis.net/docs/ST_BuildArea.html