### PR TITLE
CI: Cull windows tests and shorten name

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -1,4 +1,4 @@
-name: Test using Conda environments
+name: Conda
 
 on: [push, pull_request]
 
@@ -34,18 +34,6 @@ jobs:
           - os: macos-latest
             python: 3.8
             channel: conda-forge
-          - os: windows-latest
-            python: 3.6
-            geos: 3.6
-            numpy: 1.13
-          - os: windows-latest
-            python: 3.7
-            geos: 3.7
-            numpy: 1.15
-          - os: windows-latest
-            python: 3.8
-            geos: 3.8
-            numpy: 1.17
           - os: windows-latest
             python: 3.8
             channel: defaults

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   TestConda:
-    name: ${{ matrix.os }} - Python ${{ matrix.python }} (GEOS ${{ matrix.geos || 'latest' }}, numpy ${{ matrix.numpy || 'latest' }}, conda ${{ matrix.channel || 'defaults' }})
+    name: ${{ matrix.os }} - ${{ matrix.channel || 'defaults' }}) - Python ${{ matrix.python }} (GEOS ${{ matrix.geos || 'latest' }}, numpy ${{ matrix.numpy || 'latest' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   TestConda:
-    name: ${{ matrix.os }} - ${{ matrix.channel || 'defaults' }}) - Python ${{ matrix.python }} (GEOS ${{ matrix.geos || 'latest' }}, numpy ${{ matrix.numpy || 'latest' }}
+    name: ${{ matrix.os }} - ${{ matrix.channel || 'defaults' }} - Python ${{ matrix.python }} (GEOS ${{ matrix.geos || 'latest' }}, numpy ${{ matrix.numpy || 'latest' }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -16,6 +16,12 @@ jobs:
           - os: ubuntu-latest
             python: 3.8
             channel: conda-forge
+          - os: windows-latest
+            python: 3.8
+            channel: conda-forge
+          - os: macos-latest
+            python: 3.8
+            channel: conda-forge
           - os: macos-latest
             python: 3.6
             geos: 3.6
@@ -31,15 +37,6 @@ jobs:
           - os: macos-latest
             python: 3.8
             channel: defaults
-          - os: macos-latest
-            python: 3.8
-            channel: conda-forge
-          - os: windows-latest
-            python: 3.8
-            channel: defaults
-          - os: windows-latest
-            python: 3.8
-            channel: conda-forge
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,12 @@ PyGEOS
 	:alt: Appveyor CI status
 	:target: https://ci.appveyor.com/project/caspervdw/pygeos-3e5cu
 
+.. Github Actions status — https://github.com/pygeos/pygeos/actions
+
+.. image:: https://github.com/pygeos/pygeos/workflows/Conda/badge.svg
+	:alt: Github Actions status
+	:target: https://github.com/pygeos/pygeos/actions?query=workflow%3AConda
+
 .. PyPI
 
 .. image:: https://badge.fury.io/py/pygeos.svg


### PR DESCRIPTION
Following #222 and #219, I think we should drop the older windows tests. They are covered by appveyor.

Also I shortened the name so that you can see the differences between builds in the Github status reports below a PR.