### PR TITLE
TST: Use native CI build tools to allow flexible GEOS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,56 @@
-language: minimal
+---
+language: python
+dist: xenial
+os: linux
 
-matrix:
+cache:
+  directories:
+    - $HOME/geosinstall
+    - ~/.cache/pip
+
+jobs:
   include:
-    - os: linux # 2017
-      env: PYTHON_VERSION="3.6" DEPS="numpy=1.13 geos=3.6"
-    - os: linux # 2018
-      env: PYTHON_VERSION="3.7" DEPS="numpy=1.15 geos=3.7"
-    - os: linux # 2019
-      env: PYTHON_VERSION="3.8" DEPS="numpy=1.17 geos=3.8"
-    - os: linux # now
-      env: PYTHON_VERSION="3.8" CONDA_FORGE=1 DEPS="numpy geos"
-    - os: osx
-      env: PYTHON_VERSION="3.8" DEPS="numpy geos"
+    - python: "3.5"
+      env:  # 2015
+        GEOS_VERSION="3.5.2"
+        NUMPY_VERSION="1.10.4"
+    - python: "3.6"
+      env:  # 2017
+        GEOS_VERSION="3.6.4"
+        NUMPY_VERSION="1.13.3"
+    - python: "3.7"
+      env:  # 2018
+        GEOS_VERSION="3.7.3"
+        NUMPY_VERSION="1.15.4"
+    - python: "3.8"
+      env:  # 2019
+        GEOS_VERSION="3.8.1"
+        NUMPY_VERSION="1.17.5"
+    - python: "3.9"
+      env:  # 2020
+        GEOS_VERSION="3.8.1"
+        NUMPY_VERSION="1.19.4"
+    - python: "3.9-dev"
+      env: GEOS_VERSION="master"
+  allow_failures:
+    - python: "3.9-dev"
+      env: GEOS_VERSION="master"
 
 install:
-  - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe
-  - chmod +x conda.exe
-  - export CONDA_ALWAYS_YES=1
-  - if [ $RESTORE_FREE_CHANNEL ]; then ./conda.exe config --set restore_free_channel true; fi
-  - if [ $CONDA_FORGE ]; then ./conda.exe config --add channels conda-forge; fi
-  - ./conda.exe create --prefix $HOME/miniconda python=$PYTHON_VERSION conda pytest $DEPS
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - pip install -e . --no-deps -v
+  - export GEOS_INSTALL=$HOME/geosinstall/geos-$GEOS_VERSION
+  - ./ci/install_geos.sh
+  - cd $TRAVIS_BUILD_DIR
+  - pip install --disable-pip-version-check --upgrade pip
+  - pip install --upgrade wheel
+  - if [ "$GEOS_VERSION" = "master" ]; then
+      pip install --upgrade --pre Cython numpy pytest;
+    else
+      pip install --upgrade Cython "numpy==$NUMPY_VERSION" pytest;
+    fi
+  - export LD_LIBRARY_PATH=$GEOS_INSTALL/lib
+  - export PATH=$GEOS_INSTALL/bin:$PATH
+  - python setup.py build_ext --inplace
+  - pip install --no-deps -e .
 
 script:
-  - pytest --doctest-modules;
+  - pytest --doctest-modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,33 @@
+---
+image: Visual Studio 2019
+platform: x64
+
 environment:
+  global:
+    COMPILER: msvc2019
+
   matrix:
-    - PYTHON_PATH: "C:\\Miniconda37"
-      PYTHON_VERSION: 3.7
-      DEPS: "numpy geos Cython"
-
-    - PYTHON_PATH: "C:\\Miniconda37-x64"
-      PYTHON_VERSION: 3.7
-      DEPS: "numpy geos Cython"
-
-init:
-  - "ECHO %PYTHON% %PYTHON_VERSION%"
+    # Interleave PYTHON, ARCH and GEOS_VERSION
+    - PYTHON: "C:\\Python35-x64"
+      ARCH: x64
+      GEOS_VERSION: 3.5.2
+      NUMPY_VERSION: 1.10.4
+    - PYTHON: "C:\\Python36"
+      ARCH: x86
+      GEOS_VERSION: 3.6.4
+      NUMPY_VERSION: 1.13.3
+    - PYTHON: "C:\\Python37-x64"
+      ARCH: x64
+      GEOS_VERSION: 3.7.3
+      NUMPY_VERSION: 1.15.4
+    - PYTHON: "C:\\Python38"
+      ARCH: x86
+      GEOS_VERSION: 3.8.1
+      NUMPY_VERSION: 1.17.5
+    - PYTHON: "C:\\Python39-x64"
+      ARCH: x64
+      GEOS_VERSION: 3.8.1
+      NUMPY_VERSION: 1.19.4
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -23,26 +41,35 @@ install:
       Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
       throw "There are newer queued builds for this pull request, failing early." }
 
