### PR TITLE
Drop Python 3.5 from Travis-CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: minimal
 
 matrix:
   include:
-  - os: linux  # 2015
-    env: PYTHON_VERSION="3.5" RESTORE_FREE_CHANNEL=1 DEPS="numpy=1.10 geos=3.5"
   - os: linux  # 2017
     env: PYTHON_VERSION="3.6" DEPS="numpy=1.13 geos=3.6"
   - os: linux  # 2018
@@ -28,7 +26,4 @@ install:
   - pip install . --no-deps
 
 script:
-  - if [[ "$PYTHON_VERSION" == "3.5" ]];
-    then pytest;
-    else pytest --doctest-modules;
-    fi;
+  - pytest --doctest-modules;


### PR DESCRIPTION
Python 3.5 is now no longer supported.  Pulled this change from #210 plus drop special handling for `pytest`.