### PR TITLE
Integrate previously prepared geometries into STRtree query / bulk query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,8 @@ Version 0.9 (unreleased)
 * Fixed internal GEOS error code detection for ``get_dimensions`` and ``get_srid`` (#218).
 * Addition of ``prepare`` function that generates a GEOS prepared geometry which is stored on
   the Geometry object itself. All binary predicates (except ``equals``) make use of this (#92).
-
+* Use previously prepared geometries within ``STRtree`` ``query`` and ``query_bulk``
+  functions if available (#246).
 
 Version 0.8 (2020-09-06)
 ------------------------

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -217,6 +217,15 @@ def test_query_tree_with_none():
 
 ### predicate == 'intersects'
 
+
+def test_query_with_prepared(tree):
+    geom = box(0, 0, 1, 1)
+    expected = tree.query(geom, predicate="intersects")
+
+    pygeos.prepare(geom)
+    assert_array_equal(expected, tree.query(geom, predicate="intersects"))
+
+
 # TEMPORARY xfail: MultiPoint intersects with prepared geometries does not work
 # properly on GEOS 3.5.x; it was fixed in 3.6+
 @pytest.mark.parametrize(
@@ -1044,6 +1053,20 @@ def test_query_bulk_invalid_predicate(tree):
 
 
 ### predicate == 'intersects'
+
+
+def test_query_bulk_with_prepared(tree):
+    geom = np.array([box(0, 0, 1, 1), box(3, 3, 5, 5)])
+    expected = tree.query_bulk(geom, predicate="intersects")
+
+    # test with array of partially prepared geometries
+    pygeos.prepare(geom[0])
+    assert_array_equal(expected, tree.query_bulk(geom, predicate="intersects"))
+
+    # test with fully prepared geometries
+    pygeos.prepare(geom)
+    assert_array_equal(expected, tree.query_bulk(geom, predicate="intersects"))
+
 
 # TEMPORARY xfail: MultiPoint intersects with prepared geometries does not work
 # properly on GEOS 3.5.x; it was fixed in 3.6+


### PR DESCRIPTION
Resolves #235 

The overall strategy is to fetch both the original and prepared geometry from the `GeometryObject`, and only prepare internally within `evaluate_predicate` if not previously prepared.

Checked with valgrind to make sure we're not leaving prepared geometries around accidentally.


I discovered and corrected an autoformatting issue with the doc string for `evaluate_predicate`, hence the larger number of lines changed (the autoformatter previously rolled all params into single paragraph, to avoid this I made them separated by lines).