-  # Prepend to the PATH of this build
-  - "set PATH=%PYTHON_PATH%;%PYTHON_PATH%\\Scripts;%CONDA_ROOT%\\Library\\bin;%PATH%"
-  - conda config --set always_yes true
-  - conda update --quiet conda
+build: false  # disable automatic build
+build_script:
+  - set GEOS_INSTALL=C:\projects\deps\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
+  - set GEOS_ESCAPED_INSTALL=C:\\projects\\deps\\geos-%GEOS_VERSION%-%COMPILER%-%ARCH%
 
-  # See https://github.com/conda/conda/issues/8836 ("yes, this is insane")
-  - activate
-  - conda info --all
-  - conda config --append channels conda-forge
-  - conda create -n testenv --yes python=%PYTHON_VERSION% %DEPS% pytest
+  - ps: 'Write-Host "Configuring PATH with $env:PYTHON and $env:GEOS_INSTALL\bin" -ForegroundColor Magenta'
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%GEOS_INSTALL%\bin;%PATH%
+  - python -m pip install --disable-pip-version-check --upgrade pip
+  - pip install --upgrade wheel  # may be required to generate some dependencies
 
-  # Do this. Don't "conda activate testenv".
-  - activate testenv
+  - ps: 'Write-Host "Configuring MSVC compiler $env:COMPILER" -ForegroundColor Magenta'
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
 
-build: false
+  - ps: 'Write-Host "Checking GEOS build $env:GEOS_INSTALL" -ForegroundColor Magenta'
+  - if not exist C:\projects\deps mkdir C:\projects\deps
+  - cd C:\projects\deps
+  - call %APPVEYOR_BUILD_FOLDER%\ci\install_geos.cmd
 
-before_test:
-  - "set GEOS_LIBRARY_PATH=%CONDA_PREFIX%\\Library\\lib"
-  - "set GEOS_INCLUDE_PATH=%CONDA_PREFIX%\\Library\\include"
-  - "%CMD_IN_ENV% pip install -e . --no-deps --no-build-isolation -v"
+  - ps: 'Write-Host "Building extension" -ForegroundColor Magenta'
+  - set GEOS_LIBRARY_PATH=%GEOS_ESCAPED_INSTALL%\\lib
+  - set GEOS_INCLUDE_PATH=%GEOS_ESCAPED_INSTALL%\\include
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - xcopy %GEOS_INSTALL%\bin\geos*.dll pygeos\
+  - pip install --upgrade Cython "numpy==%NUMPY_VERSION%" pytest
+  - python setup.py build_ext --inplace
+  - pip install --no-deps -e .
 
 test_script:
   - pytest --doctest-modules
+
+cache:
+  - C:\projects\deps -> %APPVEYOR_BUILD_FOLDER%\ci\install_geos.cmd

--- a/ci/install_geos.cmd
+++ b/ci/install_geos.cmd
@@ -1,0 +1,27 @@
+:: Build and install GEOS on Windows system, save cache for later
+::
+:: This script requires environment variables to be set
+::  - set GEOS_INSTALL=C:\path\to\cached\prefix -- to build or use as cache
+::  - set GEOS_VERSION=3.7.3 -- to download and compile
+
+if exist %GEOS_INSTALL% (
+  echo Using cached %GEOS_INSTALL%
+) else (
+  echo Building %GEOS_INSTALL%
+
+  curl -fsSO http://download.osgeo.org/geos/geos-%GEOS_VERSION%.tar.bz2
+  7z x geos-%GEOS_VERSION%.tar.bz2
+  7z x geos-%GEOS_VERSION%.tar
+  cd geos-%GEOS_VERSION% || exit /B 1
+
+  pip install ninja
+  cmake --version
+
+  mkdir build
+  cd build
+  cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=%GEOS_INSTALL% .. || exit /B 2
+  cmake --build . || exit /B 3
+  ctest . || exit /B 4
+  cmake --install . || exit /B 5
+  cd ..
+)

