### PR TITLE
ENH: only add non-empty geometries to STRtree

### DIFF
--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -116,6 +116,21 @@ def test_query_empty(tree, geometry):
 
 
 @pytest.mark.parametrize(
+    "tree_geometry, geometry,expected",
+    [
+        ([point], box(0, 0, 10, 10), [0]),
+        # None is ignored in the tree, but the index of the valid geometry should
+        # be retained.
+        ([None, point], box(0, 0, 10, 10), [1]),
+        ([None, empty, point], box(0, 0, 10, 10), [2]),
+    ],
+)
+def test_query(tree_geometry, geometry, expected):
+    tree = pygeos.STRtree(np.array(tree_geometry))
+    assert_array_equal(tree.query(geometry), expected)
+
+
+@pytest.mark.parametrize(
     "geometry,expected",
     [
         # points do not intersect

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -648,6 +648,34 @@ def test_query_touches_polygons(poly_tree, geometry, expected):
 
 
 ### Bulk query tests
+@pytest.mark.parametrize(
+    "tree_geometry,geometry,expected",
+    [
+        # Empty tree returns no results
+        ([], [None], (2, 0)),
+        ([], [point], (2, 0)),
+        # None is ignored when constructing and querying the tree
+        ([None], [None], (2, 0)),
+        ([point], [None], (2, 0)),
+        ([None], [point], (2, 0)),
+        # Empty is included in the tree, but ignored when querying the tree
+        ([empty], [empty], (2, 0)),
+        ([empty], [point], (2, 0)),
+        ([point, empty], [empty], (2, 0)),
+        # Only the non-empty geometry gets hits
+        ([point, empty], [point, empty], (2, 1)),
+        (
+            [point, empty, empty_point, empty_line_string],
+            [point, empty, empty_point, empty_line_string],
+            (2, 1),
+        ),
+    ],
+)
+def test_query_bulk(tree_geometry, geometry, expected):
+    tree = pygeos.STRtree(np.array(tree_geometry))
+    assert tree.query_bulk(np.array(geometry)).shape == expected
+
+
 def test_query_bulk_wrong_dimensions(tree):
     with pytest.raises(TypeError, match="Array should be one dimensional"):
         tree.query_bulk([[pygeos.points(0.5, 0.5)]])

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -53,10 +53,10 @@ def poly_tree():
         # None geometries are ignored when creating tree
         ([None], 0, 0),
         ([point, None], 1, 1),
-        # empty geometry should be counted but have no hits
-        ([empty, empty_point, empty_line_string], 3, 0),
+        # empty geometries are ignored when creating tree
+        ([empty, empty_point, empty_line_string], 0, 0),
         # only the valid geometry should have a hit
-        ([empty, point, empty_point, empty_line_string], 4, 1),
+        ([empty, point, empty_point, empty_line_string], 1, 1),
     ],
 )
 def test_init(geometry, count, hits):

--- a/src/strtree.c
+++ b/src/strtree.c
@@ -152,8 +152,10 @@ static PyObject *STRtree_new(PyTypeObject *type, PyObject *args,
             kv_destroy(_geoms);
             return NULL;
         }
-        /* skip incase obj was None */
-        if (geom == NULL) {
+        /* If geometry is None or empty, do not add it to the tree or count.
+         * Set it as NULL for the internal geometries used for predicate tests.
+         */
+        if (geom == NULL || GEOSisEmpty_r(context, geom)) {
             kv_push(GeometryObject *, _geoms, NULL);
         } else {
         /* perform the insert */


### PR DESCRIPTION
This changes the implementation of STRtree to omit any empty geometries when constructing the tree.

* all inputs (including `None`, empty geometries) are still available in the `tree.geometries()` ndarray
* `_geoms` at the C level is used for predicate tests only, and only includes non-empty geometries.  Since empty geometries are never returned from a tree query, their absence here is a non-issue.
* only significant change: `len(tree)` is now the count of all non-empty / non-`None` geometries; previously it was the count of all non-`None` geometries.

This adds additional tests for empty geometries and other variations in constructing / querying the tree.

Prior to this change, empty geometries would result in segfaults for GEOS <= 3.6.