### PR TITLE
FIX: Accept linearrings in pygeos.multilinestrings 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Version 0.8 (unreleased)
 
 **Highlights of this release**
 
+* Fixed bug in ``multilinestrings()``, it now accepts linearrings again (#168) 
 * Release the GIL to allow for multithreading in functions that do not 
   create geometries (#144)
 * Addition of a ``frechet_distance()`` function for GEOS >= 3.7 (#144)

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -185,10 +185,13 @@ def test_create_collection_skips_none(func, sub_geom):
     [
         (pygeos.multipoints, line_string),
         (pygeos.multipoints, geometry_collection),
+        (pygeos.multipoints, multi_point),
         (pygeos.multilinestrings, point),
         (pygeos.multilinestrings, polygon),
+        (pygeos.multilinestrings, multi_line_string),
         (pygeos.multipolygons, linear_ring),
         (pygeos.multipolygons, multi_point),
+        (pygeos.multipolygons, multi_polygon),
     ],
 )
 def test_create_collection_wrong_geom_type(func, sub_geom):

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -2,7 +2,16 @@ import pygeos
 import pytest
 import numpy as np
 
-from .common import point
+from .common import (
+    point,
+    line_string,
+    linear_ring,
+    polygon,
+    multi_point,
+    multi_line_string,
+    multi_polygon,
+    geometry_collection,
+)
 
 
 def box_tpl(x1, y1, x2, y2):
@@ -12,7 +21,7 @@ def box_tpl(x1, y1, x2, y2):
 def test_points_from_coords():
     actual = pygeos.points([[0, 0], [2, 2]])
     assert str(actual[0]) == "POINT (0 0)"
-    assert str(actual[1])  == "POINT (2 2)"
+    assert str(actual[1]) == "POINT (2 2)"
 
 
 def test_points_from_xy():
@@ -121,24 +130,70 @@ def test_2_polygons_with_different_holes():
     assert pygeos.area(actual).tolist() == [96.0, 24.0]
 
 
-def test_create_collection_only_none():
-    actual = pygeos.multipoints(np.array([None], dtype=object))
-    assert str(actual) == "MULTIPOINT EMPTY"
+@pytest.mark.parametrize(
+    "func,expected",
+    [
+        (pygeos.multipoints, "MULTIPOINT EMPTY"),
+        (pygeos.multilinestrings, "MULTILINESTRING EMPTY"),
+        (pygeos.multipolygons, "MULTIPOLYGON EMPTY"),
+        (pygeos.geometrycollections, "GEOMETRYCOLLECTION EMPTY"),
+    ],
+)
+def test_create_collection_only_none(func, expected):
+    actual = func(np.array([None], dtype=object))
+    assert str(actual) == expected
 
 
-def test_create_collection_skips_none():
-    actual = pygeos.multipoints([point, None, None, point])
-    assert str(actual) == "MULTIPOINT (2 3, 2 3)"
+@pytest.mark.parametrize(
+    "func,sub_geom",
+    [
+        (pygeos.multipoints, point),
+        (pygeos.multilinestrings, line_string),
+        (pygeos.multilinestrings, linear_ring),
+        (pygeos.multipolygons, polygon),
+        (pygeos.geometrycollections, point),
+        (pygeos.geometrycollections, line_string),
+        (pygeos.geometrycollections, linear_ring),
+        (pygeos.geometrycollections, polygon),
+        (pygeos.geometrycollections, multi_point),
+        (pygeos.geometrycollections, multi_line_string),
+        (pygeos.geometrycollections, multi_polygon),
+        (pygeos.geometrycollections, geometry_collection),
+    ],
+)
+def test_create_collection(func, sub_geom):
+    actual = func([sub_geom, sub_geom])
+    assert pygeos.get_num_geometries(actual) == 2
 
 
-def test_create_collection_wrong_collection_type():
+@pytest.mark.parametrize(
+    "func,sub_geom",
+    [
+        (pygeos.multipoints, point),
+        (pygeos.multilinestrings, line_string),
+        (pygeos.multipolygons, polygon),
+        (pygeos.geometrycollections, polygon),
+    ],
+)
+def test_create_collection_skips_none(func, sub_geom):
+    actual = func([sub_geom, None, None, sub_geom])
+    assert pygeos.get_num_geometries(actual) == 2
+
+
+@pytest.mark.parametrize(
+    "func,sub_geom",
+    [
+        (pygeos.multipoints, line_string),
+        (pygeos.multipoints, geometry_collection),
+        (pygeos.multilinestrings, point),
+        (pygeos.multilinestrings, polygon),
+        (pygeos.multipolygons, linear_ring),
+        (pygeos.multipolygons, multi_point),
+    ],
+)
+def test_create_collection_wrong_geom_type(func, sub_geom):
     with pytest.raises(TypeError):
-        pygeos.lib.create_collection([point], 2)
-
-
-def test_create_collection_wrong_geom_type():
-    with pytest.raises(TypeError):
-        pygeos.multipolygons([point])
+        func([sub_geom])
 
 
 def test_box():

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1363,7 +1363,7 @@ static void create_collection_func(char **args, npy_intp *dimensions,
 {
     GEOSGeometry *g, *g_copy;
     int n_geoms, type;
-    char actual_type, first_expected_type, last_expected_type;
+    char actual_type, expected_type, alt_expected_type;
 
     GEOS_INIT;
 
@@ -1374,19 +1374,20 @@ static void create_collection_func(char **args, npy_intp *dimensions,
         type = *(int *) ip2;
         switch (type) {
             case GEOS_MULTIPOINT:
-                first_expected_type = GEOS_POINT;
-                last_expected_type = GEOS_POINT;
+                expected_type = GEOS_POINT;
+                alt_expected_type = -1;
                 break;
             case GEOS_MULTILINESTRING:
-                first_expected_type = GEOS_LINESTRING;
-                last_expected_type = GEOS_LINEARRING;
+                expected_type = GEOS_LINESTRING;
+                alt_expected_type = GEOS_LINEARRING;
                 break;
             case GEOS_MULTIPOLYGON:
-                first_expected_type = GEOS_POLYGON;
-                last_expected_type = GEOS_POLYGON;
+                expected_type = GEOS_POLYGON;
+                alt_expected_type = -1;
                 break;
             case GEOS_GEOMETRYCOLLECTION:
-                first_expected_type = -1;
+                expected_type = -1;
+                alt_expected_type = -1;
                 break;
         default:
             errstate = PGERR_GEOMETRY_TYPE;
@@ -1397,10 +1398,10 @@ static void create_collection_func(char **args, npy_intp *dimensions,
         BINARY_SINGLE_COREDIM_LOOP_INNER {
             if (!get_geom(*(GeometryObject **)cp1, &g)) { errstate = PGERR_NOT_A_GEOMETRY; goto finish; }
             if (g == NULL) { continue; }
-            if (first_expected_type != -1) {
+            if (expected_type != -1) {
                 actual_type = GEOSGeomTypeId_r(ctx, g);
                 if (actual_type == -1) { errstate = PGERR_GEOS_EXCEPTION; goto finish; }
-                if ((actual_type < first_expected_type) | (actual_type > last_expected_type)) {
+                if ((actual_type != expected_type) & (actual_type != alt_expected_type)) {
                     errstate = PGERR_GEOMETRY_TYPE; goto finish;
                 }
             }


### PR DESCRIPTION
Closes #153 

Bug introduced in #86 