--- a/ci/install_geos.sh
+++ b/ci/install_geos.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# Build and install GEOS on a POSIX system, save cache for later
+#
+# This script requires environment variables to be set
+#  - export GEOS_INSTALL=/path/to/cached/prefix -- to build or use as cache
+#  - export GEOS_VERSION=3.7.3 or master -- to download and compile
+
+set -e
+
+if [ -z "$GEOS_INSTALL" ]; then
+    echo "GEOS_INSTALL must be set"
+    exit 1
+elif [ -z "$GEOS_VERSION" ]; then
+    echo "GEOS_VERSION must be set"
+    exit 1
+fi
+
+# Create directories, if they don't exit
+mkdir -p $GEOS_INSTALL
+
+# Download and build GEOS outside other source tree
+GEOS_BUILD=$HOME/geosbuild
+
+prepare_geos_build_dir(){
+  rm -rf $GEOS_BUILD
+  mkdir -p $GEOS_BUILD
+  cd $GEOS_BUILD
+}
+
+build_geos(){
+    echo "Building geos-$GEOS_VERSION"
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GEOS_INSTALL ..
+    make -j 2
+    ctest .
+    make install
+}
+
+if [ "$GEOS_VERSION" = "master" ]; then
+    prepare_geos_build_dir
+    # use GitHub mirror
+    git clone --depth 1 https://github.com/libgeos/geos.git geos-$GEOS_VERSION
+    cd geos-$GEOS_VERSION
+    git rev-parse HEAD > newrev.txt
+    BUILD=no
+    # Only build if nothing cached or if the GEOS revision changed
+    if test ! -f $GEOS_INSTALL/rev.txt; then
+        BUILD=yes
+    elif ! diff newrev.txt $GEOS_INSTALL/rev.txt >/dev/null; then
+        BUILD=yes
+    fi
+    if test "$BUILD" = "no"; then
+        echo "Using cached install $GEOS_INSTALL"
+    else
+        cp newrev.txt $GEOS_INSTALL/rev.txt
+        build_geos
+    fi
+else
+    if [ -d "$GEOS_INSTALL/include/geos" ]; then
+        echo "Using cached install $GEOS_INSTALL"
+    else
+        prepare_geos_build_dir
+        wget -q http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2
+        tar xfj geos-$GEOS_VERSION.tar.bz2
+        cd geos-$GEOS_VERSION
+        build_geos
+    fi
+fi

--- a/pygeos/test/test_misc.py
+++ b/pygeos/test/test_misc.py
@@ -3,6 +3,7 @@ from pygeos.decorators import requires_geos, multithreading_enabled
 from unittest import mock
 import pytest
 from itertools import chain
+import sys
 
 import numpy as np
 
@@ -22,6 +23,10 @@ def test_geos_version():
     assert pygeos.geos_version_string == expected
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win") and pygeos.geos_version[:2] == (3, 7),
+    reason="GEOS_C_API_VERSION broken for GEOS 3.7.x on Windows",
+)
 def test_geos_capi_version():
     expected = "{0:d}.{1:d}.{2:d}-CAPI-{3:d}.{4:d}.{5:d}".format(
         *(pygeos.geos_version + pygeos.geos_capi_version)


### PR DESCRIPTION
* Move away from conda, which does not offer many versions of GEOS
* Build and cache GEOS for Travis CI and AppVeyor
* Test Python 3.5 and GEOS 3.5.2
* Test Python 3.6, GEOS 3.6.4, and NumPy 1.13.3
* Test Python 3.7, GEOS 3.7.3, and NumPy 1.15.4
* Test Python 3.8, GEOS 3.8.1, and NumPy 1.17.5
* Test Python 3.9, GEOS 3.8.1, and NumPy 1.19.4
* Test Python 3.9-dev, GEOS master, and NumPY pre-release (Travis CI only)
* Skip `test_geos_capi_version` for GEOS 3.7.x on Windows due to GEOS issue

Supersedes #212

<s>Future considerations could also mix a few versions of NumPy too.</s> Updated to mix NumPy versions.

Also, this PR currently drops osx from the Travis CI testing. Is it worth keeping? It would require a bit more work if this is desired.