### PR TITLE
Implement wrappers for Fréchet distance under measurement module (3.7.0+)

### DIFF
--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -2,8 +2,10 @@ import numpy as np
 
 from . import lib
 from . import Geometry  # NOQA
+from .geos import requires_geos
 
-__all__ = ["area", "distance", "bounds", "total_bounds", "length", "hausdorff_distance"]
+
+__all__ = ["area", "distance", "bounds", "total_bounds", "length", "hausdorff_distance", "frechet_distance"]
 
 
 def area(geometry, **kwargs):
@@ -172,3 +174,40 @@ def hausdorff_distance(a, b, densify=None, **kwargs):
         return lib.hausdorff_distance(a, b, **kwargs)
     else:
         return lib.haussdorf_distance_densify(a, b, densify, **kwargs)
+
+
+@requires_geos("3.7.0")
+def frechet_distance(a, b, densify=None, **kwargs):
+    """Compute the discrete Fréchet distance between two geometries.
+
+    The Fréchet distance is a measure of similarity: it is the greatest
+    distance between any point in A and the closest point in B. The discrete
+    distance is an approximation of this metric: only vertices are considered.
+    The parameter 'densify' makes this approximation less coarse by splitting
+    the line segments between vertices before computing the distance.
+
+    Fréchet distance sweep continuously along their respective curves
+    and the direction of curves is significant. This makes it a better measure
+    of similarity than Hausdorff distance for curve or surface matching.
+
+    Parameters
+    ----------
+    a, b : Geometry or array_like
+    densify : float, array_like or None
+        The value of densify is required to be between 0 and 1.
+
+    Examples
+    --------
+    >>> line_1 = Geometry("LINESTRING (0 0, 100 0)")
+    >>> line_2 = Geometry("LINESTRING (0 0, 50 50, 100 0)")
+    >>> frechet_distance(line_1, line_2)  # doctest: +ELLIPSIS
+    70.71...
+    >>> frechet_distance(line_1, line_2, densify=0.5)
+    50.0
+    >>> frechet_distance(line_1, None)
+    nan
+    """
+    if densify is None:
+        return lib.frechet_distance(a, b, **kwargs)
+    else:
+        return lib.frechet_distance_densify(a, b, densify, **kwargs)

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -211,10 +211,4 @@ def frechet_distance(a, b, densify=None, **kwargs):
     """
     if densify is None:
         return lib.frechet_distance(a, b, **kwargs)
-
-    if not isinstance(densify, (int, float)) or np.isnan(densify) or densify <= 0 or densify > 1:
-        raise ValueError(
-                "Densify must be in range (0.0 - 1.0], got {} instead".format(densify)
-            )
-
     return lib.frechet_distance_densify(a, b, densify, **kwargs)

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -204,6 +204,8 @@ def frechet_distance(a, b, densify=None, **kwargs):
     70.71...
     >>> frechet_distance(line_1, line_2, densify=0.5)
     50.0
+    >>> frechet_distance(line_1, Geometry("LINESTRING EMPTY"))
+    nan
     >>> frechet_distance(line_1, None)
     nan
     """

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -212,4 +212,8 @@ def frechet_distance(a, b, densify=None, **kwargs):
     if densify is None:
         return lib.frechet_distance(a, b, **kwargs)
     else:
