### PR TITLE
Fix typo in haussdorf -> hausdorff

### DIFF
--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -143,9 +143,9 @@ def length(geometry, **kwargs):
 
 
 def hausdorff_distance(a, b, densify=None, **kwargs):
-    """Compute the discrete Haussdorf distance between two geometries.
+    """Compute the discrete Hausdorff distance between two geometries.
 
-    The Haussdorf distance is a measure of similarity: it is the greatest
+    The Hausdorff distance is a measure of similarity: it is the greatest
     distance between any point in A and the closest point in B. The discrete
     distance is an approximation of this metric: only vertices are considered.
     The parameter 'densify' makes this approximation less coarse by splitting
@@ -173,7 +173,7 @@ def hausdorff_distance(a, b, densify=None, **kwargs):
     if densify is None:
         return lib.hausdorff_distance(a, b, **kwargs)
     else:
-        return lib.haussdorf_distance_densify(a, b, densify, **kwargs)
+        return lib.hausdorff_distance_densify(a, b, densify, **kwargs)
 
 
 @requires_geos("3.7.0")

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -136,7 +136,7 @@ def test_length_missing():
     assert np.isnan(actual)
 
 
-def test_haussdorf_distance():
+def test_hausdorff_distance():
     # example from GEOS docs
     a = pygeos.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = pygeos.linestrings([[0, 100], [0, 10], [80, 10]])
@@ -144,7 +144,7 @@ def test_haussdorf_distance():
     assert actual == pytest.approx(22.360679775, abs=1e-7)
 
 
-def test_haussdorf_distance_densify():
+def test_hausdorff_distance_densify():
     # example from GEOS docs
     a = pygeos.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = pygeos.linestrings([[0, 100], [0, 10], [80, 10]])
@@ -152,12 +152,12 @@ def test_haussdorf_distance_densify():
     assert actual == pytest.approx(47.8, abs=0.1)
 
 
-def test_haussdorf_distance_missing():
+def test_hausdorff_distance_missing():
     actual = pygeos.hausdorff_distance(point, None)
     assert np.isnan(actual)
 
 
-def test_haussdorf_densify_nan():
+def test_hausdorff_densify_nan():
     actual = pygeos.hausdorff_distance(point, point, densify=np.nan)
     assert np.isnan(actual)
 
@@ -167,12 +167,12 @@ def test_distance_empty():
     assert np.isnan(actual)
 
 
-def test_haussdorf_distance_empty():
+def test_hausdorff_distance_empty():
     actual = pygeos.hausdorff_distance(point, empty)
     assert np.isnan(actual)
 
 
-def test_haussdorf_distance_densify_empty():
+def test_hausdorff_distance_densify_empty():
     actual = pygeos.hausdorff_distance(point, empty, densify=0.2)
     assert np.isnan(actual)
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -705,8 +705,8 @@ static void equals_exact_func(char **args, npy_intp *dimensions,
 static PyUFuncGenericFunction equals_exact_funcs[1] = {&equals_exact_func};
 
 
-static char haussdorf_distance_densify_dtypes[4] = {NPY_OBJECT, NPY_OBJECT, NPY_DOUBLE, NPY_DOUBLE};
-static void haussdorf_distance_densify_func(char **args, npy_intp *dimensions,
+static char hausdorff_distance_densify_dtypes[4] = {NPY_OBJECT, NPY_OBJECT, NPY_DOUBLE, NPY_DOUBLE};
+static void hausdorff_distance_densify_func(char **args, npy_intp *dimensions,
                                             npy_intp *steps, void *data)
 {
     void *context_handle = geos_context[0];
@@ -730,7 +730,7 @@ static void haussdorf_distance_densify_func(char **args, npy_intp *dimensions,
         }
     }
 }
-static PyUFuncGenericFunction haussdorf_distance_densify_funcs[1] = {&haussdorf_distance_densify_func};
+static PyUFuncGenericFunction hausdorff_distance_densify_funcs[1] = {&hausdorff_distance_densify_func};
 
 
 static char frechet_distance_densify_dtypes[4] = {NPY_OBJECT, NPY_OBJECT, NPY_DOUBLE, NPY_DOUBLE};
@@ -1505,7 +1505,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
     DEFINE_CUSTOM (buffer, 7);
     DEFINE_CUSTOM (snap, 3);
     DEFINE_CUSTOM (equals_exact, 3);
-    DEFINE_CUSTOM (haussdorf_distance_densify, 3);
+    DEFINE_CUSTOM (hausdorff_distance_densify, 3);
     DEFINE_CUSTOM (delaunay_triangles, 3);
     DEFINE_CUSTOM (voronoi_polygons, 4);
     DEFINE_CUSTOM (is_valid_reason, 1);


### PR DESCRIPTION
Pretty straightforward change. I noticed 'hausdorff' was misspelled as 'haussdorf' in a few places while working on my previous PR https://github.com/pygeos/pygeos/pull/144, making it hard to be discovered through Ctrl+F.