### PR TITLE
Rename get_coordinate_dimension (dimensions -> dimension)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Version 0.8 (unreleased)
 * Addition of a ``build_area()`` function for GEOS >= 3.8 (#141)
 * Addition of a ``normalize()`` function (#136)
 * Addition of a ``make_valid()`` function for GEOS >= 3.8 (#107)
+* The ``get_coordinate_dimensions()`` function was renamed to
+  ``get_coordinate_dimension()`` for consistency with GEOS (#176)
 
 **Acknowledgments**
 

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -8,7 +8,7 @@ __all__ = [
     "GeometryType",
     "get_type_id",
     "get_dimensions",
-    "get_coordinate_dimensions",
+    "get_coordinate_dimension",
     "get_num_coordinates",
     "get_srid",
     "set_srid",
@@ -102,7 +102,7 @@ def get_dimensions(geometry):
 
 
 @multithreading_enabled
-def get_coordinate_dimensions(geometry):
+def get_coordinate_dimension(geometry):
     """Returns the dimensionality of the coordinates in a geometry (2 or 3).
 
     Returns -1 for not-a-geometry values.
@@ -113,14 +113,14 @@ def get_coordinate_dimensions(geometry):
 
     Examples
     --------
-    >>> get_coordinate_dimensions(Geometry("POINT (0 0)"))
+    >>> get_coordinate_dimension(Geometry("POINT (0 0)"))
     2
-    >>> get_coordinate_dimensions(Geometry("POINT Z (0 0 0)"))
+    >>> get_coordinate_dimension(Geometry("POINT Z (0 0 0)"))
     3
-    >>> get_coordinate_dimensions(None)
+    >>> get_coordinate_dimension(None)
     -1
     """
-    return lib.get_coordinate_dimensions(geometry)
+    return lib.get_coordinate_dimension(geometry)
 
 
 @multithreading_enabled

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -127,9 +127,9 @@ def test_get_dimensions():
     assert actual == [0, 1, 1, 2, 0, 1, 2, 1, -1]
 
 
-def test_get_coordinate_dimensions():
-    actual = pygeos.get_coordinate_dimensions([point, point_z]).tolist()
-    assert actual == [2, 3]
+def test_get_coordinate_dimension():
+    actual = pygeos.get_coordinate_dimension([point, point_z, None]).tolist()
+    assert actual == [2, 3, -1]
 
 
 def test_get_num_coordinates():

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -730,7 +730,7 @@ static PyUFuncGenericFunction Y_d_funcs[1] = {&Y_d_func};
 /* Define the geom -> int functions (Y_i) */
 static void *get_type_id_data[1] = {GEOSGeomTypeId_r};
 static void *get_dimensions_data[1] = {GEOSGeom_getDimensions_r};
-static void *get_coordinate_dimensions_data[1] = {GEOSGeom_getCoordinateDimension_r};
+static void *get_coordinate_dimension_data[1] = {GEOSGeom_getCoordinateDimension_r};
 static void *get_srid_data[1] = {GEOSGetSRID_r};
 static int GetNumPoints(void *context, void *geom, int n) {
     char typ = GEOSGeomTypeId_r(context, geom);
@@ -1901,7 +1901,7 @@ int init_ufuncs(PyObject *m, PyObject *d)
 
     DEFINE_Y_i (get_type_id);
     DEFINE_Y_i (get_dimensions);
-    DEFINE_Y_i (get_coordinate_dimensions);
+    DEFINE_Y_i (get_coordinate_dimension);
     DEFINE_Y_i (get_srid);
     DEFINE_Y_i (get_num_points);
     DEFINE_Y_i (get_num_interior_rings);


### PR DESCRIPTION
I just noticed a small inconsistency with the GEOS API. In GEOS it is `GEOSGeom_getCoordinateDimension` (without trailing "s"), while in pygeos we have `get_coordinate_dimensions` (plural). 
Since our names are mostly based on GEOS' names, I *suppose* this inconsistency was an oversight (unless @caspervdw there is a reason for it?)

BTW, in PostGIS they abbreviate this to [`ST_CoordDim`](https://postgis.net/docs/ST_CoordDim.html) (and have an additional alias [`ST_NDims`](https://postgis.net/docs/ST_NDims.html)), but I think writing it in full is fine for us.