+        if not isinstance(densify, (int, float)) or np.isnan(densify) or densify <= 0 or densify > 1:
+            raise ValueError(
+                    "Densify must be in range (0.0 - 1.0], got {} instead".format(densify)
+                )
         return lib.frechet_distance_densify(a, b, densify, **kwargs)

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -211,9 +211,10 @@ def frechet_distance(a, b, densify=None, **kwargs):
     """
     if densify is None:
         return lib.frechet_distance(a, b, **kwargs)
-    else:
-        if not isinstance(densify, (int, float)) or np.isnan(densify) or densify <= 0 or densify > 1:
-            raise ValueError(
-                    "Densify must be in range (0.0 - 1.0], got {} instead".format(densify)
-                )
-        return lib.frechet_distance_densify(a, b, densify, **kwargs)
+
+    if not isinstance(densify, (int, float)) or np.isnan(densify) or densify <= 0 or densify > 1:
+        raise ValueError(
+                "Densify must be in range (0.0 - 1.0], got {} instead".format(densify)
+            )
+
+    return lib.frechet_distance_densify(a, b, densify, **kwargs)

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -241,11 +241,11 @@ def test_frechet_distance_densify(geom1, geom2, densify, expected):
 @pytest.mark.parametrize(
     "geom1, geom2",
     [
-        (point, None),
-        (None, point),
+        (line_string, None),
+        (None, line_string),
         (None, None),
-        (point, empty),
-        (empty, point),
+        (line_string, empty),
+        (empty, line_string),
         (empty, empty),
     ],
 )
@@ -266,11 +266,11 @@ def test_frechet_distance_nan_for_invalid_geometry_inputs(geom1, geom2):
     ]
 )
 def test_frechet_densify_invalid_values(densify):
-    with pytest.raises(ValueError):
-        actual = pygeos.frechet_distance(point, point, densify=densify)
+    with pytest.raises(ValueError, match=r"Densify must be in range \(0.0 - 1.0], got .* instead"):
+        actual = pygeos.frechet_distance(line_string, line_string, densify=densify)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
 def test_frechet_distance_densify_empty():
-    actual = pygeos.frechet_distance(point, empty, densify=0.2)
+    actual = pygeos.frechet_distance(line_string, empty, densify=0.2)
     assert np.isnan(actual)

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -175,3 +175,42 @@ def test_haussdorf_distance_empty():
 def test_haussdorf_distance_densify_empty():
     actual = pygeos.hausdorff_distance(point, empty, densify=0.2)
     assert np.isnan(actual)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
+def test_frechet_distance():
+    # example from GEOS docs
+    a = pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]])
+    b = pygeos.linestrings([[0, 200], [200, 150], [0, 100], [200, 50], [0, 0]])
+    actual = pygeos.frechet_distance(a, b)
+    assert actual == pytest.approx(200, abs=1e-7)
+    c = pygeos.linestrings([[0, 0], [200, 50], [0, 100], [200, 150], [0, 200]])
+    actual = pygeos.frechet_distance(a, c)
+    assert actual == pytest.approx(282.842712474619, abs=1e-12)
+
+    # example from GEOS tests
+    a = pygeos.linestrings([[0, 0], [100, 0]])
+    b = pygeos.linestrings([[0, 0], [50, 50], [100, 0]])
+    actual = pygeos.frechet_distance(a, b)
+    assert actual == pytest.approx(70.7106781186548, abs=1e-12)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
+def test_frechet_distance_densify():
+    # example from GEOS tests
+    a = pygeos.linestrings([[0, 0], [100, 0]])
+    b = pygeos.linestrings([[0, 0], [50, 50], [100, 0]])
+    actual = pygeos.frechet_distance(a, b, densify=0.001)
+    assert actual == pytest.approx(50, abs=0.1)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
+def test_frechet_distance_missing():
+    actual = pygeos.frechet_distance(point, None)
+    assert np.isnan(actual)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
+def test_frechet_densify_nan():
+    actual = pygeos.frechet_distance(point, point, densify=np.nan)
+    assert np.isnan(actual)

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -216,11 +216,13 @@ def test_frechet_densify_nan():
     assert np.isnan(actual)
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
 def test_frechet_distance_empty():
     actual = pygeos.frechet_distance(point, empty)
     assert np.isnan(actual)
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
 def test_frechet_distance_densify_empty():
     actual = pygeos.frechet_distance(point, empty, densify=0.2)
     assert np.isnan(actual)

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -255,9 +255,19 @@ def test_frechet_distance_nan_for_invalid_geometry_inputs(geom1, geom2):
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
-def test_frechet_densify_nan():
-    actual = pygeos.frechet_distance(point, point, densify=np.nan)
-    assert np.isnan(actual)
+@pytest.mark.parametrize(
+    "densify",
+    [
+        np.nan,
+        0,
+        -1,
+        2,
+        "0.5"
+    ]
+)
+def test_frechet_densify_invalid_values(densify):
+    with pytest.raises(ValueError):
+        actual = pygeos.frechet_distance(point, point, densify=densify)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -255,14 +255,29 @@ def test_frechet_distance_nan_for_invalid_geometry_inputs(geom1, geom2):
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
+def test_frechet_densify_ndarray():
+    actual = pygeos.frechet_distance(
+        pygeos.linestrings([[0, 0], [100, 0]]),
+        pygeos.linestrings([[0, 0], [50, 50], [100, 0]]),
+        densify=[0.1, 0.2, 1]
+    )
+    expected = np.array([50, 50.99019514, 70.7106781186548])
+    np.testing.assert_array_almost_equal(actual, expected)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
+def test_frechet_densify_nan():
+    actual = pygeos.frechet_distance(line_string, line_string, densify=np.nan)
+    assert np.isnan(actual)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
 @pytest.mark.parametrize(
     "densify",
     [
-        np.nan,
         0,
         -1,
         2,
-        "0.5"
     ]
 )
 def test_frechet_densify_invalid_values(densify):

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -214,3 +214,13 @@ def test_frechet_distance_missing():
 def test_frechet_densify_nan():
     actual = pygeos.frechet_distance(point, point, densify=np.nan)
     assert np.isnan(actual)
+
+
+def test_frechet_distance_empty():
+    actual = pygeos.frechet_distance(point, empty)
+    assert np.isnan(actual)
+
+
+def test_frechet_distance_densify_empty():
+    actual = pygeos.frechet_distance(point, empty, densify=0.2)
+    assert np.isnan(actual)

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -181,11 +181,24 @@ def test_haussdorf_distance_densify_empty():
 @pytest.mark.parametrize(
     "geom1, geom2, expected",
     [
+        # identical geometries should have 0 distance
+        (
+            pygeos.linestrings([[0, 0], [100, 0]]),
+            pygeos.linestrings([[0, 0], [100, 0]]),
+            0,
+        ),
         # example from GEOS docs
         (
             pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]]),
             pygeos.linestrings([[0, 200], [200, 150], [0, 100], [200, 50], [0, 0]]),
             200
+        ),
+        # same geometries but different curve direction results in maximum
+        # distance between vertices on the lines.
+        (
+            pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]]),
+            pygeos.linestrings([[200, 0], [150, 200], [100, 0], [50, 200], [0, 0]]),
+            200,
         ),
         # another example from GEOS docs
         (

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -178,47 +178,72 @@ def test_haussdorf_distance_densify_empty():
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
-def test_frechet_distance():
-    # example from GEOS docs
-    a = pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]])
-    b = pygeos.linestrings([[0, 200], [200, 150], [0, 100], [200, 50], [0, 0]])
-    actual = pygeos.frechet_distance(a, b)
-    assert actual == pytest.approx(200, abs=1e-7)
-    c = pygeos.linestrings([[0, 0], [200, 50], [0, 100], [200, 150], [0, 200]])
-    actual = pygeos.frechet_distance(a, c)
-    assert actual == pytest.approx(282.842712474619, abs=1e-12)
-
-    # example from GEOS tests
-    a = pygeos.linestrings([[0, 0], [100, 0]])
-    b = pygeos.linestrings([[0, 0], [50, 50], [100, 0]])
-    actual = pygeos.frechet_distance(a, b)
-    assert actual == pytest.approx(70.7106781186548, abs=1e-12)
+@pytest.mark.parametrize(
+    "geom1, geom2, expected",
+    [
+        # example from GEOS docs
+        (
+            pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]]),
+            pygeos.linestrings([[0, 200], [200, 150], [0, 100], [200, 50], [0, 0]]),
+            200
+        ),
+        # another example from GEOS docs
+        (
+            pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]]),
+            pygeos.linestrings([[0, 0], [200, 50], [0, 100], [200, 150], [0, 200]]),
+            282.842712474619
+        ),
+        # example from GEOS tests
+        (
+            pygeos.linestrings([[0, 0], [100, 0]]),
+            pygeos.linestrings([[0, 0], [50, 50], [100, 0]]),
+            70.7106781186548
+        ),
+    ],
+)
+def test_frechet_distance(geom1, geom2, expected):
+    actual = pygeos.frechet_distance(geom1, geom2)
+    assert actual == pytest.approx(expected, abs=1e-12)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
-def test_frechet_distance_densify():
-    # example from GEOS tests
-    a = pygeos.linestrings([[0, 0], [100, 0]])
-    b = pygeos.linestrings([[0, 0], [50, 50], [100, 0]])
-    actual = pygeos.frechet_distance(a, b, densify=0.001)
-    assert actual == pytest.approx(50, abs=0.1)
+@pytest.mark.parametrize(
+    "geom1, geom2, densify, expected",
+    [
+        # example from GEOS tests
+        (
+            pygeos.linestrings([[0, 0], [100, 0]]),
+            pygeos.linestrings([[0, 0], [50, 50], [100, 0]]),
+            0.001,
+            50
+        ),
+    ],
+)
+def test_frechet_distance_densify(geom1, geom2, densify, expected):
+    actual = pygeos.frechet_distance(geom1, geom2, densify=densify)
+    assert actual == pytest.approx(expected, abs=1e-12)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
-def test_frechet_distance_missing():
-    actual = pygeos.frechet_distance(point, None)
+@pytest.mark.parametrize(
+    "geom1, geom2",
+    [
+        (point, None),
+        (None, point),
+        (None, None),
+        (point, empty),
+        (empty, point),
+        (empty, empty),
+    ],
+)
+def test_frechet_distance_nan_for_invalid_geometry_inputs(geom1, geom2):
+    actual = pygeos.frechet_distance(geom1, geom2)
     assert np.isnan(actual)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
 def test_frechet_densify_nan():
     actual = pygeos.frechet_distance(point, point, densify=np.nan)
-    assert np.isnan(actual)
-
-
-@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
-def test_frechet_distance_empty():
-    actual = pygeos.frechet_distance(point, empty)
     assert np.isnan(actual)
 
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -535,10 +535,9 @@ static void *hausdorff_distance_data[1] = {GEOSHausdorffDistance_r};
       /* Handle empty geometries (they give segfaults) */
       if (GEOSisEmpty_r(context, a) | GEOSisEmpty_r(context, b)) {
           *c = NPY_NAN;
-      } else {
-          return GEOSFrechetDistance_r(context, a, b, c);
+          return 1;
       }
-      return 1;
+      return GEOSFrechetDistance_r(context, a, b, c);
   }
   static void *frechet_distance_data[1] = {GEOSFrechetDistanceWrapped_r};
 #endif

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -748,6 +748,10 @@ static void frechet_distance_densify_func(char **args, npy_intp *dimensions,
         if ((in1 == NULL) | (in2 == NULL) | npy_isnan(in3) | GEOSisEmpty_r(context_handle, in1) | GEOSisEmpty_r(context_handle, in2)) {
             *(double *)op1 = NPY_NAN;
         } else {
+            if ((in3 <= 0) | (in3 > 1)) {
+                PyErr_Format(PyExc_ValueError, "Densify must be in range (0.0 - 1.0], got %f instead", in3);
+                return;
+            }
             GEOSFrechetDistanceDensify_r(context_handle, in1, in2, in3, (double *) op1);
         }
     }

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -749,7 +749,7 @@ static void frechet_distance_densify_func(char **args, npy_intp *dimensions,
         if ((in1 == NULL) | (in2 == NULL) | npy_isnan(in3) | GEOSisEmpty_r(context_handle, in1) | GEOSisEmpty_r(context_handle, in2)) {
             *(double *)op1 = NPY_NAN;
         } else {
-            return GEOSFrechetDistanceDensify_r(context_handle, in1, in2, in3, (double *) op1);
+            GEOSFrechetDistanceDensify_r(context_handle, in1, in2, in3, (double *) op1);
         }
     }
 }


### PR DESCRIPTION
Code is pretty much similar to the implementation of wrappers for Hausdorff distance, except for:

1. Fréchet distance is only supported in 3.7.0, hence appropriate checks are additionally added.
2. When testing Hausdorff distance, there are tests with empty linestrings, but in the case of Fréchet distance, the GEOS library seems to be segfaulting when such inputs are passed. Hence I have skipped tests with empty linestrings for now. Any alternate suggestions over this are welcome.

Also, this is part of #126.