### PR TITLE
TST: Fix make_valid tests for OverlayNG (normalize result/expected)

### DIFF
--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -119,12 +119,12 @@ def test_make_valid_none():
         # an L shaped polygon without area is converted to a multilinestring
         (
             Geometry("POLYGON((0 0, 1 1, 1 2, 1 1, 0 0))"),
-            Geometry("MULTILINESTRING ((0 0, 1 1), (1 1, 1 2))"),
+            Geometry("MULTILINESTRING ((1 1, 1 2), (0 0, 1 1))"),
         ),
         # a polygon with self-intersection (bowtie) is converted into polygons
         (
             Geometry("POLYGON((0 0, 2 2, 2 0, 0 2, 0 0))"),
-            Geometry("MULTIPOLYGON (((1 1, 0 0, 0 2, 1 1)), ((1 1, 2 2, 2 0, 1 1)))"),
+            Geometry("MULTIPOLYGON (((1 1, 2 2, 2 0, 1 1)), ((0 0, 0 2, 1 1, 0 0)))"),
         ),
         (empty, empty),
         ([empty], [empty])
@@ -133,7 +133,8 @@ def test_make_valid_none():
 def test_make_valid(geom, expected):
     actual = pygeos.make_valid(geom)
     assert actual is not expected
-    assert pygeos.normalize(actual) == pygeos.normalize(expected)
+    assert pygeos.normalize(actual) == expected
+
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
 @pytest.mark.parametrize(

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -133,6 +133,7 @@ def test_make_valid_none():
 def test_make_valid(geom, expected):
     actual = pygeos.make_valid(geom)
     assert actual is not expected
+    # normalize needed to handle variation in output across GEOS versions
     assert pygeos.normalize(actual) == expected
 
 
@@ -159,6 +160,7 @@ def test_make_valid(geom, expected):
 )
 def test_make_valid_1d(geom, expected):
     actual = pygeos.make_valid(geom)
+    # normalize needed to handle variation in output across GEOS versions
     assert np.all(pygeos.normalize(actual) == pygeos.normalize(expected))
 
 

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -133,7 +133,7 @@ def test_make_valid_none():
 def test_make_valid(geom, expected):
     actual = pygeos.make_valid(geom)
     assert actual is not expected
-    assert actual == expected
+    assert pygeos.normalize(actual) == pygeos.normalize(expected)
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
 @pytest.mark.parametrize(
@@ -158,7 +158,7 @@ def test_make_valid(geom, expected):
 )
 def test_make_valid_1d(geom, expected):
     actual = pygeos.make_valid(geom)
-    assert np.all(actual == expected)
+    assert np.all(pygeos.normalize(actual) == pygeos.normalize(expected))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I tested the new OverlayNG a while ago, and we only had 2 failures related to `make_valid`. But both are just a change in coordinate order and solved by using spatial equality or normalizing the resulting and expected multipolygon first.

