### PR TITLE
Release the GIL for geometry-creating operations

### DIFF
--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -401,7 +401,7 @@ def simplify(geometry, tolerance, preserve_topology=False, **kwargs):
     else:
         return lib.simplify(geometry, tolerance, **kwargs)
 
-
+@multithreading_enabled
 def snap(geometry, reference, tolerance, **kwargs):
     """Snaps an input geometry to reference geometry's vertices.
 

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -2,7 +2,7 @@ from enum import IntEnum
 import numpy as np
 from . import Geometry  # NOQA
 from . import lib
-from .decorators import requires_geos
+from .decorators import requires_geos, multithreading_enabled
 
 
 __all__ = [
@@ -36,7 +36,7 @@ class BufferJoinStyles(IntEnum):
     MITRE = 2
     BEVEL = 3
 
-
+@multithreading_enabled
 def boundary(geometry, **kwargs):
     """Returns the topological boundary of a geometry.
 
@@ -162,7 +162,7 @@ def buffer(
         **kwargs
     )
 
-
+@multithreading_enabled
 def centroid(geometry, **kwargs):
     """Computes the geometric center (center-of-mass) of a geometry.
 
@@ -188,7 +188,7 @@ def centroid(geometry, **kwargs):
     """
     return lib.centroid(geometry, **kwargs)
 
-
+@multithreading_enabled
 def convex_hull(geometry, **kwargs):
     """Computes the minimum convex geometry that encloses an input geometry.
 
@@ -241,7 +241,7 @@ def delaunay_triangles(geometry, tolerance=0.0, only_edges=False, **kwargs):
     """
     return lib.delaunay_triangles(geometry, tolerance, only_edges, **kwargs)
 
-
+@multithreading_enabled
 def envelope(geometry, **kwargs):
     """Computes the minimum bounding box that encloses an input geometry.
 
@@ -262,7 +262,7 @@ def envelope(geometry, **kwargs):
     """
     return lib.envelope(geometry, **kwargs)
 
-
+@multithreading_enabled
 def extract_unique_points(geometry, **kwargs):
     """Returns all distinct vertices of an input geometry as a multipoint.
 
@@ -290,6 +290,7 @@ def extract_unique_points(geometry, **kwargs):
 
 
 @requires_geos("3.8.0")
+@multithreading_enabled
 def build_area(geometry, **kwargs):
     """Creates an areal geometry formed by the constituent linework of given geometry.
 
@@ -310,6 +311,7 @@ def build_area(geometry, **kwargs):
 
 
 @requires_geos("3.8.0")
+@multithreading_enabled
 def make_valid(geometry, **kwargs):
     """Repairs invalid geometries.
 
@@ -326,7 +328,7 @@ def make_valid(geometry, **kwargs):
     """
     return lib.make_valid(geometry, **kwargs)
 
-
+@multithreading_enabled
 def normalize(geometry, **kwargs):
     """Converts Geometry to normal form (or canonical form).
 
@@ -346,7 +348,7 @@ def normalize(geometry, **kwargs):
     """
     return lib.normalize(geometry, **kwargs)
 
-
+@multithreading_enabled
 def point_on_surface(geometry, **kwargs):
     """Returns a point that intersects an input geometry.
 
@@ -367,7 +369,7 @@ def point_on_surface(geometry, **kwargs):
     """
     return lib.point_on_surface(geometry, **kwargs)
 
-
+@multithreading_enabled
 def simplify(geometry, tolerance, preserve_topology=False, **kwargs):
     """Returns a simplified version of an input geometry using the
     Douglas-Peucker algorithm.

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -60,7 +60,7 @@ def boundary(geometry, **kwargs):
     """
     return lib.boundary(geometry, **kwargs)
 
