### PR TITLE
Implement GEOSCoverageUnion_r under set_operations (GEOS 3.8.0+)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Version 0.8 (unreleased)
 
 **Highlights of this release**
 
+* Addition of ``coverage_union()`` and ``coverage_union_all()` functions
+  for GEOS >= 3.8 (#142)
 * Release the GIL to allow for multithreading in functions that do not 
   create geometries (#144)
 * Addition of a ``frechet_distance()`` function for GEOS >= 3.7 (#144)

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -1,6 +1,6 @@
 import numpy as np
 from . import lib, Geometry, GeometryType
-from .geos import requires_geos
+from .decorators import requires_geos
 
 __all__ = [
     "difference",

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -217,8 +217,11 @@ def coverage_union(a, b, **kwargs):
     Examples
     --------
     >>> polygon = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
-    >>> coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
-    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
+    >>> actual = coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
+    >>> from .predicates import equals
+    >>> expected = Geometry("POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))")
+    >>> equals(actual, expected)
+    True
 
     Overlapping polygons raise an error
     >>> coverage_union(polygon, None)
@@ -256,8 +259,11 @@ def coverage_union_all(geometries, axis=0, **kwargs):
     --------
     >>> polygon_1 = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> polygon_2 = Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")
-    >>> coverage_union_all([polygon_1, polygon_2])
-    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
+    >>> actual = coverage_union_all([polygon_1, polygon_2])
+    >>> from .predicates import equals
+    >>> expected = Geometry("POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))")
+    >>> equals(actual, expected)
+    True
 
     Overlapping polygons raise an error
     >>> polygon_2 = Geometry("POLYGON ((1 0, 0.9 1, 2 1, 2 0, 1 0))")

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -216,13 +216,14 @@ def coverage_union(a, b, **kwargs):
 
     Examples
     --------
+    >>> from pygeos.constructive import normalize
     >>> polygon = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
-    >>> coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
-    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
+    >>> normalize(coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")))
+    <pygeos.Geometry POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))>
 
     Union with None returns same polygon
-    >>> coverage_union(polygon, None)
-    <pygeos.Geometry POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))>
+    >>> normalize(coverage_union(polygon, None))
+    <pygeos.Geometry POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))>
     """
     return coverage_union_all([a, b], **kwargs)
 
@@ -250,10 +251,11 @@ def coverage_union_all(geometries, axis=0, **kwargs):
 
     Examples
     --------
+    >>> from pygeos.constructive import normalize
     >>> polygon_1 = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> polygon_2 = Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")
-    >>> coverage_union_all([polygon_1, polygon_2])
-    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
+    >>> normalize(coverage_union_all([polygon_1, polygon_2]))
+    <pygeos.Geometry POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))>
     """
     # coverage union in GEOS works over GeometryCollections
     # first roll the aggregation axis backwards

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -222,7 +222,7 @@ def coverage_union(a, b, **kwargs):
 
     Union with None returns same polygon
     >>> coverage_union(polygon, None)
-    <pygeos.Geometry POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))>
+    <pygeos.Geometry POLYGON ((1 0, 0 0, 0 1, 1 1, 1 0))>
     """
     return coverage_union_all([a, b], **kwargs)
 

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -223,9 +223,11 @@ def coverage_union(a, b, **kwargs):
     >>> equals(actual, expected)
     True
 
+    Union with None returns same polygon
+    >>> equals(coverage_union(polygon, None), polygon)
+    True
+
     Overlapping polygons raise an error
-    >>> coverage_union(polygon, None)
-    <pygeos.Geometry POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))>
     >>> coverage_union(polygon, Geometry("POLYGON ((1 0, 0.9 1, 2 1, 2 0, 1 0))"))
     Traceback (most recent call last):
         ...

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -232,6 +232,12 @@ def coverage_union(a, b, **kwargs):
     Traceback (most recent call last):
         ...
     pygeos.GEOSException: TopologyException: CoverageUnion cannot process incorrectly noded inputs.
+
+    Non polygon geometries raise an error
+    >>> coverage_union(polygon, Geometry("LINESTRING(0 0, 2 2)"))
+    Traceback (most recent call last):
+        ...
+    pygeos.GEOSException: IllegalArgumentException: Unhandled geometry type in CoverageUnion.
     """
     return coverage_union_all([a, b], **kwargs)
 
@@ -273,6 +279,14 @@ def coverage_union_all(geometries, axis=0, **kwargs):
     Traceback (most recent call last):
         ...
     pygeos.GEOSException: TopologyException: CoverageUnion cannot process incorrectly noded inputs.
+
+    Non polygon geometries raise an error
+    >>> line_1 = Geometry("LINESTRING(0 0, 2 2)")
+    >>> line_2 = Geometry("LINESTRING(2 2, 3 3)")
+    >>> coverage_union_all([line_1, line_2])
+    Traceback (most recent call last):
+        ...
+    pygeos.GEOSException: IllegalArgumentException: Unhandled geometry type in CoverageUnion.
     """
     # coverage union in GEOS works over GeometryCollections
     # first roll the aggregation axis backwards

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -216,28 +216,13 @@ def coverage_union(a, b, **kwargs):
 
     Examples
     --------
-    >>> polygon = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
-    >>> actual = coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
-    >>> from pygeos.predicates import equals
-    >>> expected = Geometry("POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))")
-    >>> equals(actual, expected)
-    True
+    >>> polygon = Geometry("POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))")
+    >>> coverage_union(polygon, Geometry("POLYGON ((2 1, 2 0, 1 0, 1 1, 2 1))"))
+    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
 
     Union with None returns same polygon
-    >>> equals(coverage_union(polygon, None), polygon)
-    True
-
-    Overlapping polygons raise an error
-    >>> coverage_union(polygon, Geometry("POLYGON ((1 0, 0.9 1, 2 1, 2 0, 1 0))"))
-    Traceback (most recent call last):
-        ...
-    pygeos.GEOSException: TopologyException: CoverageUnion cannot process incorrectly noded inputs.
-
-    Non polygon geometries raise an error
-    >>> coverage_union(polygon, Geometry("LINESTRING(0 0, 2 2)"))
-    Traceback (most recent call last):
-        ...
-    pygeos.GEOSException: IllegalArgumentException: Unhandled geometry type in CoverageUnion.
+    >>> coverage_union(polygon, None)
+    <pygeos.Geometry POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))>
     """
     return coverage_union_all([a, b], **kwargs)
 
@@ -265,28 +250,10 @@ def coverage_union_all(geometries, axis=0, **kwargs):
 
     Examples
     --------
-    >>> polygon_1 = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
-    >>> polygon_2 = Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")
-    >>> actual = coverage_union_all([polygon_1, polygon_2])
-    >>> from pygeos.predicates import equals
-    >>> expected = Geometry("POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))")
-    >>> equals(actual, expected)
-    True
-
-    Overlapping polygons raise an error
-    >>> polygon_2 = Geometry("POLYGON ((1 0, 0.9 1, 2 1, 2 0, 1 0))")
+    >>> polygon_1 = Geometry("POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))")
+    >>> polygon_2 = Geometry("POLYGON ((2 1, 2 0, 1 0, 1 1, 2 1))")
     >>> coverage_union_all([polygon_1, polygon_2])
-    Traceback (most recent call last):
-        ...
-    pygeos.GEOSException: TopologyException: CoverageUnion cannot process incorrectly noded inputs.
-
-    Non polygon geometries raise an error
-    >>> line_1 = Geometry("LINESTRING(0 0, 2 2)")
-    >>> line_2 = Geometry("LINESTRING(2 2, 3 3)")
-    >>> coverage_union_all([line_1, line_2])
-    Traceback (most recent call last):
-        ...
-    pygeos.GEOSException: IllegalArgumentException: Unhandled geometry type in CoverageUnion.
+    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
     """
     # coverage union in GEOS works over GeometryCollections
     # first roll the aggregation axis backwards

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -218,7 +218,7 @@ def coverage_union(a, b, **kwargs):
     --------
     >>> polygon = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> actual = coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
-    >>> from .predicates import equals
+    >>> from pygeos.predicates import equals
     >>> expected = Geometry("POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))")
     >>> equals(actual, expected)
     True
@@ -268,7 +268,7 @@ def coverage_union_all(geometries, axis=0, **kwargs):
     >>> polygon_1 = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> polygon_2 = Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")
     >>> actual = coverage_union_all([polygon_1, polygon_2])
-    >>> from .predicates import equals
+    >>> from pygeos.predicates import equals
     >>> expected = Geometry("POLYGON ((0 0, 0 1, 1 1, 2 1, 2 0, 1 0, 0 0))")
     >>> equals(actual, expected)
     True

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -218,7 +218,7 @@ def coverage_union(a, b, **kwargs):
     --------
     >>> polygon = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
-    <pygeos.Geometry POLYGON ((0 1, 1 1, 2 1, 2 0, 1 0, 0 0, 0 1))>
+    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
 
     Union with None returns same polygon
     >>> coverage_union(polygon, None)
@@ -253,7 +253,7 @@ def coverage_union_all(geometries, axis=0, **kwargs):
     >>> polygon_1 = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> polygon_2 = Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")
     >>> coverage_union_all([polygon_1, polygon_2])
-    <pygeos.Geometry POLYGON ((0 1, 1 1, 2 1, 2 0, 1 0, 0 0, 0 1))>
+    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
     """
     # coverage union in GEOS works over GeometryCollections
     # first roll the aggregation axis backwards

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -218,7 +218,7 @@ def coverage_union(a, b, **kwargs):
     --------
     >>> polygon = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
-    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
+    <pygeos.Geometry POLYGON ((0 1, 1 1, 2 1, 2 0, 1 0, 0 0, 0 1))>
 
     Union with None returns same polygon
     >>> coverage_union(polygon, None)
@@ -253,7 +253,7 @@ def coverage_union_all(geometries, axis=0, **kwargs):
     >>> polygon_1 = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
     >>> polygon_2 = Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")
     >>> coverage_union_all([polygon_1, polygon_2])
-    <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
+    <pygeos.Geometry POLYGON ((0 1, 1 1, 2 1, 2 0, 1 0, 0 0, 0 1))>
     """
     # coverage union in GEOS works over GeometryCollections
     # first roll the aggregation axis backwards

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -216,8 +216,8 @@ def coverage_union(a, b, **kwargs):
 
     Examples
     --------
-    >>> polygon = Geometry("POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))")
-    >>> coverage_union(polygon, Geometry("POLYGON ((2 1, 2 0, 1 0, 1 1, 2 1))"))
+    >>> polygon = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
+    >>> coverage_union(polygon, Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))"))
     <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
 
     Union with None returns same polygon
@@ -250,8 +250,8 @@ def coverage_union_all(geometries, axis=0, **kwargs):
 
     Examples
     --------
-    >>> polygon_1 = Geometry("POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))")
-    >>> polygon_2 = Geometry("POLYGON ((2 1, 2 0, 1 0, 1 1, 2 1))")
+    >>> polygon_1 = Geometry("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
+    >>> polygon_2 = Geometry("POLYGON ((1 0, 1 1, 2 1, 2 0, 1 0))")
     >>> coverage_union_all([polygon_1, polygon_2])
     <pygeos.Geometry POLYGON ((2 1, 2 0, 1 0, 0 0, 0 1, 1 1, 2 1))>
     """

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -2,7 +2,7 @@ import pytest
 import pygeos
 from pygeos import Geometry
 
-from .common import point, all_types
+from .common import point, all_types, polygon, multi_polygon
 
 SET_OPERATIONS = (
     pygeos.difference,
@@ -23,6 +23,12 @@ reduce_test_data = [
     pygeos.box(0, 0, 5, 5),
     pygeos.box(2, 2, 7, 7),
     pygeos.box(4, 4, 9, 9),
+]
+
+non_polygon_types = [
+    geom
+    for geom in all_types
+    if (not pygeos.is_empty(geom) and geom not in (polygon, multi_polygon))
 ]
 
 
@@ -77,3 +83,47 @@ def test_coverage_union_reduce_1dim(n):
     for i in range(1, n):
         expected = pygeos.coverage_union(expected, test_data[i])
     assert pygeos.equals(actual, expected)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
+def test_coverage_union_reduce_axis():
+    # shape = (3, 2), all polygons - none of them overlapping
+    data = [[pygeos.box(i, j, i + 1, j + 1) for i in range(2)] for j in range(3)]
+    actual = pygeos.coverage_union_all(data)
+    assert actual.shape == (2,)
+    actual = pygeos.coverage_union_all(data, axis=0)  # default
+    assert actual.shape == (2,)
+    actual = pygeos.coverage_union_all(data, axis=1)
+    assert actual.shape == (3,)
+    actual = pygeos.coverage_union_all(data, axis=-1)
+    assert actual.shape == (3,)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
+def test_coverage_union_overlapping_inputs():
+    polygon = Geometry("POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))")
+
+    # Overlapping polygons raise an error
+    with pytest.raises(pygeos.GEOSException, match="CoverageUnion cannot process incorrectly noded inputs."):
+        pygeos.coverage_union(polygon, Geometry("POLYGON ((1 0, 0.9 1, 2 1, 2 0, 1 0))"))
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
+@pytest.mark.parametrize(
+    "geom_1, geom_2",
+    # All possible polygon, non_polygon combinations
+    [
+        [polygon, non_polygon]
+        for non_polygon in non_polygon_types
+    ] +
+    # All possible non_polygon, non_polygon combinations
+    [
+        [non_polygon_1, non_polygon_2]
+        for non_polygon_1 in non_polygon_types
+        for non_polygon_2 in non_polygon_types
+    ],
+)
+def test_coverage_union_non_polygon_inputs(geom_1, geom_2):
+    # Non polygon geometries raise an error
+    with pytest.raises(pygeos.GEOSException, match="Unhandled geometry type in CoverageUnion."):
+        pygeos.coverage_union(geom_1, geom_2)

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -9,12 +9,14 @@ SET_OPERATIONS = (
     pygeos.intersection,
     pygeos.symmetric_difference,
     pygeos.union,
+    # pygeos.coverage_union is tested seperately
 )
 
 REDUCE_SET_OPERATIONS = (
     (pygeos.intersection_all, pygeos.intersection),
     (pygeos.symmetric_difference_all, pygeos.symmetric_difference),
     (pygeos.union_all, pygeos.union),
+    # (pygeos.coverage_union_all, pygeos.coverage_union) is tested seperately
 )
 
 reduce_test_data = [
@@ -54,3 +56,24 @@ def test_set_operation_reduce_axis(func, related_func):
     assert actual.shape == (3,)
     actual = func(data, axis=-1)
     assert actual.shape == (3,)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
+@pytest.mark.parametrize("n", range(1, 4))
+def test_coverage_union_reduce_1dim(n):
+    """
+    This is tested seperately from other set operations as it differs in two ways:
+      1. It expects only non-overlapping polygons
+      2. It expects GEOS 3.8.0+
+    """
+    test_data = [
+        pygeos.box(0, 0, 1, 1),
+        pygeos.box(1, 0, 2, 1),
+        pygeos.box(2, 0, 3, 1),
+    ]
+    actual = pygeos.coverage_union_all(test_data[:n])
+    # perform the reduction in a python loop and compare
+    expected = test_data[0]
+    for i in range(1, n):
+        expected = pygeos.coverage_union(expected, test_data[i])
+    assert pygeos.equals(actual, expected)

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -188,7 +188,6 @@ static void *GEOSBoundaryAllTypes_r(void *context, void *geom) {
 }
 static void *boundary_data[1] = {GEOSBoundaryAllTypes_r};
 static void *unary_union_data[1] = {GEOSUnaryUnion_r};
-static void *coverage_union_data[1] = {GEOSCoverageUnion_r};
 static void *point_on_surface_data[1] = {GEOSPointOnSurface_r};
 static void *centroid_data[1] = {GEOSGetCentroid_r};
 static void *line_merge_data[1] = {GEOSLineMerge_r};
@@ -229,6 +228,7 @@ static void *polygons_without_holes_data[1] = {GEOSLinearRingToPolygon};
 #if GEOS_SINCE_3_8_0
   static void *build_area_data[1] = {GEOSBuildArea_r};
   static void *make_valid_data[1] = {GEOSMakeValid_r};
+  static void *coverage_union_data[1] = {GEOSCoverageUnion_r};
 #endif
 typedef void *FuncGEOS_Y_Y(void *context, void *a);
 static char Y_Y_dtypes[2] = {NPY_OBJECT, NPY_OBJECT};
@@ -1545,7 +1545,6 @@ int init_ufuncs(PyObject *m, PyObject *d)
     DEFINE_Y_Y (convex_hull);
     DEFINE_Y_Y (boundary);
     DEFINE_Y_Y (unary_union);
-    DEFINE_Y_Y (coverage_union);
     DEFINE_Y_Y (point_on_surface);
     DEFINE_Y_Y (centroid);
     DEFINE_Y_Y (line_merge);
@@ -1619,6 +1618,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
     #if GEOS_SINCE_3_8_0
       DEFINE_Y_Y (make_valid);
       DEFINE_Y_Y (build_area);
+      DEFINE_Y_Y (coverage_union);
     #endif
 
     Py_DECREF(ufunc);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -188,6 +188,7 @@ static void *GEOSBoundaryAllTypes_r(void *context, void *geom) {
 }
 static void *boundary_data[1] = {GEOSBoundaryAllTypes_r};
 static void *unary_union_data[1] = {GEOSUnaryUnion_r};
+static void *coverage_union_data[1] = {GEOSCoverageUnion_r};
 static void *point_on_surface_data[1] = {GEOSPointOnSurface_r};
 static void *centroid_data[1] = {GEOSGetCentroid_r};
 static void *line_merge_data[1] = {GEOSLineMerge_r};
@@ -1544,6 +1545,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
     DEFINE_Y_Y (convex_hull);
     DEFINE_Y_Y (boundary);
     DEFINE_Y_Y (unary_union);
+    DEFINE_Y_Y (coverage_union);
     DEFINE_Y_Y (point_on_surface);
     DEFINE_Y_Y (centroid);
     DEFINE_Y_Y (line_merge);


### PR DESCRIPTION
Implement `GEOSCoverageUnion_r` under `set_operations`, while keeping the module API similar to others, by introducing two functions `coverage_union` and `coverage_union_all`. With the latter being a reducer function of the former.

The only slightly hacky thing is that I had to test `coverage_union` slightly different from other functions of the set operations module, as it is different from them, added a comment about this in code.

See related issue https://github.com/pygeos/pygeos/issues/126.