### PR TITLE
FIX: Consistent behaviour for all reduction set_operations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,10 @@ Version 0.9 (unreleased)
 * API change: geometry and counting functions (``get_num_coordinates``,
   ``get_num_geometries``, ``get_num_interior_rings``, ``get_num_points``) now return 0
   for ``None`` input values instead of -1 (#218).
+* API change: ``intersection_all`` and ``symmetric_difference_all`` now ignore None values
+  instead of returning None if any value is None (#249).
+* API change: ``union_all`` now returns None (instead of ``GEOMETRYCOLLECTION EMPTY``) if
+  all input values are None (#249).
 * Fixed internal GEOS error code detection for ``get_dimensions`` and ``get_srid`` (#218).
 * Addition of ``prepare`` function that generates a GEOS prepared geometry which is stored on
   the Geometry object itself. All binary predicates (except ``equals``) make use of this (#92).

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -61,6 +61,8 @@ def intersection(a, b, **kwargs):
 def intersection_all(geometries, axis=0, **kwargs):
     """Returns the intersection of multiple geometries.
 
+    This function ignores None values. If all inputs are None, None is returned.
+
     Parameters
     ----------
     geometries : array_like
@@ -81,7 +83,7 @@ def intersection_all(geometries, axis=0, **kwargs):
     >>> intersection_all([line_1, line_2])
     <pygeos.Geometry LINESTRING (1 1, 2 2)>
     >>> intersection_all([[line_1, line_2, None]], axis=1).tolist()
-    [None]
+    [<pygeos.Geometry LINESTRING (1 1, 2 2)>]
     """
     return lib.intersection.reduce(geometries, axis=axis, **kwargs)
 
@@ -111,6 +113,8 @@ def symmetric_difference(a, b, **kwargs):
 def symmetric_difference_all(geometries, axis=0, **kwargs):
     """Returns the symmetric difference of multiple geometries.
 
+    This function ignores None values. If all inputs are None, None is returned.
+
     Parameters
     ----------
     geometries : array_like
@@ -131,7 +135,7 @@ def symmetric_difference_all(geometries, axis=0, **kwargs):
     >>> symmetric_difference_all([line_1, line_2])
     <pygeos.Geometry MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))>
     >>> symmetric_difference_all([[line_1, line_2, None]], axis=1).tolist()
-    [None]
+    [<pygeos.Geometry MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))>]
     """
     return lib.symmetric_difference.reduce(geometries, axis=axis, **kwargs)
 
@@ -161,6 +165,8 @@ def union(a, b, **kwargs):
 @multithreading_enabled
 def union_all(geometries, axis=0, **kwargs):
     """Returns the union of multiple geometries.
+
+    This function ignores None values. If all inputs are None, None is returned.
 
     Parameters
     ----------
@@ -196,7 +202,15 @@ def union_all(geometries, axis=0, **kwargs):
         )
     # create_collection acts on the inner axis
     collections = lib.create_collection(geometries, GeometryType.GEOMETRYCOLLECTION)
-    return lib.unary_union(collections, **kwargs)
+    result = lib.unary_union(collections, **kwargs)
+    # for consistency with other _all functions, we replace GEOMETRY COLLECTION EMPTY
+    # if the original collection had no geometries
+    only_none = lib.get_num_geometries(collections) == 0
+    if np.isscalar(only_none):
+        return result if not only_none else None
+    else:
+        result[lib.get_num_geometries(collections) == 0] = None
+        return result
 
 
 @requires_geos("3.8.0")

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -209,7 +209,7 @@ def union_all(geometries, axis=0, **kwargs):
     if np.isscalar(only_none):
         return result if not only_none else None
     else:
-        result[lib.get_num_geometries(collections) == 0] = None
+        result[only_none] = None
         return result
 
 

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -61,7 +61,8 @@ def intersection(a, b, **kwargs):
 def intersection_all(geometries, axis=0, **kwargs):
     """Returns the intersection of multiple geometries.
 
-    This function ignores None values. If all inputs are None, None is returned.
+    This function ignores None values when other Geometry elements are present.
+    If all elements of the given axis are None, None is returned.
 
     Parameters
     ----------
@@ -113,7 +114,8 @@ def symmetric_difference(a, b, **kwargs):
 def symmetric_difference_all(geometries, axis=0, **kwargs):
     """Returns the symmetric difference of multiple geometries.
 
-    This function ignores None values. If all inputs are None, None is returned.
+    This function ignores None values when other Geometry elements are present.
+    If all elements of the given axis are None, None is returned.
 
     Parameters
     ----------
@@ -166,7 +168,8 @@ def union(a, b, **kwargs):
 def union_all(geometries, axis=0, **kwargs):
     """Returns the union of multiple geometries.
 
-    This function ignores None values. If all inputs are None, None is returned.
+    This function ignores None values when other Geometry elements are present.
+    If all elements of the given axis are None, None is returned.
 
     Parameters
     ----------

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -97,6 +97,14 @@ def test_set_operation_reduce_all_none(n, func, related_func):
     assert func([None] * n) is None
 
 
+@pytest.mark.parametrize("n", range(1, 3))
+@pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
+def test_set_operation_reduce_all_none_arr(n, func, related_func):
+    # API change: before, union_all([None]) yielded EMPTY GEOMETRYCOLLECTION
+    # The new behaviour is that it returns None if all inputs are None.
+    assert func([[None] * n] * 2, axis=1).tolist() == [None, None]
+
+
 @pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8")
 @pytest.mark.parametrize("n", range(1, 4))
 def test_coverage_union_reduce_1dim(n):

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -65,12 +65,26 @@ def test_set_operation_reduce_axis(func, related_func):
     assert actual.shape == (3,)
 
 
+@pytest.mark.parametrize("none_position", range(3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
-def test_set_operation_reduce_any_none(func, related_func):
+def test_set_operation_reduce_one_none(func, related_func, none_position):
     # API change: before, intersection_all and symmetric_difference_all returned
     # None if any input geometry was None.
     # The new behaviour is to ignore None values.
-    actual = func(reduce_test_data[:2] + [None])
+    test_data = reduce_test_data[:2]
+    test_data.insert(none_position, None)
+    actual = func(test_data)
+    expected = related_func(reduce_test_data[0], reduce_test_data[1])
+    assert pygeos.equals(actual, expected)
+
+
+@pytest.mark.parametrize("none_position", range(3))
+@pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
+def test_set_operation_reduce_two_none(func, related_func, none_position):
+    test_data = reduce_test_data[:2]
+    test_data.insert(none_position, None)
+    test_data.insert(none_position, None)
+    actual = func(test_data)
     expected = related_func(reduce_test_data[0], reduce_test_data[1])
     assert pygeos.equals(actual, expected)
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -726,11 +726,13 @@ static void YY_Y_func_reduce(char** args, npy_intp* dimensions, npy_intp* steps,
     errstate = PGERR_NOT_A_GEOMETRY;
   } else {
     BINARY_LOOP {
-      // Cleanup previous in1
       if (in1_is_temp && (in1 != NULL)) {
-        // If i == 0, in1 is NULL
-        // If i == 1, in1 is the first input, which is owned by python
-        // If in1 == NULL (None in Python terms), we are skipping it
+        /* Cleanup previous in1 if necessary:
+         * On the first iteration, in1 is NULL
+         * On the second iteration, int1_is_temp == 0 because in1 is owned by python.
+         * On the third iteration, in1_is_temp == 1. Unless some NULL values were
+         * encountered.
+         */
         GEOSGeom_destroy_r(ctx, in1);
       }
       // This is the main reduce logic: in1 becomes previous out
@@ -741,6 +743,8 @@ static void YY_Y_func_reduce(char** args, npy_intp* dimensions, npy_intp* steps,
         errstate = PGERR_NOT_A_GEOMETRY;
         break;
       }
+      // Now there are 4 possible situations:
+      // 1. (not NULL, not NULL); run the GEOS function
       if ((in1 != NULL) && (in2 != NULL)) {
         out = func(ctx, in1, in2);
         if (out == NULL) {
@@ -748,13 +752,18 @@ static void YY_Y_func_reduce(char** args, npy_intp* dimensions, npy_intp* steps,
           break;
         }
         out_is_temp = 1;  // Call GEOSGeom_destroy_r on this geometry later
-      } else if ((in1 == NULL) && (in2 != NULL)) {
+      }
+      // 2. (NULL, not NULL); When the first element of the reduction axis is None
+      else if ((in1 == NULL) && (in2 != NULL)) {
         out = in2;
         out_is_temp = 0;  // Skips calling GEOSGeom_destroy_r on this geometry
+        // 3. (not NULL, NULL); When a None value is encountered after the first not-None
       } else if ((in1 != NULL) && (in2 == NULL)) {
         // out already equals in1! but be sure it is not cleaned up
         in1_is_temp = out_is_temp = 0;
       }
+      // 4. (NULL, NULL); When 1st and 2nd elements of a reduction axis are None
+      //   Do nothing
     }
     // We need to cleanup the intermediate geometry stored in in1.
     if (in1_is_temp && (in1 != NULL)) {


### PR DESCRIPTION
Closes #37. API changes:

- `intersection_all` and `symmetric_difference_all` now ignore None values, rather than returning None if any value is None
- `union_all` (instead of `GEOMETRYCOLLECTION EMPTY`) now returns None if all input values are None

Memory-leak tested with valgrind.