-
+@multithreading_enabled
 def buffer(
     geometry,
     radius,

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -430,7 +430,7 @@ def snap(geometry, reference, tolerance, **kwargs):
     """
     return lib.snap(geometry, reference, tolerance, **kwargs)
 
-
+@multithreading_enabled
 def voronoi_polygons(
     geometry, tolerance=0.0, extend_to=None, only_edges=False, **kwargs
 ):

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -205,7 +205,7 @@ def convex_hull(geometry, **kwargs):
     """
     return lib.convex_hull(geometry, **kwargs)
 
-
+@multithreading_enabled
 def delaunay_triangles(geometry, tolerance=0.0, only_edges=False, **kwargs):
     """Computes a Delaunay triangulation around the vertices of an input
     geometry.

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -1,6 +1,7 @@
 import numpy as np
 from . import lib
 from . import Geometry, GeometryType
+from .decorators import multithreading_enabled
 
 __all__ = [
     "points",
@@ -70,7 +71,7 @@ def linearrings(coords, y=None, z=None):
     """
     return _wrap_construct_ufunc(lib.linearrings, coords, y, z)
 
-
+@multithreading_enabled
 def polygons(shells, holes=None):
     """Create an array of polygons.
 

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -249,7 +249,7 @@ def get_y(point):
 
 # linestrings
 
-
+@multithreading_enabled
 def get_point(geometry, index):
     """Returns the nth point of a linestring or linearring.
 
@@ -310,7 +310,7 @@ def get_num_points(geometry):
 
 # polygons
 
-
+@multithreading_enabled
 def get_exterior_ring(geometry):
     """Returns the exterior ring of a polygon.
 
@@ -331,7 +331,7 @@ def get_exterior_ring(geometry):
     """
     return lib.get_exterior_ring(geometry)
 
-
+@multithreading_enabled
 def get_interior_ring(geometry, index):
     """Returns the nth interior ring of a polygon.
 
@@ -387,7 +387,7 @@ def get_num_interior_rings(geometry):
 
 # collections
 
-
+@multithreading_enabled
 def get_geometry(geometry, index):
     """Returns the nth geometry from a collection of geometries.
 

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -4,7 +4,7 @@ from .decorators import multithreading_enabled
 
 __all__ = ["line_interpolate_point", "line_locate_point", "line_merge", "shared_paths"]
 
-
+@multithreading_enabled
 def line_interpolate_point(line, distance, normalize=False):
     """Returns a point interpolated at given distance on a line.
 
@@ -70,7 +70,7 @@ def line_locate_point(line, other, normalize=False):
     else:
         return lib.line_locate_point(line, other)
 
-
+@multithreading_enabled
 def line_merge(line):
     """Returns (multi)linestrings formed by combining the lines in a
     multilinestrings.

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -1,5 +1,6 @@
 import numpy as np
 from . import lib, Geometry, GeometryType
+from .decorators import multithreading_enabled
 
 __all__ = [
     "difference",
@@ -11,7 +12,7 @@ __all__ = [
     "union_all",
 ]
 
-
+@multithreading_enabled
 def difference(a, b, **kwargs):
     """Returns the part of geometry A that does not intersect with geometry B.
 
@@ -32,7 +33,7 @@ def difference(a, b, **kwargs):
     """
     return lib.difference(a, b, **kwargs)
 
-
+@multithreading_enabled
 def intersection(a, b, **kwargs):
     """Returns the geometry that is shared between input geometries.
 
@@ -53,7 +54,7 @@ def intersection(a, b, **kwargs):
     """
     return lib.intersection(a, b, **kwargs)
 
-
+@multithreading_enabled
 def intersection_all(geometries, axis=0, **kwargs):
     """Returns the intersection of multiple geometries.
 
@@ -81,7 +82,7 @@ def intersection_all(geometries, axis=0, **kwargs):
     """
     return lib.intersection.reduce(geometries, axis=axis, **kwargs)
 
-
+@multithreading_enabled
 def symmetric_difference(a, b, **kwargs):
     """Returns the geometry that represents the portions of input geometries
     that do not intersect.
@@ -103,7 +104,7 @@ def symmetric_difference(a, b, **kwargs):
     """
     return lib.symmetric_difference(a, b, **kwargs)
 
-
+@multithreading_enabled
 def symmetric_difference_all(geometries, axis=0, **kwargs):
     """Returns the symmetric difference of multiple geometries.
 
@@ -131,7 +132,7 @@ def symmetric_difference_all(geometries, axis=0, **kwargs):
     """
     return lib.symmetric_difference.reduce(geometries, axis=axis, **kwargs)
 
-
+@multithreading_enabled
 def union(a, b, **kwargs):
     """Merges geometries into one.
 
@@ -154,7 +155,7 @@ def union(a, b, **kwargs):
     """
     return lib.union(a, b, **kwargs)
 
-
+@multithreading_enabled
 def union_all(geometries, axis=0, **kwargs):
     """Returns the union of multiple geometries.
 

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -21,6 +21,7 @@ reduce_test_data = [
     pygeos.box(0, 0, 5, 5),
     pygeos.box(2, 2, 7, 7),
     pygeos.box(4, 4, 9, 9),
+    pygeos.box(5, 5, 10, 10),
 ]
 
 
@@ -32,7 +33,7 @@ def test_set_operation_array(a, func):
     assert isinstance(actual[0], Geometry)
 
 
-@pytest.mark.parametrize("n", range(1, 4))
+@pytest.mark.parametrize("n", range(1, 5))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_1dim(n, func, related_func):
     actual = func(reduce_test_data[:n])

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -101,7 +101,7 @@ static void Y_b_func(char **args, npy_intp *dimensions,
                      npy_intp *steps, void *data)
 {
     FuncGEOS_Y_b *func = (FuncGEOS_Y_b *)data;
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
     char ret;
 
     GEOS_INIT_THREADS;
@@ -171,7 +171,7 @@ static void YY_b_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
     FuncGEOS_YY_b *func = (FuncGEOS_YY_b *)data;
-    GEOSGeometry *in1, *in2;
+    GEOSGeometry *in1 = NULL, *in2 = NULL;
     char ret;
 
     GEOS_INIT_THREADS;
@@ -258,9 +258,10 @@ static void Y_Y_func(char **args, npy_intp *dimensions,
                      npy_intp *steps, void *data)
 {
     FuncGEOS_Y_Y *func = (FuncGEOS_Y_Y *)data;
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
     GEOSGeometry **geom_arr;
 
+    // Fail if inputs do not have the expected structure.
     if ((steps[1] == 0) && (dimensions[0] > 1)) {
         PyErr_Format(PyExc_NotImplementedError, "Unknown ufunc mode with args=[%p, %p], steps=[%ld, %ld], dimensions=[%ld].", args[0], args[1], steps[0], steps[1], dimensions[0]);
         return;
@@ -344,9 +345,10 @@ static void Yd_Y_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
     FuncGEOS_Yd_Y *func = (FuncGEOS_Yd_Y *)data;
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
     GEOSGeometry **geom_arr;
 
+    // Fail if inputs do not have the expected structure.
     if ((steps[2] == 0) && (dimensions[0] > 1)) {
         PyErr_Format(PyExc_NotImplementedError, "Unknown ufunc mode with args=[%p, %p, %p], steps=[%ld, %ld, %ld], dimensions=[%ld].", args[0], args[1], args[2], steps[0], steps[1], steps[2], dimensions[0]);
         return;
@@ -483,9 +485,10 @@ static void Yi_Y_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
     FuncGEOS_Yi_Y *func = (FuncGEOS_Yi_Y *)data;
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
     GEOSGeometry **geom_arr;
 
+    // Fail if inputs do not have the expected structure.
     if ((steps[2] == 0) && (dimensions[0] > 1)) {
         PyErr_Format(PyExc_NotImplementedError, "Unknown ufunc mode with args=[%p, %p, %p], steps=[%ld, %ld, %ld], dimensions=[%ld].", args[0], args[1], args[2], steps[0], steps[1], steps[2], dimensions[0]);
         return;
@@ -560,7 +563,7 @@ static void YY_Y_func_reduce(char **args, npy_intp *dimensions,
                              npy_intp *steps, void *data)
 {
     FuncGEOS_YY_Y *func = (FuncGEOS_YY_Y *)data;
-    GEOSGeometry *in1 = NULL, *in2, *out;
+    GEOSGeometry *in1 = NULL, *in2 = NULL, *out = NULL;
 
     GEOS_INIT_THREADS;
 
@@ -619,13 +622,14 @@ static void YY_Y_func(char **args, npy_intp *dimensions,
             YY_Y_func_reduce(args, dimensions, steps, data);
             return;
         } else {
+            // Fail if inputs do not have the expected structure.
             PyErr_Format(PyExc_NotImplementedError, "Unknown ufunc mode with args=[%p, %p, %p], steps=[%ld, %ld, %ld], dimensions=[%ld].", args[0], args[1], args[2], steps[0], steps[1], steps[2], dimensions[0]);
             return;
         }
     }
 
     FuncGEOS_YY_Y *func = (FuncGEOS_YY_Y *)data;
-    GEOSGeometry *in1, *in2;
+    GEOSGeometry *in1 = NULL, *in2 = NULL;
     GEOSGeometry **geom_arr;
 
     // allocate a temporary array to store output GEOSGeometry objects
@@ -696,7 +700,7 @@ static void Y_d_func(char **args, npy_intp *dimensions,
                      npy_intp *steps, void *data)
 {
     FuncGEOS_Y_d *func = (FuncGEOS_Y_d *)data;
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
 
     GEOS_INIT_THREADS;
 
@@ -747,7 +751,7 @@ static void Y_i_func(char **args, npy_intp *dimensions,
                      npy_intp *steps, void *data)
 {
     FuncGEOS_Y_i *func = (FuncGEOS_Y_i *)data;
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
     int result;
 
     // In the GEOS CAPI, sometimes -1 is an error, sometimes 0
@@ -825,7 +829,7 @@ static void YY_d_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
     FuncGEOS_YY_d *func = (FuncGEOS_YY_d *)data;
-    GEOSGeometry *in1, *in2;
+    GEOSGeometry *in1 = NULL, *in2 = NULL;
 
     GEOS_INIT_THREADS;
 
@@ -865,7 +869,7 @@ static void YYd_d_func(char **args, npy_intp *dimensions,
                        npy_intp *steps, void *data)
 {
     FuncGEOS_YYd_d *func = (FuncGEOS_YYd_d *)data;
-    GEOSGeometry *in1, *in2;
+    GEOSGeometry *in1 = NULL, *in2 = NULL;
 
     GEOS_INIT_THREADS;
 
@@ -893,7 +897,7 @@ static PyUFuncGenericFunction YYd_d_funcs[1] = {&YYd_d_func};
 /* Define functions with unique call signatures */
 static void *null_data[1] = {NULL};
 static char buffer_inner(void *ctx, GEOSBufferParams *params, void *ip1, void *ip2, GEOSGeometry **geom_arr, npy_intp i) {
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
 
     /* get the geometry: return on error */
     if (!get_geom(*(GeometryObject **)ip1, &in1)) {
@@ -922,6 +926,7 @@ static void buffer_func(char **args, npy_intp *dimensions,
     npy_intp i;
     GEOSGeometry **geom_arr;
 
+    // Fail if inputs do not have the expected structure.
     if ((steps[7] == 0) && (dimensions[0] > 1)) {
         PyErr_Format(PyExc_NotImplementedError, "Unknown ufunc mode with args[0]=%p, args[7]=%p, steps[0]=%ld, steps[7]=%ld, dimensions[0]=%ld.", args[0], args[7], steps[0], steps[7], dimensions[0]);
         return;
@@ -991,7 +996,7 @@ static char snap_dtypes[4] = {NPY_OBJECT, NPY_OBJECT, NPY_DOUBLE, NPY_OBJECT};
 static void snap_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
-    GEOSGeometry *in1, *in2, *ret_ptr;
+    GEOSGeometry *in1 = NULL, *in2 = NULL, *ret_ptr;
 
     GEOS_INIT;
 
@@ -1019,7 +1024,7 @@ static char equals_exact_dtypes[4] = {NPY_OBJECT, NPY_OBJECT, NPY_DOUBLE, NPY_BO
 static void equals_exact_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
-    GEOSGeometry *in1, *in2;
+    GEOSGeometry *in1 = NULL, *in2 = NULL;
     npy_bool ret;
 
     GEOS_INIT_THREADS;
@@ -1048,9 +1053,10 @@ static char delaunay_triangles_dtypes[4] = {NPY_OBJECT, NPY_DOUBLE, NPY_BOOL, NP
 static void delaunay_triangles_func(char **args, npy_intp *dimensions,
                                     npy_intp *steps, void *data)
 {
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
     GEOSGeometry **geom_arr;
 
+    // Fail if inputs do not have the expected structure.
     if ((steps[3] == 0) && (dimensions[0] > 1)) {
         PyErr_Format(PyExc_NotImplementedError, "Unknown ufunc mode with args=[%p, %p, %p, %p], steps=[%ld, %ld, %ld, %ld], dimensions=[%ld].", args[0], args[1], args[2], args[3], steps[0], steps[1], steps[2], steps[3], dimensions[0]);
         return;
@@ -1102,9 +1108,10 @@ static char voronoi_polygons_dtypes[5] = {NPY_OBJECT, NPY_DOUBLE, NPY_OBJECT, NP
 static void voronoi_polygons_func(char **args, npy_intp *dimensions,
                                   npy_intp *steps, void *data)
 {
-    GEOSGeometry *in1, *in3;
+    GEOSGeometry *in1 = NULL, *in3 = NULL;
     GEOSGeometry **geom_arr;
 
+    // Fail if inputs do not have the expected structure.
     if ((steps[4] == 0) && (dimensions[0] > 1)) {
         PyErr_Format(PyExc_NotImplementedError, "Unknown ufunc mode with args=[%p, %p, %p, %p, %p], steps=[%ld, %ld, %ld, %ld, %ld], dimensions=[%ld].", args[0], args[1], args[2], args[3], args[4], steps[0], steps[1], steps[2], steps[3], steps[4], dimensions[0]);
         return;
@@ -1156,7 +1163,7 @@ static void is_valid_reason_func(char **args, npy_intp *dimensions,
                                  npy_intp *steps, void *data)
 {
     char *reason;
-    GEOSGeometry *in1;
+    GEOSGeometry *in1 = NULL;
 
     GEOS_INIT;
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1081,28 +1081,51 @@ static char voronoi_polygons_dtypes[5] = {NPY_OBJECT, NPY_DOUBLE, NPY_OBJECT, NP
 static void voronoi_polygons_func(char **args, npy_intp *dimensions,
                                   npy_intp *steps, void *data)
 {
-    GEOSGeometry *in1, *in3, *ret_ptr;
+    GEOSGeometry *in1, *in3;
 
-    GEOS_INIT;
+    if ((steps[4] == 0) && (dimensions[0] > 1)) {
+        PyErr_Format(PyExc_NotImplementedError, "Cannot handle ufunc mode with args=[%p, %p, %p, %p, %p], steps=[%ld, %ld, %ld, %ld, %ld], dimensions=[%ld].", args[0], args[1], args[2], args[3], args[4], steps[0], steps[1], steps[2], steps[3], steps[4], dimensions[0]);
+        return;
+    }
+
+    // allocate a temporary array to store output GEOSGeometry objects
+    GEOSGeometry **geom_arr = malloc(sizeof(void *) * dimensions[0]);
+    if (geom_arr == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "Could not allocate memory");
+        return;
+    }
+
+    GEOS_INIT_THREADS;
 
     QUATERNARY_LOOP {
-        /* get the geometry: return on error */
-        if (!get_geom(*(GeometryObject **)ip1, &in1)) { errstate = PGERR_NOT_A_GEOMETRY; goto finish; }
+        // get the geometry: return on error
+        if (!get_geom(*(GeometryObject **)ip1, &in1) || !get_geom(*(GeometryObject **)ip3, &in3)) {
+            errstate = PGERR_NOT_A_GEOMETRY;
+            destroy_geom_arr(ctx, geom_arr, i - 1);
+            break;
+        }
         double in2 = *(double *) ip2;
-        if (!get_geom(*(GeometryObject **)ip3, &in3)) { errstate = PGERR_NOT_A_GEOMETRY; goto finish; }
         npy_bool in4 = *(npy_bool *) ip4;
         if ((in1 == NULL) | npy_isnan(in2)) {
             /* propagate NULL geometries; in3 = NULL is actually supported */
-            ret_ptr = NULL;
+            geom_arr[i] = NULL;
         } else {
-            ret_ptr = GEOSVoronoiDiagram_r(ctx, in1, in3, in2, (int) in4);
-            if (ret_ptr == NULL) { errstate = PGERR_GEOS_EXCEPTION; goto finish; }
+            geom_arr[i] = GEOSVoronoiDiagram_r(ctx, in1, in3, in2, (int) in4);
+            if (geom_arr[i] == NULL) {
+                errstate = PGERR_GEOS_EXCEPTION;
+                destroy_geom_arr(ctx, geom_arr, i - 1);
+                break;
+            }
         }
-        OUTPUT_Y;
     }
 
-    finish:
-        GEOS_FINISH;
+    GEOS_FINISH_THREADS;
+
+    // fill the numpy array with PyObjects while holding the GIL
+    if (errstate == PGERR_SUCCESS) {
+        geom_arr_to_npy(geom_arr, args[4], steps[4], dimensions[0]);
+    }
+    free(geom_arr);
 }
 static PyUFuncGenericFunction voronoi_polygons_funcs[1] = {&voronoi_polygons_func};
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -603,7 +603,7 @@ static void YY_Y_func_reduce(char **args, npy_intp *dimensions,
         // However, in some cases the intermediate geometry equals the first input, which is
         // 'owned' by python. Destoying that would lead to a segfault when the python object
         // is dereferenced.
-        // We check for that situation explicitely from the ufunc input (misusing the variable 'in2').
+        // We check for that situation explicitly from the ufunc input (misusing the variable 'in2').
         get_geom(*(GeometryObject **)args[0], &in2);
         if (in1 != in2) {
             GEOSGeom_destroy_r(ctx, in1);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -601,12 +601,6 @@ static void YY_Y_func_reduce(char **args, npy_intp *dimensions,
         }
     }
 
-    // Cleanup the temporary in1 (unless owned by python)
-    // get_geom(*(GeometryObject **)args[0], &in2);
-    // if (in1 != in2) {
-    //     GEOSGeom_destroy_r(ctx, in1);
-    // }
-
     GEOS_FINISH_THREADS;
 
     // fill the numpy array with a single PyObject while holding the GIL
@@ -618,7 +612,8 @@ static void YY_Y_func_reduce(char **args, npy_intp *dimensions,
 static void YY_Y_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
-    // A reduce is characterized by the step of the output array being 0:
+    // A reduce is characterized by
+
     if ((steps[2] == 0) && (dimensions[0] > 1)) {
         if (args[0] == args[2]) {
             YY_Y_func_reduce(args, dimensions, steps, data);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -44,29 +44,6 @@
     *out = ret
 
 
-// free_three_arr frees 3 arrays, accounting for the possibility they are the same //
-static void free_three_arr(GEOSGeometry **array1, GEOSGeometry **array2, GEOSGeometry **array3) {
-    char free1 = 1, free2 = 1, free3 = 1;
-    if (array1 == array2) {
-        free2 = 0;
-    }
-    if (array1 == array3) {
-        free3 = 0;
-    }
-    if (array2 == array3) {
-        free3 = 0;
-    }
-    if (free1) {
-        free(array1);
-    }
-    if (free2) {
-        free(array2);
-    }
-    if (free3) {
-        free(array3);
-    }
-};
-
 static void destroy_geom_arr(void *context, GEOSGeometry **array, npy_intp length) {
     npy_intp i;
     for(i = 0; i < length; i++) {
@@ -81,7 +58,7 @@ static void geom_arr_to_npy(GEOSGeometry **array, char *ptr, npy_intp stride, np
     PyObject *ret;
     PyObject **out;
 
-    for(i = 0; i < (stride == 0 ? 1 : count); i++, ptr += stride) {
+    for(i = 0; i < count; i++, ptr += stride) {
         ret = GeometryObject_FromGEOS(&GeometryType, array[i]);
         out = (PyObject **)ptr;
         Py_XDECREF(*out);
@@ -551,81 +528,44 @@ static void YY_Y_func(char **args, npy_intp *dimensions,
                       npy_intp *steps, void *data)
 {
     FuncGEOS_YY_Y *func = (FuncGEOS_YY_Y *)data;
-    GEOSGeometry *in1, *in2, *out;
-    char *ip1 = args[0], *ip2 = args[1], *op1 = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
-    npy_intp n = dimensions[0];
-    npy_intp i;
-    GEOSGeometry **geom_in1, **geom_in2, **geom_out;
+    GEOSGeometry *in1, *in2;
 
-    // allocate temporary arrays to store input GEOSGeometry objects
-    // account for the possibilities that arrays could be identical or length-1
-    geom_in1 = malloc(sizeof(void *) * (is1 == 0 ? 1 : n));
-    if (ip2 == ip1) {
-        geom_in2 = geom_in1;
-    } else {
-        geom_in2 = malloc(sizeof(void *) * (is2 == 0 ? 1 : n));
-    }        
-    if (op1 == ip1 ) {
-        geom_out = geom_in1;
-    } else if (op1 == ip2) {
-        geom_out = geom_in2;
-    } else {
-        geom_out = malloc(sizeof(void *) * (os1 == 0 ? 1 : n));
-    }   
-    if ((geom_in1 == NULL) | (geom_in2 == NULL) | (geom_out == NULL)) {
-        free_three_arr(geom_in1, geom_in2, geom_out);
+    // allocate a temporary array to store output GEOSGeometry objects
+    GEOSGeometry **geom_arr = malloc(sizeof(void *) * dimensions[0]);
+    if (geom_arr == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Could not allocate memory");
         return;
-    }
-    // fill input arrays
-    for(i = 0; i < (is1 == 0 ? 1 : n); i++, ip1 += is1) {
-        if (!get_geom(*(GeometryObject **)ip1, &in1)) {
-            free_three_arr(geom_in1, geom_in2, geom_out);
-            PyErr_SetString(PyExc_TypeError, "One of the arguments is of incorrect type. Please provide only Geometry objects.");
-            return;
-        }
-        geom_in1[i] = in1;
-    }
-    if (geom_in1 != geom_in2) {
-        for(i = 0; i < (is2 == 0 ? 1 : n); i++, ip2 += is2) {
-            if (!get_geom(*(GeometryObject **)ip2, &in2)) {
-                free_three_arr(geom_in1, geom_in2, geom_out);
-                PyErr_SetString(PyExc_TypeError, "One of the arguments is of incorrect type. Please provide only Geometry objects.");
-                return;
-            }
-            geom_in2[i] = in2;
-        }
     }
 
     GEOS_INIT_THREADS;
 
-    for (i = 0; i < n; i++) {
-        in1 = geom_in1[is1 == 0 ? 0 : i];
-        in2 = geom_in2[is2 == 0 ? 0 : i];
+    BINARY_LOOP {
+        /* get the geometries: return on error */
+        if (!get_geom(*(GeometryObject **)ip1, &in1) || !get_geom(*(GeometryObject **)ip2, &in2)) {
+            errstate = PGERR_NOT_A_GEOMETRY;
+            destroy_geom_arr(ctx, geom_arr, i - 1);
+            break;
+        }
         if ((in1 == NULL) | (in2 == NULL)) {
-            // in case of a missing value: return NULL (None)
-            out = NULL;
+            /* in case of a missing value: return NULL (None) */
+            geom_arr[i] = NULL;
         } else {
-            out = func(ctx, in1, in2);
-            if (out == NULL) {
+            geom_arr[i] = func(ctx, in1, in2);
+            if (geom_arr[i] == NULL) {
                 errstate = PGERR_GEOS_EXCEPTION;
-                if (os1 > 0) {
-                    destroy_geom_arr(ctx, geom_out, i - 1);
-                }
+                destroy_geom_arr(ctx, geom_arr, i - 1);
                 break;
             }
         }
-        geom_out[os1 == 0 ? 0 : i] = out;
     }
 
     GEOS_FINISH_THREADS;
 
     // fill the numpy array with PyObjects while holding the GIL
     if (errstate == PGERR_SUCCESS) {
-        geom_arr_to_npy(geom_out, args[2], steps[2], dimensions[0]);
+        geom_arr_to_npy(geom_arr, args[2], steps[2], dimensions[0]);
     }
-    free_three_arr(geom_in1, geom_in2, geom_out);
+    free(geom_arr);
 }
 static PyUFuncGenericFunction YY_Y_funcs[1] = {&YY_Y_func};
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -529,9 +529,14 @@ static void YY_Y_func(char **args, npy_intp *dimensions,
 {
     FuncGEOS_YY_Y *func = (FuncGEOS_YY_Y *)data;
     GEOSGeometry *in1, *in2;
+    GEOSGeometry **geom_arr;
+    npy_intp out_i;
+    char is_reduce = steps[2] == 0;
 
     // allocate a temporary array to store output GEOSGeometry objects
-    GEOSGeometry **geom_arr = malloc(sizeof(void *) * dimensions[0]);
+    // note that if the output step is 0, the length is always 1
+    // this happens for ufunc.reduce operations
+    geom_arr = malloc(sizeof(void *) * (is_reduce ? 1 : dimensions[0]));
     if (geom_arr == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Could not allocate memory");
         return;
@@ -540,20 +545,40 @@ static void YY_Y_func(char **args, npy_intp *dimensions,
     GEOS_INIT_THREADS;
 
     BINARY_LOOP {
-        /* get the geometries: return on error */
-        if (!get_geom(*(GeometryObject **)ip1, &in1) || !get_geom(*(GeometryObject **)ip2, &in2)) {
+        // the index (out_i) into the output array is either 0 or i
+        out_i = is_reduce ? 0 : i;
+        if (!get_geom(*(GeometryObject **)ip2, &in2)) {
             errstate = PGERR_NOT_A_GEOMETRY;
-            destroy_geom_arr(ctx, geom_arr, i - 1);
+            destroy_geom_arr(ctx, geom_arr, out_i - 1);
             break;
         }
-        if ((in1 == NULL) | (in2 == NULL)) {
-            /* in case of a missing value: return NULL (None) */
-            geom_arr[i] = NULL;
+        // For some ufunc.reduce operations the output stride is 0. In that case we
+        // the previous output is the input, except for the first step.
+        if (is_reduce && (i > 0)) {
+            in1 = geom_arr[0];
         } else {
-            geom_arr[i] = func(ctx, in1, in2);
-            if (geom_arr[i] == NULL) {
+            if (!get_geom(*(GeometryObject **)ip1, &in1)) {
+                errstate = PGERR_NOT_A_GEOMETRY;
+                destroy_geom_arr(ctx, geom_arr, out_i - 1);
+                break;
+            }
+        }
+        if ((in1 == NULL) | (in2 == NULL)) {
+            // in case of a missing value: return NULL (None)
+            geom_arr[out_i] = NULL;
+            // we can break the loop as we know the NULL will propagate
+            if (is_reduce) {
+                break;
+            }
+        } else {
+            geom_arr[out_i] = func(ctx, in1, in2);
+            if (is_reduce && (i > 0)) {
+                // in1 was intermediate; clean it up
+                GEOSGeom_destroy_r(ctx, in1);
+            }
+            if (geom_arr[out_i] == NULL) {
                 errstate = PGERR_GEOS_EXCEPTION;
-                destroy_geom_arr(ctx, geom_arr, i - 1);
+                destroy_geom_arr(ctx, geom_arr, out_i - 1);
                 break;
             }
         }
@@ -562,8 +587,10 @@ static void YY_Y_func(char **args, npy_intp *dimensions,
     GEOS_FINISH_THREADS;
 
     // fill the numpy array with PyObjects while holding the GIL
+    // if step[2] == 0 and dimensions[0] > 1 we would make several PyObjects that own the same
+    // GEOSGeometry, which would lead to multiple deallocations of GEOSGeometry later
     if (errstate == PGERR_SUCCESS) {
-        geom_arr_to_npy(geom_arr, args[2], steps[2], dimensions[0]);
+        geom_arr_to_npy(geom_arr, args[2], steps[2], is_reduce ? 1 : dimensions[0]);
     }
     free(geom_arr);
 }


### PR DESCRIPTION
This addresses #155 , now only for the geometry-to-geometry operations (like `envelope` and `convex_hull`)

The same pattern could be repeated for all other geometry-creating operations.