### PR TITLE
Fix bug when setting coordinates on an empty point

### DIFF
--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -28,7 +28,6 @@ __all__ = [
 class GeometryType(IntEnum):
     """The enumeration of GEOS geometry types"""
 
-    NAG = -1
     POINT = 0
     LINESTRING = 1
     LINEARRING = 2

--- a/pygeos/test/test_coordinates.py
+++ b/pygeos/test/test_coordinates.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_equal
 
 from .common import empty
 from .common import point
+from .common import empty_point
 from .common import point_z
 from .common import line_string
 from .common import line_string_z
@@ -105,6 +106,7 @@ def test_get_coords_3d(geoms, x, y, z, include_z):
     [
         ([], 0, False),
         ([empty], 0, False),
+        ([empty_point], 0, False),
         ([point, empty], 1, False),
         ([empty, point, empty], 1, False),
         ([point, None], 1, False),

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -4,6 +4,7 @@ import pytest
 
 from .common import point
 from .common import point_nan
+from .common import empty_point
 from .common import line_string
 from .common import linear_ring
 from .common import polygon
@@ -191,7 +192,7 @@ def test_adapt_ptr_raises():
         point._ptr += 1
 
 
-@pytest.mark.parametrize("geom", all_types + (pygeos.points(np.nan, np.nan),))
+@pytest.mark.parametrize("geom", all_types + (pygeos.points(np.nan, np.nan), empty_point))
 def test_hash_same_equal(geom):
     assert hash(geom) == hash(pygeos.apply(geom, lambda x: x))
 

--- a/src/coords.c
+++ b/src/coords.c
@@ -109,6 +109,11 @@ static void *set_coordinates_simple(GEOSContextHandle_t context, GEOSGeometry *g
     double *x, *y;
     GEOSGeometry *ret;
 
+    /* Special case for POINT EMPTY (Point coordinate list cannot be 0-length) */
+    if ((type == 0) & (GEOSisEmpty_r(context, geom) == 1)) {
+        return GEOSGeom_createEmptyPoint_r(context);
+    }
+
     /* Investigate the current (const) CoordSequence */
     const GEOSCoordSequence *seq = GEOSGeom_getCoordSeq_r(context, geom);
     if (seq == NULL) { return NULL; }


### PR DESCRIPTION
This confirms that #196 was indeed solved in master by #190 . The test however uncovered another bug in `set_coordinates`, it raised a GEOSException when setting coordinates on an empty point.

Also, I cleaned up the old `NAG` geometrytype (we use `None` for that since a long time)