### PR TITLE
Memory leak testing using valgrind

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore everything
+**
+
+# Allow files and directories
+!/*.py
+!/*LICENSE*
+!/setup.cfg
+!/pygeos/**
+!/src/**
+
+# Ignore unnecessary files inside allowed directories
+# This should go after the allowed directories
+**/*~
+**/*.log
+**/.DS_Store
+**/Thumbs.db
+**/*.pyc
+**/*.so
+**/.*

--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,18 @@ On windows (assuming you are in a Visual C++ shell)::
     $ set GEOS_INCLUDE_PATH=%CONDA_PREFIX%\Library\include
     $ set GEOS_LIBRARY_PATH=%CONDA_PREFIX%\Library\lib
 
+
+Memleak testing using valgrind for developers
+---------------------------------------------
+
+PyGEOS uses pytest-valgrind to automatically detect memory leaks. As tests take
+about 20 minutes to complete, this is not done as part of the CI. Run the tests
+locally using the included dockerfile::
+
+    $ docker build . -f ./docker/Dockerfile.valgrind -t pygeos/valgrind
+    $ docker run pygeos/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output > valgrind.log
+
+
 Relationship to Shapely
 -----------------------
 

--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -1,0 +1,17 @@
+FROM python:3.6-stretch
+
+RUN apt-get update && apt-get install -y valgrind libgeos-dev --no-install-recommends
+
+RUN pip install numpy pytest pytest-valgrind
+
+COPY . /code
+
+WORKDIR /code
+
+RUN python setup.py build_ext --inplace
+
+ENV PYTHONMALLOC malloc
+
+# docker build . -f ./docker/Dockerfile.valgrind -t pygeos/valgrind
+
+# docker run pygeos/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output

--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -1,3 +1,8 @@
+# This docker is used for memory leak testing of pygeos. To use it, first build:
+# docker build . -f ./docker/Dockerfile.valgrind -t pygeos/valgrind
+# Then run the pytest suite with valgrind enabled:
+# docker run pygeos/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output > valgrind.log && cat /tmp/valgrind-output > valgrind2.log
+
 FROM python:3.6-stretch
 
 RUN apt-get update && apt-get install -y valgrind libgeos-dev --no-install-recommends
@@ -11,7 +16,3 @@ WORKDIR /code
 RUN python setup.py build_ext --inplace
 
 ENV PYTHONMALLOC malloc
-
-# docker build . -f ./docker/Dockerfile.valgrind -t pygeos/valgrind
-
-# docker run pygeos/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output

--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -1,7 +1,7 @@
 # This docker is used for memory leak testing of pygeos. To use it, first build:
 # docker build . -f ./docker/Dockerfile.valgrind -t pygeos/valgrind
 # Then run the pytest suite with valgrind enabled:
-# docker run pygeos/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output > valgrind.log && cat /tmp/valgrind-output > valgrind2.log
+# docker run pygeos/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output > valgrind.log
 
 FROM python:3.6-stretch
 


### PR DESCRIPTION
Valgrind is a C utility to track memory leak issues. See description of how to use the included docker in the README.

Currently, 322 out of 1124 tests are failing, so we have some work to do! I'll go through the logs and make separate issues.

The whole run takes 20 minutes so I did not make it part of the CI.