### PR TITLE
ENH: Add get_z ufunc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Version 0.8 (unreleased)
 * Addition of a ``build_area()`` function for GEOS >= 3.8 (#141)
 * Addition of a ``normalize()`` function (#136)
 * Addition of a ``make_valid()`` function for GEOS >= 3.8 (#107)
+* Addition of a ``get_z()`` function for GEOS >= 3.7 (#175)
 * The ``get_coordinate_dimensions()`` function was renamed to
   ``get_coordinate_dimension()`` for consistency with GEOS (#176)
 

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -253,6 +253,8 @@ def get_y(point):
 def get_z(point):
     """Returns the z-coordinate of a point.
 
+    Requires at least GEOS 3.7.0.
+
     Parameters
     ----------
     point : Geometry or array_like

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -2,7 +2,7 @@ from enum import IntEnum
 import numpy as np
 from . import lib
 from . import Geometry  # NOQA
-from .decorators import multithreading_enabled
+from .decorators import multithreading_enabled, requires_geos
 
 __all__ = [
     "GeometryType",
@@ -248,6 +248,7 @@ def get_y(point):
     return lib.get_y(point)
 
 
+@requires_geos("3.7.0")
 @multithreading_enabled
 def get_z(point):
     """Returns the z-coordinate of a point.

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -14,6 +14,7 @@ __all__ = [
     "set_srid",
     "get_x",
     "get_y",
+    "get_z",
     "get_exterior_ring",
     "get_num_points",
     "get_num_interior_rings",
@@ -212,7 +213,7 @@ def get_x(point):
 
     See also
     --------
-    get_y
+    get_y, get_z
 
     Examples
     --------
@@ -235,7 +236,7 @@ def get_y(point):
 
     See also
     --------
-    get_x
+    get_x, get_z
 
     Examples
     --------
@@ -245,6 +246,32 @@ def get_y(point):
     nan
     """
     return lib.get_y(point)
+
+
+@multithreading_enabled
+def get_z(point):
+    """Returns the z-coordinate of a point.
+
+    Parameters
+    ----------
+    point : Geometry or array_like
+        Non-point geometries or geometries without 3rd dimension will result
+        in NaN being returned.
+
+    See also
+    --------
+    get_x, get_y
+
+    Examples
+    --------
+    >>> get_z(Geometry("POINT Z (1 2 3)"))
+    3.0
+    >>> get_z(Geometry("POINT (1 2)"))
+    nan
+    >>> get_z(Geometry("MULTIPOINT Z (1 1 1, 2 2 2)"))
+    nan
+    """
+    return lib.get_z(point)
 
 
 # linestrings

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -143,7 +143,19 @@ def test_get_set_srid():
     assert pygeos.get_srid(actual) == 4326
 
 
-@pytest.mark.parametrize("func", [pygeos.get_x, pygeos.get_y, pygeos.get_z])
+@pytest.mark.parametrize(
+    "func",
+    [
+        pygeos.get_x,
+        pygeos.get_y,
+        pytest.param(
+            pygeos.get_z,
+            marks=pytest.mark.skipif(
+                pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7"
+            ),
+        ),
+    ],
+)
 @pytest.mark.parametrize("geom", all_types[1:])
 def test_get_xyz_no_point(func, geom):
     assert np.isnan(func(geom))
@@ -157,10 +169,12 @@ def test_get_y():
     assert pygeos.get_y([point, point_z]).tolist() == [3.0, 1.0]
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
 def test_get_z():
     assert pygeos.get_z([point_z]).tolist() == [1.0]
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
 def test_get_z_2d():
     assert np.isnan(pygeos.get_z(point))
 

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -143,9 +143,9 @@ def test_get_set_srid():
     assert pygeos.get_srid(actual) == 4326
 
 
-@pytest.mark.parametrize("func", [pygeos.get_x, pygeos.get_y])
+@pytest.mark.parametrize("func", [pygeos.get_x, pygeos.get_y, pygeos.get_z])
 @pytest.mark.parametrize("geom", all_types[1:])
-def test_get_xy_no_point(func, geom):
+def test_get_xyz_no_point(func, geom):
     assert np.isnan(func(geom))
 
 
@@ -155,6 +155,14 @@ def test_get_x():
 
 def test_get_y():
     assert pygeos.get_y([point, point_z]).tolist() == [3.0, 1.0]
+
+
+def test_get_z():
+    assert pygeos.get_z([point_z]).tolist() == [1.0]
+
+
+def test_get_z_2d():
+    assert np.isnan(pygeos.get_z(point))
 
 
 @pytest.mark.parametrize("geom", all_types)

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -699,6 +699,19 @@ static int GetY(void *context, void *a, double *b) {
     }
 }
 static void *get_y_data[1] = {GetY};
+static int GetZ(void *context, void *a, double *b) {
+    char typ = GEOSGeomTypeId_r(context, a);
+    if (typ != 0) {
+        *(double *)b = NPY_NAN;
+        return 1;
+    // } else if (GEOSGeom_getCoordinateDimension_r(context, a) != 3) {
+    //     *(double *)b = NPY_NAN;
+    //     return 0;
+    } else {
+        return GEOSGeomGetZ_r(context, a, b);
+    }
+}
+static void *get_z_data[1] = {GetZ};
 static void *area_data[1] = {GEOSArea_r};
 static void *length_data[1] = {GEOSLength_r};
 typedef int FuncGEOS_Y_d(void *context, void *a, double *b);
@@ -1896,6 +1909,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
 
     DEFINE_Y_d (get_x);
     DEFINE_Y_d (get_y);
+    DEFINE_Y_d (get_z);
     DEFINE_Y_d (area);
     DEFINE_Y_d (length);
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -705,9 +705,6 @@ static void *get_y_data[1] = {GetY};
         if (typ != 0) {
             *(double *)b = NPY_NAN;
             return 1;
-        // } else if (GEOSGeom_getCoordinateDimension_r(context, a) != 3) {
-        //     *(double *)b = NPY_NAN;
-        //     return 0;
         } else {
             return GEOSGeomGetZ_r(context, a, b);
         }

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -699,19 +699,21 @@ static int GetY(void *context, void *a, double *b) {
     }
 }
 static void *get_y_data[1] = {GetY};
-static int GetZ(void *context, void *a, double *b) {
-    char typ = GEOSGeomTypeId_r(context, a);
-    if (typ != 0) {
-        *(double *)b = NPY_NAN;
-        return 1;
-    // } else if (GEOSGeom_getCoordinateDimension_r(context, a) != 3) {
-    //     *(double *)b = NPY_NAN;
-    //     return 0;
-    } else {
-        return GEOSGeomGetZ_r(context, a, b);
+#if GEOS_SINCE_3_7_0
+    static int GetZ(void *context, void *a, double *b) {
+        char typ = GEOSGeomTypeId_r(context, a);
+        if (typ != 0) {
+            *(double *)b = NPY_NAN;
+            return 1;
+        // } else if (GEOSGeom_getCoordinateDimension_r(context, a) != 3) {
+        //     *(double *)b = NPY_NAN;
+        //     return 0;
+        } else {
+            return GEOSGeomGetZ_r(context, a, b);
+        }
     }
-}
-static void *get_z_data[1] = {GetZ};
+    static void *get_z_data[1] = {GetZ};
+#endif
 static void *area_data[1] = {GEOSArea_r};
 static void *length_data[1] = {GEOSLength_r};
 typedef int FuncGEOS_Y_d(void *context, void *a, double *b);
@@ -1909,7 +1911,6 @@ int init_ufuncs(PyObject *m, PyObject *d)
 
     DEFINE_Y_d (get_x);
     DEFINE_Y_d (get_y);
-    DEFINE_Y_d (get_z);
     DEFINE_Y_d (area);
     DEFINE_Y_d (length);
 
@@ -1951,6 +1952,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
     DEFINE_CUSTOM (from_shapely, 1);
 
     #if GEOS_SINCE_3_7_0
+      DEFINE_Y_d (get_z);
       DEFINE_YY_d (frechet_distance);
       DEFINE_YYd_d (frechet_distance_densify);
     #endif


### PR DESCRIPTION
Adding a `pygeos.get_z` ufunc (in addition to `get_x` and `get_y`).

One open question might be what to return when the Point only has 2 dimensions. I originally thought to raise an error (see the commented code in the ufunc), but it seems that GEOS is not erroring on this but returning NaN, and we already return NaN as well for non-point geometries. 
On the other hand, I like the information to the user from raising an error in this case (eg for Shapely's `Point().z` attribute, we can certainly keep raising, even if the ufunc here would return NaN).