### PR TITLE
API change: return 0 for None values in geometry counting functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,10 @@ Version 0.9 (unreleased)
   geometries (#197).
 * Addition of Cython and internal PyGEOS C API to enable easier development of internal
   functions (previously all significant internal functions were developed in C) (#51).
+* API change: geometry and counting functions (``get_num_coordinates``,
+  ``get_num_geometries``, ``get_num_interior_rings``, ``get_num_points``) now return 0
+  for ``None`` input values instead of -1 (#218).
+* Fixed internal GEOS error code detection for ``get_dimensions`` and ``get_srid`` (#218).
 
 Version 0.8 (2020-09-06)
 ------------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,4 +45,4 @@ before_test:
   - "%CMD_IN_ENV% pip install -e . --no-deps --no-build-isolation -v"
 
 test_script:
-  - pytest --doctest-modules
+  - pytest --doctest-modules -s

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ build_script:
   - pip install --no-deps -e .
 
 test_script:
-  - pytest --doctest-modules -s
+  - pytest --doctest-modules
 
 cache:
   - C:\projects\deps -> %APPVEYOR_BUILD_FOLDER%\ci\install_geos.cmd

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -316,6 +316,8 @@ def get_point(geometry, index):
 def get_num_points(geometry):
     """Returns number of points in a linestring or linearring.
 
+    Returns 0 for not-a-geometry values.
+
     Parameters
     ----------
     geometry : Geometry or array_like
@@ -333,6 +335,8 @@ def get_num_points(geometry):
     >>> get_num_points(line)
     4
     >>> get_num_points(Geometry("MULTIPOINT (0 0, 1 1, 2 2, 3 3)"))
+    0
+    >>> get_num_points(None)
     0
     """
     return lib.get_num_points(geometry)

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -128,7 +128,7 @@ def get_coordinate_dimension(geometry):
 def get_num_coordinates(geometry):
     """Returns the total number of coordinates in a geometry.
 
-    Returns -1 for not-a-geometry values.
+    Returns 0 for not-a-geometry values.
 
     Parameters
     ----------
@@ -143,7 +143,7 @@ def get_num_coordinates(geometry):
     >>> get_num_coordinates(Geometry("GEOMETRYCOLLECTION (POINT(0 0), LINESTRING(0 0, 1 1))"))
     3
     >>> get_num_coordinates(None)
-    -1
+    0
     """
     return lib.get_num_coordinates(geometry)
 
@@ -391,6 +391,8 @@ def get_interior_ring(geometry, index):
 def get_num_interior_rings(geometry):
     """Returns number of internal rings in a polygon
 
+    Returns 0 for not-a-geometry values.
+
     Parameters
     ----------
     geometry : Geometry or array_like
@@ -410,6 +412,8 @@ def get_num_interior_rings(geometry):
     >>> get_num_interior_rings(polygon_with_hole)
     1
     >>> get_num_interior_rings(Geometry("POINT (1 1)"))
+    0
+    >>> get_num_interior_rings(None)
     0
     """
     return lib.get_num_interior_rings(geometry)
@@ -457,6 +461,8 @@ def get_geometry(geometry, index):
 def get_num_geometries(geometry):
     """Returns number of geometries in a collection.
 
+    Returns 0 for not-a-geometry values.
+
     Parameters
     ----------
     geometry : Geometry or array_like
@@ -474,5 +480,7 @@ def get_num_geometries(geometry):
     4
     >>> get_num_geometries(Geometry("POINT (1 1)"))
     1
+    >>> get_num_geometries(None)
+    0
     """
     return lib.get_num_geometries(geometry)

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -146,8 +146,6 @@ def get_num_coordinates(geometry):
     1
     >>> get_num_coordinates(Geometry("GEOMETRYCOLLECTION (POINT(0 0), LINESTRING(0 0, 1 1))"))
     3
-    >>> get_num_coordinates(None)
-    0
     """
     return lib.get_num_coordinates(geometry)
 
@@ -533,7 +531,5 @@ def get_num_geometries(geometry):
     4
     >>> get_num_geometries(Geometry("POINT (1 1)"))
     1
-    >>> get_num_geometries(None)
-    0
     """
     return lib.get_num_geometries(geometry)

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -146,6 +146,8 @@ def get_num_coordinates(geometry):
     1
     >>> get_num_coordinates(Geometry("GEOMETRYCOLLECTION (POINT(0 0), LINESTRING(0 0, 1 1))"))
     3
+    >>> get_num_coordinates(None)
+    0
     """
     return lib.get_num_coordinates(geometry)
 
@@ -531,5 +533,7 @@ def get_num_geometries(geometry):
     4
     >>> get_num_geometries(Geometry("POINT (1 1)"))
     1
+    >>> get_num_geometries(None)
+    0
     """
     return lib.get_num_geometries(geometry)

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -1,3 +1,4 @@
+import sys
 import numpy as np
 import pygeos
 import pytest
@@ -32,6 +33,8 @@ def test_get_num_interior_rings():
     assert actual == [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]
 
 
+# FIXME:
+@pytest.mark.xfail(sys.platform == "win32", reason="Not correctly detecting function signature")
 def test_get_num_geometries():
     actual = pygeos.get_num_geometries(all_types + (None,)).tolist()
     assert actual == [1, 1, 1, 1, 2, 1, 2, 2, 0, 0]
@@ -137,7 +140,8 @@ def test_get_coordinate_dimension():
     actual = pygeos.get_coordinate_dimension([point, point_z, None]).tolist()
     assert actual == [2, 3, -1]
 
-
+# FIXME:
+@pytest.mark.xfail(sys.platform == "win32", reason="Not correctly detecting function signature")
 def test_get_num_coordinates():
     actual = pygeos.get_num_coordinates(all_types + (None,)).tolist()
     assert actual == [1, 3, 5, 5, 2, 2, 10, 3, 0, 0]

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -18,18 +18,20 @@ from .common import all_types
 
 
 def test_get_num_points():
-    actual = pygeos.get_num_points(all_types).tolist()
-    assert actual == [0, 3, 5, 0, 0, 0, 0, 0, 0]
+    actual = pygeos.get_num_points(all_types + (None,)).tolist()
+    assert actual == [0, 3, 5, 0, 0, 0, 0, 0, 0, 0]
 
 
 def test_get_num_interior_rings():
-    actual = pygeos.get_num_interior_rings(all_types + (polygon_with_hole,)).tolist()
-    assert actual == [0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    actual = pygeos.get_num_interior_rings(
+        all_types + (polygon_with_hole, None)
+    ).tolist()
+    assert actual == [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]
 
 
 def test_get_num_geometries():
-    actual = pygeos.get_num_geometries(all_types).tolist()
-    assert actual == [1, 1, 1, 1, 2, 1, 2, 2, 0]
+    actual = pygeos.get_num_geometries(all_types + (None,)).tolist()
+    assert actual == [1, 1, 1, 1, 2, 1, 2, 2, 0, 0]
 
 
 @pytest.mark.parametrize(
@@ -134,8 +136,14 @@ def test_get_coordinate_dimension():
 
 
 def test_get_num_coordinates():
-    actual = pygeos.get_num_coordinates(all_types).tolist()
-    assert actual == [1, 3, 5, 5, 2, 2, 10, 3, 0]
+    actual = pygeos.get_num_coordinates(all_types + (None,)).tolist()
+    assert actual == [1, 3, 5, 5, 2, 2, 10, 3, 0, 0]
+
+
+def test_get_srid():
+    """All geometry types have no SRID by default; None returns -1"""
+    actual = pygeos.get_srid(all_types + (None,)).tolist()
+    assert actual == [0, 0, 0, 0, 0, 0, 0, 0, 0, -1]
 
 
 def test_get_set_srid():
@@ -192,7 +200,9 @@ def test_adapt_ptr_raises():
         point._ptr += 1
 
 
-@pytest.mark.parametrize("geom", all_types + (pygeos.points(np.nan, np.nan), empty_point))
+@pytest.mark.parametrize(
+    "geom", all_types + (pygeos.points(np.nan, np.nan), empty_point)
+)
 def test_hash_same_equal(geom):
     assert hash(geom) == hash(pygeos.apply(geom, lambda x: x))
 

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -27,10 +27,8 @@ def test_get_num_points():
 
 
 def test_get_num_interior_rings():
-    actual = pygeos.get_num_interior_rings(
-        all_types + (polygon_with_hole, None)
-    ).tolist()
-    assert actual == [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]
+    actual = pygeos.get_num_interior_rings(all_types + (polygon_with_hole, None))
+    assert actual.tolist() == [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]
 
 
 def test_get_num_geometries():

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -33,8 +33,6 @@ def test_get_num_interior_rings():
     assert actual == [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]
 
 
-# FIXME:
-@pytest.mark.xfail(sys.platform == "win32", reason="Not correctly detecting function signature")
 def test_get_num_geometries():
     actual = pygeos.get_num_geometries(all_types + (None,)).tolist()
     assert actual == [1, 1, 1, 1, 2, 1, 2, 2, 0, 0]
@@ -140,8 +138,7 @@ def test_get_coordinate_dimension():
     actual = pygeos.get_coordinate_dimension([point, point_z, None]).tolist()
     assert actual == [2, 3, -1]
 
-# FIXME:
-@pytest.mark.xfail(sys.platform == "win32", reason="Not correctly detecting function signature")
+
 def test_get_num_coordinates():
     actual = pygeos.get_num_coordinates(all_types + (None,)).tolist()
     assert actual == [1, 3, 5, 5, 2, 2, 10, 3, 0, 0]

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -835,6 +835,48 @@ static void Y_i_func(char** args, npy_intp* dimensions, npy_intp* steps, void* d
   GEOSGeometry* in1 = NULL;
   int result;
 
+  // DEBUG: print which function signature is called here; this seems to behave differently
+  // on windows
+  int match = 0;
+  if ((void*)func == GEOSGeomTypeId_r) {
+    printf("C ext: GEOSGeomTypeId_r\n");
+    match = 1;
+  }
+  if ((void*)func == GetNumPoints) {
+    printf("C ext: GetNumPoints\n");
+    match = 1;
+  }
+  if ((void*)func == GetNumInteriorRings) {
+    printf("C ext: GetNumInteriorRings\n");
+    match = 1;
+  }
+  if ((void*)func == GEOSGetNumGeometries_r) {
+    printf("C ext: GEOSGetNumGeometries_r\n");
+    match = 1;
+  }
+  if ((void*)func == GEOSGetNumCoordinates_r) {
+    printf("C ext: GEOSGetNumCoordinates_r\n");
+    match = 1;
+  }
+  if ((void*)func == GEOSGeom_getDimensions_r) {
+    printf("C ext: GEOSGeom_getDimensions_r\n");
+    match = 1;
+  }
+  if ((void*)func == GEOSGeom_getCoordinateDimension_r) {
+    printf("C ext: GEOSGeom_getCoordinateDimension_r\n");
+    match = 1;
+  }
+  if ((void*)func == GEOSGetSRID_r) {
+    printf("C ext: GEOSGetSRID_r\n");
+    match = 1;
+  }
+  // no match found
+  if (match == 0) {
+    printf("C ext: no match on function signature\n");
+  }
+
+  // END DEBUG
+
   int none_value;
   if (((void*)func == GetNumPoints) || ((void*)func == GetNumInteriorRings) ||
       ((void*)func == GEOSGetNumGeometries_r) ||

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -835,6 +835,16 @@ static void Y_i_func(char** args, npy_intp* dimensions, npy_intp* steps, void* d
   GEOSGeometry* in1 = NULL;
   int result;
 
+  int none_value;
+  if (((void*)func == GetNumPoints) || ((void*)func == GetNumInteriorRings) ||
+      ((void*)func == GEOSGetNumGeometries_r) ||
+      ((void*)func == GEOSGetNumGeometries_r) ||
+      ((void*)func == GEOSGetNumCoordinates_r)) {
+    none_value = 0;
+  } else {
+    none_value = -1;
+  }
+
   // In the GEOS CAPI, sometimes -1 is an error, sometimes 0
   int errcode;
   if (((void*)func == GEOSGeom_getDimensions_r) || ((void*)func == GEOSGetSRID_r)) {
@@ -852,8 +862,8 @@ static void Y_i_func(char** args, npy_intp* dimensions, npy_intp* steps, void* d
       goto finish;
     }
     if (in1 == NULL) {
-      /* None results in -1 */
-      *(npy_int*)op1 = -1;
+      /* None results in 0 for counting functions, -1 otherwise */
+      *(npy_int*)op1 = none_value;
     } else {
       result = func(ctx, in1);
       // Check last_error if the result equals errcode.

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -837,6 +837,23 @@ static void Y_i_func(char** args, npy_intp* dimensions, npy_intp* steps, void* d
 
   // DEBUG: print which function signature is called here; this seems to behave
   // differently on windows
+  printf(
+    "-----------------------\nincoming func: %p, (cast: %p, deref: %p)\n",
+    func,
+    (void*)func,
+    &func
+  );
+  printf(
+    "known GEOS funcs: %p (deref: %p), %p, %p, %p, %p, %p\n------------------------\n",
+    GEOSGeomTypeId_r,
+    &GEOSGeomTypeId_r,
+    GEOSGetNumGeometries_r,
+    GEOSGetNumCoordinates_r,
+    GEOSGeom_getDimensions_r,
+    GEOSGeom_getCoordinateDimension_r,
+    GEOSGetSRID_r
+  );
+
   int match = 0;
   if ((void*)func == GEOSGeomTypeId_r) {
     printf("C ext: GEOSGeomTypeId_r\n");

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -804,7 +804,11 @@ finish:
 static PyUFuncGenericFunction Y_d_funcs[1] = {&Y_d_func};
 
 /* Define the geom -> int functions (Y_i) */
-static void* get_type_id_data[1] = {&GEOSGeomTypeId_r};
+static int GEOSGeomTypeId(void* context, void* geom, int n) {
+  return GEOSGeomTypeId_r(context, geom);
+}
+// static void* get_type_id_data[1] = {GEOSGeomTypeId_r};
+static void* get_type_id_data[1] = {GEOSGeomTypeId};
 static void* get_dimensions_data[1] = {GEOSGeom_getDimensions_r};
 static void* get_coordinate_dimension_data[1] = {GEOSGeom_getCoordinateDimension_r};
 static void* get_srid_data[1] = {GEOSGetSRID_r};
@@ -839,14 +843,14 @@ static void Y_i_func(char** args, npy_intp* dimensions, npy_intp* steps, void* d
   // differently on windows
   printf(
     "-----------------------\nincoming func: %p, (cast: %p, deref: %p)\n",
-    func,
+    data,
     (void*)func,
     &func
   );
   printf(
-    "known GEOS funcs: %p (deref: %p), %p, %p, %p, %p, %p\n------------------------\n",
+    "known GEOS funcs: %p (wrapper: %p), %p, %p, %p, %p, %p\n------------------------\n",
     GEOSGeomTypeId_r,
-    &GEOSGeomTypeId_r,
+    GEOSGeomTypeId,
     GEOSGetNumGeometries_r,
     GEOSGetNumCoordinates_r,
     GEOSGeom_getDimensions_r,

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -804,7 +804,7 @@ finish:
 static PyUFuncGenericFunction Y_d_funcs[1] = {&Y_d_func};
 
 /* Define the geom -> int functions (Y_i) */
-static void* get_type_id_data[1] = {GEOSGeomTypeId_r};
+static void* get_type_id_data[1] = {&GEOSGeomTypeId_r};
 static void* get_dimensions_data[1] = {GEOSGeom_getDimensions_r};
 static void* get_coordinate_dimension_data[1] = {GEOSGeom_getCoordinateDimension_r};
 static void* get_srid_data[1] = {GEOSGetSRID_r};

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -166,7 +166,7 @@ static PyUFuncGenericFunction Y_b_funcs[1] = {&Y_b_func};
 /* Define the object -> bool functions (O_b) which do not raise on non-geom objects*/
 static char IsMissing(void* context, PyObject* obj) {
   GEOSGeometry* g = NULL;
-  if (!get_geom((GeometryObject *) obj, &g)) {
+  if (!get_geom((GeometryObject*)obj, &g)) {
     return 0;
   };
   return g == NULL;  // get_geom sets g to NULL for None input
@@ -174,7 +174,7 @@ static char IsMissing(void* context, PyObject* obj) {
 static void* is_missing_data[1] = {IsMissing};
 static char IsGeometry(void* context, PyObject* obj) {
   GEOSGeometry* g = NULL;
-  if (!get_geom((GeometryObject *) obj, &g)) {
+  if (!get_geom((GeometryObject*)obj, &g)) {
     return 0;
   }
   return g != NULL;
@@ -182,7 +182,7 @@ static char IsGeometry(void* context, PyObject* obj) {
 static void* is_geometry_data[1] = {IsGeometry};
 static char IsValidInput(void* context, PyObject* obj) {
   GEOSGeometry* g = NULL;
-  return get_geom((GeometryObject *) obj, &g);
+  return get_geom((GeometryObject*)obj, &g);
 }
 static void* is_valid_input_data[1] = {IsValidInput};
 typedef char FuncGEOS_O_b(void* context, PyObject* obj);
@@ -835,8 +835,8 @@ static void Y_i_func(char** args, npy_intp* dimensions, npy_intp* steps, void* d
   GEOSGeometry* in1 = NULL;
   int result;
 
-  // DEBUG: print which function signature is called here; this seems to behave differently
-  // on windows
+  // DEBUG: print which function signature is called here; this seems to behave
+  // differently on windows
   int match = 0;
   if ((void*)func == GEOSGeomTypeId_r) {
     printf("C ext: GEOSGeomTypeId_r\n");
@@ -879,7 +879,6 @@ static void Y_i_func(char** args, npy_intp* dimensions, npy_intp* steps, void* d
 
   int none_value;
   if (((void*)func == GetNumPoints) || ((void*)func == GetNumInteriorRings) ||
-      ((void*)func == GEOSGetNumGeometries_r) ||
       ((void*)func == GEOSGetNumGeometries_r) ||
       ((void*)func == GEOSGetNumCoordinates_r)) {
     none_value = 0;


### PR DESCRIPTION
Resolves #218  
Resolves #234

Previously, `get_num_geometries`, `get_num_coordinates`, `get_num_points`, `get_num_interior_rings` returned -1 for non-geometry values (`None`).

This changes the API to return 0 instead, which is more appropriate for counting type functions, since users may sum these values to perform subsequent operations as noted in #218, #197.

The only previously-stated return value that is changed here is for `get_num_coordinates`; the return value was not previously declared in docstrings for the other functions and -1 is likely unexpected for them.