### PR TITLE
Add Cython to RTD build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - python==3.6.*
   - geos==3.8.0
   - numpydoc==0.7.*
+  - Cython==0.29.*

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,8 @@ name: pygeos
 channels:
   - defaults
 dependencies:
-  - python==3.6.*
-  - geos==3.8.0
-  - numpydoc==0.7.*
+  - python==3.8.*
+  - geos==3.8.*
+  - numpy==1.19.*
+  - numpydoc==1.1.*
   - Cython==0.29.*


### PR DESCRIPTION
This should fix our build at readthedocs

Also I redid the github integration and granted the RTD app access to update the status of projects in the pygeos organisation. The success (or failure) of the RTD build should now appear at each pull request (including this one).

See https://docs.readthedocs.io/en/stable/guides/autobuild-docs-for-pull-requests.html#features for further reading.