### PR TITLE
Support pickling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Version 0.9 (unreleased)
 
 **Highlights of this release**
 
+* Added support for pickling to ``Geometry`` objects (#190)
 * Limited the length of geometry repr to 80 characters (#189)
 
 

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -35,7 +35,8 @@ Geometries can be serialized using pickle:
   >>> pickle.loads(point_1)
   <pygeos.Geometry POINT (5.2 52.1)>
 
-.. warning:: Pickling is not supported for linearrings and empty points. See :func:`pygeos.io.to_wkb` for a list of limitations.
+.. warning:: Pickling is not supported for linearrings and empty points.
+             See :func:`pygeos.io.to_wkb` for a complete list of limitations.
 
 Hashing
 ~~~~~~~
@@ -51,7 +52,8 @@ Therefore, geometries are equal if and only if their WKB representations are equ
   >>> {point_1, point_2, point_3}
   {<pygeos.Geometry POINT (5.2 52.1)>, <pygeos.Geometry POINT (1 1)>}
 
-.. warning:: Due to limitations of WKB, linearrings will equal linearrings if they contain the exact same points. Also, different kind of empty points will be considered equal. See :func:`pygeos.io.to_wkb` for a complete list.
+.. warning:: Due to limitations of WKB, linearrings will equal linearrings if they contain the exact same points.
+             Also, different kind of empty points will be considered equal. See :func:`pygeos.io.to_wkb`.
 
 Comparing two geometries directly is also supported.
 This is the same as using :func:`pygeos.predicates.equals_exact` with a ``tolerance`` value of zero.

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -8,7 +8,7 @@ lets the python garbage collector free its memory when it is not
 used anymore.
 
 Geometry objects are immutable. This means that after constructed, they cannot
-be changed inplace. Every PyGEOS operation will result in a new object being returned.
+be changed in place. Every PyGEOS operation will result in a new object being returned.
 
 Construction
 ~~~~~~~~~~~~
@@ -35,15 +35,7 @@ Geometries can be serialized using pickle:
   >>> pickle.loads(point_1)
   <pygeos.Geometry POINT (5.2 52.1)>
 
-.. warning:: Pickling is not supported for linearrings and empty points.
-
-In pickled form, a geometry is represented in its WKB (Well-Known Binary) representation.
-Because of this, the following limitations apply:
-
-- linearrings will be converted to linestrings
-- a point with only NaN coordinates is converted to an empty point
-- empty points are transformed to 3D in GEOS < 3.8
-- empty points are transformed to 2D in GEOS 3.8
+.. warning:: Pickling is not supported for linearrings and empty points. See :func:`pygeos.io.to_wkb` for a list of limitations.
 
 Hashing
 ~~~~~~~
@@ -58,6 +50,8 @@ Therefore, geometries are equal if and only if their WKB representations are equ
   >>> point_3 = Geometry("POINT (5.2 52.1)")
   >>> {point_1, point_2, point_3}
   {<pygeos.Geometry POINT (5.2 52.1)>, <pygeos.Geometry POINT (1 1)>}
+
+.. warning:: Due to limitations of WKB, linearrings will equal linearrings if they contain the exact same points. Also, different kind of empty points will be considered equal. See :func:`pygeos.io.to_wkb` for a complete list.
 
 Comparing two geometries directly is also supported.
 This is the same as using :func:`pygeos.predicates.equals_exact` with a ``tolerance`` value of zero.

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -1,5 +1,78 @@
-Geometry properties
-===================
+Geometry
+========
+
+The `pygeos.Geometry` class is the central datatype in PyGEOS. 
+An instance of `pygeos.Geometry` is a container of the actual GEOSGeometry object.
+The Geometry object keeps track of the underlying GEOSGeometry and
+lets the python garbage collector free its memory when it is not
+used anymore.
+
+Geometry objects are immutable. This means that after constructed, they cannot
+be changed inplace. Every PyGEOS operation will result in a new object being returned.
+
+Construction
+~~~~~~~~~~~~
+
+For convenience, the ``Geometry`` class can be constructed with a WKT (Well-Known Text)
+or WKB (Well-Known Binary) representation of your geometry:
+
+.. code:: python
+
+  >>> from pygeos import Geometry
+  >>> point_1 = Geometry("POINT (5.2 52.1)")
+  >>> point_2 = Geometry(b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?")
+
+A more efficient way of constructing geometries is by making use of the (vectorized)
+functions described in :mod:`pygeos.creation`.
+
+Pickling
+~~~~~~~~
+
+Geometries can be serialized using pickle:
+
+  >>> import pickle
+  >>> pickled = pickle.dumps(point_1)
+  >>> pickle.loads(point_1)
+  <pygeos.Geometry POINT (5.2 52.1)>
+
+.. warning:: Pickling is not supported for linearrings and empty points.
+
+In pickled form, a geometry is represented in its WKB (Well-Known Binary) representation.
+Because of this, the following limitations apply:
+
+- linearrings will be converted to linestrings
+- a point with only NaN coordinates is converted to an empty point
+- empty points are transformed to 3D in GEOS < 3.8
+- empty points are transformed to 2D in GEOS 3.8
+
+Hashing
+~~~~~~~
+
+Geometries can be used as elements in sets or as keys in dictionaries.
+Python uses a technique called *hashing* for lookups in these datastructures.
+PyGEOS generates this hash from the WKB representation.
+Therefore, geometries are equal if and only if their WKB representations are equal.
+
+.. code:: python
+
+  >>> point_3 = Geometry("POINT (5.2 52.1)")
+  >>> {point_1, point_2, point_3}
+  {<pygeos.Geometry POINT (5.2 52.1)>, <pygeos.Geometry POINT (1 1)>}
+
+Comparing two geometries directly is also supported.
+This is the same as using :func:`pygeos.predicates.equals_exact` with a ``tolerance`` value of zero.
+
+  >>> point_1 == point_2
+  False
+  >>> point_1 != point_2
+  True
+
+
+Properties
+~~~~~~~~~~
+
+Geometry objects have no attributes or properties.
+Instead, use functions listed below to obtain information about geometry objects.
 
 .. automodule:: pygeos.geometry
    :members:

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -97,6 +97,13 @@ def to_wkb(
     The Well-Known Binary format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
 
+    The following limitations apply to WKB serialization:
+
+    - linearrings will be converted to linestrings
+    - a point with only NaN coordinates is converted to an empty point
+    - empty points are transformed to 3D in GEOS < 3.8
+    - empty points are transformed to 2D in GEOS 3.8
+
     Parameters
     ----------
     geometry : Geometry or array_like

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -5,7 +5,7 @@ import pickle
 import struct
 from unittest import mock
 
-from .common import all_types, point, empty_point
+from .common import all_types, point, empty_point, point_z
 
 
 POINT11_WKB = b'\x01\x01\x00\x00\x00' + struct.pack("<2d", 1., 1.)
@@ -352,9 +352,18 @@ def test_from_shapely_incompatible_versions():
         pygeos.from_shapely(point)
 
 
-@pytest.mark.parametrize("geom", all_types)
+@pytest.mark.parametrize("geom", all_types + (point_z, empty_point))
 def test_pickle(geom):
     if pygeos.get_type_id(geom) == 2:
-        pytest.xfail("Linearrings are converted to linestrings in pickle")
+        # Linearrings get converted to linestrings
+        expected = pygeos.linestrings(pygeos.get_coordinates(geom))
+    else:
+        expected = geom
     pickled = pickle.dumps(geom)
-    assert pygeos.equals_exact(pickle.loads(pickled), geom)
+    assert pygeos.equals_exact(pickle.loads(pickled), expected)
+
+
+def test_pickle_with_srid():
+    geom = pygeos.set_srid(point, 4326)
+    pickled = pickle.dumps(geom)
+    assert pygeos.get_srid(pickle.loads(pickled)) == 4326

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -354,5 +354,7 @@ def test_from_shapely_incompatible_versions():
 
 @pytest.mark.parametrize("geom", all_types)
 def test_pickle(geom):
+    if pygeos.get_type_id(geom) == 2:
+        pytest.xfail("Linearrings are converted to linestrings in pickle")
     pickled = pickle.dumps(geom)
     assert pygeos.equals_exact(pickle.loads(pickled), geom)

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pygeos
 import pytest
+import pickle
 import struct
 from unittest import mock
 
@@ -351,7 +352,7 @@ def test_from_shapely_incompatible_versions():
         pygeos.from_shapely(point)
 
 
-import pickle
-def test_pickle_geometry_class():
-    pickled = pickle.dumps(pygeos.Geometry)
-    assert pickle.loads(pickled) is pygeos.Geometry
+@pytest.mark.parametrize("geom", all_types)
+def test_pickle(geom):
+    pickled = pickle.dumps(geom)
+    assert pygeos.equals_exact(pickle.loads(pickled), geom)

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -349,3 +349,9 @@ def test_from_shapely_error(geom):
 def test_from_shapely_incompatible_versions():
     with pytest.raises(ImportError):
         pygeos.from_shapely(point)
+
+
+import pickle
+def test_pickle_geometry_class():
+    pickled = pickle.dumps(pygeos.Geometry)
+    assert pickle.loads(pickled) is pygeos.Geometry

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -113,6 +113,19 @@ static PyObject *GeometryObject_str(GeometryObject *self)
     return GeometryObject_ToWKT(self, "%s");
 }
 
+static PyObject *GeometryObject_reduce(PyObject *self)
+{
+    Py_INCREF(self->ob_type);
+    return PyTuple_Pack(
+        2,
+        self->ob_type,
+        PyTuple_Pack(
+            1,
+            GeometryObject_ToWKT((GeometryObject *)self, "%s")
+        )
+    );
+}
+
 static Py_hash_t GeometryObject_hash(GeometryObject *self)
 {
     unsigned char *wkb;
@@ -238,6 +251,7 @@ static PyObject *GeometryObject_new(PyTypeObject *type, PyObject *args,
 }
 
 static PyMethodDef GeometryObject_methods[] = {
+    {"__reduce__", GeometryObject_reduce, METH_NOARGS, "For pickling."},
     {NULL}  /* Sentinel */
 };
 

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -243,7 +243,7 @@ static PyMethodDef GeometryObject_methods[] = {
 
 PyTypeObject GeometryType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "pygeos.lib.GEOSGeometry",
+    .tp_name = "pygeos.lib.Geometry",
     .tp_doc = "Geometry type",
     .tp_basicsize = sizeof(GeometryObject),
     .tp_itemsize = 0,


### PR DESCRIPTION
Closes #46

After a failed approach with `__getstate__` and `__setstate__`, I chose for the `__reduce__` route. `__setstate__` does not play  nice with the fact that our geometry objects are immutable. Further reading: https://docs.python.org/3/library/pickle.html#pickling-class-instances

`__reduce__` should return a tuple (callable, args). A convenient way for us would be the following:
- `(pygeos.lib.Geometry, ("<WKT>", ))`

However, WKT serialization is less efficient than WKB serialization. We could opt for:

- `(pygeos.lib.from_wkb, (b"<WKB>", ))`

When testing these approaches, a noticed that both of them have drawbacks.

- WKT does not support SRID serialization and it has an issue with empty points in multipoints (#171).
- WKB does not support linearrings

I am still in favour of going the WKB route. Do we accept that linearrings gets transformed into linestrings when pickled-unpickled?

```
>>> import pickle, pygeos
>>> g = pygeos.linearrings([[(0, 0), (0, 1), (1, 1), (0, 0)]])
>>> pickle.loads(pickle.dumps(g))
array([<pygeos.Geometry LINESTRING (0 0, 0 1, 1 1, 0 0)>], dtype=object)
```