### PR TITLE
ENH: Add get / set precision ufuncs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ Version 0.9 (unreleased)
   functions if available (#246).
 * Ensure that ``python setup.py clean`` removes all previously Cythonized and compiled
   files (#239).
+* Addition of ``get_precision`` to get precision of a geometry and ``set_precision``
+  to set the precision of a geometry (may round and reduce coordinates).
 
 Version 0.8 (2020-09-06)
 ------------------------

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -546,8 +546,8 @@ def get_num_geometries(geometry):
 def get_precision(geometry):
     """Get the precision of a geometry.
 
-    If a precision has not been previously set, it will be 0 (floating point precision).
-    Otherwise, it will return the grid size that was set on a geometry.
+    If a precision has not been previously set, it will be 0 (double precision).
+    Otherwise, it will return the precision grid size that was set on a geometry.
 
     Returns NaN for not-a-geometry values.
 
@@ -561,11 +561,11 @@ def get_precision(geometry):
 
     Examples
     --------
-    >>> get_precision(Geometry("POINT (1 1)")) == 0
-    True
-    >>> geometry = set_precision(Geometry("POINT (1 1)"), 1)
-    >>> get_precision(geometry) == 1
-    True
+    >>> get_precision(Geometry("POINT (1 1)"))
+    0.0
+    >>> geometry = set_precision(Geometry("POINT (1 1)"), 1.0)
+    >>> get_precision(geometry)
+    1.0
     >>> np.isnan(get_precision(None))
     True
     """
@@ -574,8 +574,10 @@ def get_precision(geometry):
 
 @requires_geos("3.6.0")
 @multithreading_enabled
-def set_precision(geometry, grid_size=0, preserve_topology=False):
+def set_precision(geometry, grid_size, preserve_topology=False):
     """Returns geometry with the precision set to a precision grid size.
+
+    By default, geometries use double precision coordinates (grid_size = 0).
 
     Coordinates will be rounded if a precision grid is less precise than the input
     geometry. Duplicated vertices will be dropped from lines and polygons for grid sizes greater
@@ -594,8 +596,10 @@ def set_precision(geometry, grid_size=0, preserve_topology=False):
     Parameters
     ----------
     geometry : Geometry or array_like
-    grid_size : double, optional (default: 0)
-        precision grid size.  If 0, will use floating point precision.
+    grid_size : double
+        precision grid size.  If 0, will use double precision (will not modify geometry
+        if precision grid size was not previously set).  If this value is more
+        precise than input geometry, the input geometry will not be modified.
     preserve_topology : bool, optional (default: False)
         If True, will attempt to preserve the topology of a geometry after rounding
         coordinates.
@@ -606,13 +610,13 @@ def set_precision(geometry, grid_size=0, preserve_topology=False):
 
     Examples
     --------
-    >>> set_precision(Geometry("POINT (0.9 0.9)"), 1)
+    >>> set_precision(Geometry("POINT (0.9 0.9)"), 1.0)
     <pygeos.Geometry POINT (1 1)>
-    >>> set_precision(Geometry("POINT (0.9 0.9 0.9)"), 1)
+    >>> set_precision(Geometry("POINT (0.9 0.9 0.9)"), 1.0)
     <pygeos.Geometry POINT Z (1 1 0.9)>
-    >>> set_precision(Geometry("LINESTRING (0 0, 0 0.1, 0 1, 1 1)"), 1)
+    >>> set_precision(Geometry("LINESTRING (0 0, 0 0.1, 0 1, 1 1)"), 1.0)
     <pygeos.Geometry LINESTRING (0 0, 0 1, 1 1)>
-    >>> set_precision(None) is None
+    >>> set_precision(None, 1.0) is None
     True
     """
 

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -546,8 +546,9 @@ def get_num_geometries(geometry):
 def get_precision(geometry):
     """Get the precision of a geometry.
 
-    If a precision has not been previously set, it will be 0 (double precision).
-    Otherwise, it will return the precision grid size that was set on a geometry.
+    If a precision has not been previously set, it will be 0 (double
+    precision). Otherwise, it will return the precision grid size that was
+    set on a geometry.
 
     Returns NaN for not-a-geometry values.
 
@@ -579,30 +580,32 @@ def set_precision(geometry, grid_size, preserve_topology=False):
 
     By default, geometries use double precision coordinates (grid_size = 0).
 
-    Coordinates will be rounded if a precision grid is less precise than the input
-    geometry. Duplicated vertices will be dropped from lines and polygons for grid sizes greater
-    than 0. Line and polygon geometries may collapse to empty geometries if all vertices are
-    closer together than grid_size. Z values, if present, will not be modified.
+    Coordinates will be rounded if a precision grid is less precise than the
+    input geometry. Duplicated vertices will be dropped from lines and
+    polygons for grid sizes greater than 0. Line and polygon geometries may
+    collapse to empty geometries if all vertices are closer together than
+    grid_size. Z values, if present, will not be modified.
 
-    Note: subsequent operations will always be performed in the precision
-    of the geometry with higher precision (smaller "grid_size"). That same precision will
-    be attached to the operation outputs.
+    Note: subsequent operations will always be performed in the precision of
+    the geometry with higher precision (smaller "grid_size"). That same
+    precision will be attached to the operation outputs.
 
-    Also note: input geometries should be geometrically valid; unexpected results may
-    occur if input geometries are not.
+    Also note: input geometries should be geometrically valid; unexpected
+    results may occur if input geometries are not.
 
     Returns None if geometry is None.
 
     Parameters
     ----------
     geometry : Geometry or array_like
-    grid_size : double
-        precision grid size.  If 0, will use double precision (will not modify geometry
-        if precision grid size was not previously set).  If this value is more
-        precise than input geometry, the input geometry will not be modified.
+    grid_size : float
+        Precision grid size. If 0, will use double precision (will not modify
+        geometry if precision grid size was not previously set). If this
+        value is more precise than input geometry, the input geometry will
+        not be modified.
     preserve_topology : bool, optional (default: False)
-        If True, will attempt to preserve the topology of a geometry after rounding
-        coordinates.
+        If True, will attempt to preserve the topology of a geometry after
+        rounding coordinates.
 
     See also
     --------

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -579,6 +579,9 @@ def set_precision(geometry, grid_size=0, preserve_topology=False):
     coordinates in the geometry to the precision grid if less precise than the input
     geometry.
 
+    Duplicated vertices will be dropped from lines and polygons for grid sizes greater
+    than 0.
+
     Line and polygon geometries may collapse to empty geometries if all vertices are
     closer together than grid_size.
 
@@ -612,9 +615,10 @@ def set_precision(geometry, grid_size=0, preserve_topology=False):
     <pygeos.Geometry POINT (1 1)>
     >>> set_precision(Geometry("POINT (0.9 0.9 0.9)"), 1)
     <pygeos.Geometry POINT Z (1 1 0.9)>
+    >>> set_precision(Geometry("LINESTRING (0 0, 0 0.1, 0 1, 1 1)"), 1)
+    <pygeos.Geometry LINESTRING (0 0, 0 1, 1 1)>
     >>> set_precision(None) is None
     True
     """
 
     return lib.set_precision(geometry, grid_size, preserve_topology)
-

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -574,16 +574,15 @@ def get_precision(geometry):
 
 @requires_geos("3.6.0")
 @multithreading_enabled
-def set_precision(geometry, grid_size=0, preserve_topology=False, keep_collapsed=False):
+def set_precision(geometry, grid_size=0, preserve_topology=False):
     """Returns geometry with the precision set to the precision grid size, rounding all
     coordinates in the geometry to the precision grid if less precise than the input
     geometry.
 
-    Z values, if present, will not be modified.
+    Line and polygon geometries may collapse to empty geometries if all vertices are
+    closer together than grid_size.
 
-    If keep_collapsed is True, linestrings and linearrings will be retained
-    if they would otherwise collapse to empty geometry.  Polygons always collapse, even
-    if keep_collapsed is True.
+    Z values, if present, will not be modified.
 
     Note: subsequent operations will always be performed in the precision
     of the geometry with higher precision (smaller "grid_size"). That same precision will
@@ -602,8 +601,6 @@ def set_precision(geometry, grid_size=0, preserve_topology=False, keep_collapsed
     preserve_topology : bool, optional (default: False)
         If True, will attempt to preserve the topology of the geometry after rounding
         coordinates.
-    keep_collapsed : bool, optional (default: False)
-        If True, will retain collapsed elements.
 
     See also
     --------
@@ -619,5 +616,5 @@ def set_precision(geometry, grid_size=0, preserve_topology=False, keep_collapsed
     True
     """
 
-    return lib.set_precision(geometry, grid_size, preserve_topology, keep_collapsed)
+    return lib.set_precision(geometry, grid_size, preserve_topology)
 

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -27,7 +27,7 @@ __all__ = [
     "get_geometry",
     "get_parts",
     "get_precision",
-    "set_precision"
+    "set_precision",
 ]
 
 
@@ -541,7 +541,7 @@ def get_num_geometries(geometry):
     return lib.get_num_geometries(geometry)
 
 
-
+@requires_geos("3.6.0")
 @multithreading_enabled
 def get_precision(geometry):
     """Get the precision of the geometry.
@@ -572,6 +572,7 @@ def get_precision(geometry):
     return lib.get_precision(geometry)
 
 
+@requires_geos("3.6.0")
 @multithreading_enabled
 def set_precision(geometry, grid_size=0, preserve_topology=False, keep_collapsed=False):
     """Returns geometry with the precision set to the precision grid size, rounding all

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -544,10 +544,10 @@ def get_num_geometries(geometry):
 @requires_geos("3.6.0")
 @multithreading_enabled
 def get_precision(geometry):
-    """Get the precision of the geometry.
+    """Get the precision of a geometry.
 
-    If the precision has not been previously set, it will be 0 (floating point precision).
-    Otherwise, it will return the grid size that was set on the geometry.
+    If a precision has not been previously set, it will be 0 (floating point precision).
+    Otherwise, it will return the grid size that was set on a geometry.
 
     Returns NaN for not-a-geometry values.
 
@@ -575,17 +575,12 @@ def get_precision(geometry):
 @requires_geos("3.6.0")
 @multithreading_enabled
 def set_precision(geometry, grid_size=0, preserve_topology=False):
-    """Returns geometry with the precision set to the precision grid size, rounding all
-    coordinates in the geometry to the precision grid if less precise than the input
-    geometry.
+    """Returns geometry with the precision set to a precision grid size.
 
-    Duplicated vertices will be dropped from lines and polygons for grid sizes greater
-    than 0.
-
-    Line and polygon geometries may collapse to empty geometries if all vertices are
-    closer together than grid_size.
-
-    Z values, if present, will not be modified.
+    Coordinates will be rounded if a precision grid is less precise than the input
+    geometry. Duplicated vertices will be dropped from lines and polygons for grid sizes greater
+    than 0. Line and polygon geometries may collapse to empty geometries if all vertices are
+    closer together than grid_size. Z values, if present, will not be modified.
 
     Note: subsequent operations will always be performed in the precision
     of the geometry with higher precision (smaller "grid_size"). That same precision will
@@ -602,7 +597,7 @@ def set_precision(geometry, grid_size=0, preserve_topology=False):
     grid_size : double, optional (default: 0)
         precision grid size.  If 0, will use floating point precision.
     preserve_topology : bool, optional (default: False)
-        If True, will attempt to preserve the topology of the geometry after rounding
+        If True, will attempt to preserve the topology of a geometry after rounding
         coordinates.
 
     See also

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -26,6 +26,8 @@ __all__ = [
     "get_interior_ring",
     "get_geometry",
     "get_parts",
+    "get_precision",
+    "set_precision"
 ]
 
 
@@ -537,3 +539,84 @@ def get_num_geometries(geometry):
     0
     """
     return lib.get_num_geometries(geometry)
+
+
+
+@multithreading_enabled
+def get_precision(geometry):
+    """Get the precision of the geometry.
+
+    If the precision has not been previously set, it will be 0 (floating point precision).
+    Otherwise, it will return the grid size that was set on the geometry.
+
+    Returns NaN for not-a-geometry values.
+
+    Parameters
+    ----------
+    geometry : Geometry or array_like
+
+    See also
+    --------
+    set_precision
+
+    Examples
+    --------
+    >>> get_precision(Geometry("POINT (1 1)")) == 0
+    True
+    >>> geometry = set_precision(Geometry("POINT (1 1)"), 1)
+    >>> get_precision(geometry) == 1
+    True
+    >>> np.isnan(get_precision(None))
+    True
+    """
+    return lib.get_precision(geometry)
+
+
+@multithreading_enabled
+def set_precision(geometry, grid_size=0, preserve_topology=False, keep_collapsed=False):
+    """Returns geometry with the precision set to the precision grid size, rounding all
+    coordinates in the geometry to the precision grid if less precise than the input
+    geometry.
+
+    Z values, if present, will not be modified.
+
+    If keep_collapsed is True, linestrings and linearrings will be retained
+    if they would otherwise collapse to empty geometry.  Polygons always collapse, even
+    if keep_collapsed is True.
+
+    Note: subsequent operations will always be performed in the precision
+    of the geometry with higher precision (smaller "grid_size"). That same precision will
+    be attached to the operation outputs.
+
+    Also note: input geometries should be geometrically valid; unexpected results may
+    occur if input geometries are not.
+
+    Returns None if geometry is None.
+
+    Parameters
+    ----------
+    geometry : Geometry or array_like
+    grid_size : double, optional (default: 0)
+        precision grid size.  If 0, will use floating point precision.
+    preserve_topology : bool, optional (default: False)
+        If True, will attempt to preserve the topology of the geometry after rounding
+        coordinates.
+    keep_collapsed : bool, optional (default: False)
+        If True, will retain collapsed elements.
+
+    See also
+    --------
+    get_precision
+
+    Examples
+    --------
+    >>> set_precision(Geometry("POINT (0.9 0.9)"), 1)
+    <pygeos.Geometry POINT (1 1)>
+    >>> set_precision(Geometry("POINT (0.9 0.9 0.9)"), 1)
+    <pygeos.Geometry POINT Z (1 1 0.9)>
+    >>> set_precision(None) is None
+    True
+    """
+
+    return lib.set_precision(geometry, grid_size, preserve_topology, keep_collapsed)
+

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -405,6 +405,16 @@ def test_set_precision():
 
     assert np.all(np.isnan(pygeos.get_coordinates(pygeos.set_precision(point_nan, 1))))
 
+    # will not drop duplicated points in original
+    geometry = pygeos.set_precision(
+        pygeos.Geometry("LINESTRING (0 0, 0 0, 0 1, 1 1)"), 0
+    )
+    assert pygeos.equals(geometry, pygeos.Geometry("LINESTRING (0 0, 0 0, 0 1, 1 1)"))
+
+    # setting precision will remove duplicated points
+    geometry = pygeos.set_precision(geometry, 1)
+    assert pygeos.equals(geometry, pygeos.Geometry("LINESTRING (0 0, 0 1, 1 1)"))
+
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision_none():

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -364,6 +364,7 @@ def test_get_parts_invalid_geometry(geom):
         pygeos.get_parts(geom)
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_get_precision():
     geometries = all_types + (point_z, empty_point, empty_line_string, empty_polygon)
     # default is 0
@@ -378,6 +379,7 @@ def test_get_precision():
     assert np.all(np.isnan(pygeos.get_precision([None])))
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision():
     initial_geometry = pygeos.Geometry("POINT (0.9 0.9)")
     assert pygeos.get_precision(initial_geometry) == 0
@@ -400,14 +402,17 @@ def test_set_precision():
     assert np.all(np.isnan(pygeos.get_coordinates(pygeos.set_precision(point_nan, 1))))
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision_none():
     assert pygeos.set_precision(None, 0) is None
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision_nan():
     assert pygeos.set_precision(pygeos.Geometry("POINT (0.9 0.9)"), np.nan) is None
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision_preserve_topology():
     # bowtie
     geometry = pygeos.Geometry("POLYGON((0 0, 2.1 2.1, 2.1 0, 0 2.1, 0 0))")
@@ -440,6 +445,7 @@ def test_set_precision_preserve_topology():
     )
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision_keep_collapsed():
     geometry = pygeos.Geometry("LINESTRING (0 0, 0.1 0.1)")
 
@@ -483,8 +489,14 @@ def test_set_precision_keep_collapsed():
     geometry = pygeos.Geometry("LINEARRING (0 0, 0.1 0, 0.1 0.1, 0 0.1, 0 0)")
 
     # by default, collapses to an empty linearring
-    assert pygeos.equals(pygeos.set_precision(geometry, 1, keep_collapsed=False), pygeos.Geometry("LINEARRING EMPTY"))
+    assert pygeos.equals(
+        pygeos.set_precision(geometry, 1, keep_collapsed=False),
+        pygeos.Geometry("LINEARRING EMPTY"),
+    )
 
     # unlike polygons, linear rings remain uncollapsed
-    assert pygeos.equals_exact(pygeos.set_precision(geometry, 1, keep_collapsed=True), pygeos.Geometry("LINEARRING (0 0, 0 0, 0 0, 0 0, 0 0)"))
+    assert pygeos.equals_exact(
+        pygeos.set_precision(geometry, 1, keep_collapsed=True),
+        pygeos.Geometry("LINEARRING (0 0, 0 0, 0 0, 0 0, 0 0)"),
+    )
 

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -379,7 +379,9 @@ def test_get_precision():
     actual = pygeos.get_precision(geometry).tolist()
     assert actual == [1] * len(geometries)
 
-    assert np.isnan(pygeos.get_precision(None))
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
+def test_get_precision_none():
     assert np.all(np.isnan(pygeos.get_precision([None])))
 
 
@@ -389,7 +391,6 @@ def test_set_precision():
     assert pygeos.get_precision(initial_geometry) == 0
 
     geometry = pygeos.set_precision(initial_geometry, 0)
-    print("geometry", geometry)
     assert pygeos.get_precision(geometry) == 0
     assert pygeos.equals(geometry, initial_geometry)
 
@@ -399,13 +400,10 @@ def test_set_precision():
     # original should remain unchanged
     assert pygeos.equals(initial_geometry, pygeos.Geometry("POINT (0.9 0.9)"))
 
-    geometry = pygeos.set_precision(pygeos.Geometry("POINT Z (0.9 0.9 0.9)"), 1)
-    assert pygeos.get_precision(geometry) == 1
-    assert pygeos.equals(geometry, pygeos.Geometry("POINT Z (1 1 0.9)"))
 
-    assert np.all(np.isnan(pygeos.get_coordinates(pygeos.set_precision(point_nan, 1))))
-
-    # will not drop duplicated points in original
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
+def test_set_precision_drop_coords():
+    # setting precision of 0 will not drop duplicated points in original
     geometry = pygeos.set_precision(
         pygeos.Geometry("LINESTRING (0 0, 0 0, 0 1, 1 1)"), 0
     )
@@ -414,6 +412,18 @@ def test_set_precision():
     # setting precision will remove duplicated points
     geometry = pygeos.set_precision(geometry, 1)
     assert pygeos.equals(geometry, pygeos.Geometry("LINESTRING (0 0, 0 1, 1 1)"))
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
+def test_set_precision_z():
+    geometry = pygeos.set_precision(pygeos.Geometry("POINT Z (0.9 0.9 0.9)"), 1)
+    assert pygeos.get_precision(geometry) == 1
+    assert pygeos.equals(geometry, pygeos.Geometry("POINT Z (1 1 0.9)"))
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
+def test_set_precision_nan():
+    assert np.all(np.isnan(pygeos.get_coordinates(pygeos.set_precision(point_nan, 1))))
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -339,32 +339,20 @@ def test_get_parts_invalid_dimensions(geom):
         pygeos.get_parts(geom)
 
 
-@pytest.mark.parametrize(
-    "geom",
-    [point, line_string, polygon],
-)
+@pytest.mark.parametrize("geom", [point, line_string, polygon])
 def test_get_parts_non_multi(geom):
     """Non-multipart geometries should be returned identical to inputs"""
     assert np.all(pygeos.equals_exact(np.asarray(geom), pygeos.get_parts(geom)))
 
 
-@pytest.mark.parametrize(
-    "geom",
-    [None, [None], []],
-)
+@pytest.mark.parametrize("geom", [None, [None], []])
 def test_get_parts_None(geom):
     assert len(pygeos.get_parts(geom)) == 0
 
 
-@pytest.mark.parametrize(
-    "geom",
-    ["foo", ["foo"], 42],
-)
+@pytest.mark.parametrize("geom", ["foo", ["foo"], 42])
 def test_get_parts_invalid_geometry(geom):
-    with pytest.raises(
-        TypeError,
-        match="One of the arguments is of incorrect type.",
-    ):
+    with pytest.raises(TypeError, match="One of the arguments is of incorrect type."):
         pygeos.get_parts(geom)
 
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -865,7 +865,8 @@ static void* length_data[1] = {GEOSLength_r};
 
 #if GEOS_SINCE_3_6_0
 static int GetPrecision(void* context, void* a, double* b) {
-  // GEOS returns -1 on error; 0 indicates floating point precision
+  // GEOS returns -1 on error; 0 indicates double precision; > 0 indicates a precision
+  // grid size was set for this geometry.
   double out = GEOSGeom_getPrecision_r(context, a);
   if (out == -1) {
     return 0;

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -862,6 +862,8 @@ static void* get_z_data[1] = {GetZ};
 #endif
 static void* area_data[1] = {GEOSArea_r};
 static void* length_data[1] = {GEOSLength_r};
+
+#if GEOS_SINCE_3_6_0
 static int GetPrecision(void* context, void* a, double* b) {
   // GEOS returns -1 on error; 0 indicates floating point precision
   double out = GEOSGeom_getPrecision_r(context, a);
@@ -872,9 +874,7 @@ static int GetPrecision(void* context, void* a, double* b) {
   *(double*)b = out;
   return 1;
 }
-
 static void* get_precision_data[1] = {GetPrecision};
-#if GEOS_SINCE_3_6_0
 static int MinimumClearance(void* context, void* a, double* b) {
   // GEOSMinimumClearance deviates from the pattern of returning 0 on exception and 1 on
   // success for functions that return an int (it follows pattern for boolean functions
@@ -1547,6 +1547,7 @@ finish:
 }
 static PyUFuncGenericFunction relate_funcs[1] = {&relate_func};
 
+#if GEOS_SINCE_3_6_0
 static char set_precision_dtypes[5] = {NPY_OBJECT, NPY_DOUBLE, NPY_BOOL, NPY_BOOL, NPY_OBJECT};
 static void set_precision_func(char** args, npy_intp* dimensions, npy_intp* steps,
                                void* data) {
@@ -1602,6 +1603,8 @@ static void set_precision_func(char** args, npy_intp* dimensions, npy_intp* step
 }
 
 static PyUFuncGenericFunction set_precision_funcs[1] = {&set_precision_func};
+#endif
+
 
 /* define double -> geometry construction functions */
 static char points_dtypes[2] = {NPY_DOUBLE, NPY_OBJECT};
@@ -2429,7 +2432,6 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_Y_d(get_y);
   DEFINE_Y_d(area);
   DEFINE_Y_d(length);
-  DEFINE_Y_d(get_precision);
 
   DEFINE_Y_i(get_type_id);
   DEFINE_Y_i(get_dimensions);
@@ -2456,7 +2458,7 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_CUSTOM(voronoi_polygons, 4);
   DEFINE_CUSTOM(is_valid_reason, 1);
   DEFINE_CUSTOM(relate, 2);
-  DEFINE_CUSTOM(set_precision, 4);
+
   DEFINE_GENERALIZED(points, 1, "(d)->()");
   DEFINE_GENERALIZED(linestrings, 1, "(i, d)->()");
   DEFINE_GENERALIZED(linearrings, 1, "(i, d)->()");
@@ -2473,6 +2475,8 @@ int init_ufuncs(PyObject* m, PyObject* d) {
 
 #if GEOS_SINCE_3_6_0
   DEFINE_Y_d(minimum_clearance);
+  DEFINE_Y_d(get_precision);
+  DEFINE_CUSTOM(set_precision, 4);
 #endif
 
 #if GEOS_SINCE_3_7_0

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1548,7 +1548,7 @@ finish:
 static PyUFuncGenericFunction relate_funcs[1] = {&relate_func};
 
 #if GEOS_SINCE_3_6_0
-static char set_precision_dtypes[5] = {NPY_OBJECT, NPY_DOUBLE, NPY_BOOL, NPY_BOOL, NPY_OBJECT};
+static char set_precision_dtypes[4] = {NPY_OBJECT, NPY_DOUBLE, NPY_BOOL, NPY_OBJECT};
 static void set_precision_func(char** args, npy_intp* dimensions, npy_intp* steps,
                                void* data) {
   GEOSGeometry* in1 = NULL;
@@ -1573,12 +1573,11 @@ static void set_precision_func(char** args, npy_intp* dimensions, npy_intp* step
     double in2 = *(double*)ip2;
     // preserve topology
     npy_bool in3 = *(npy_bool*)ip3;
-    // keep collapsed coordinates
-    npy_bool in4 = *(npy_bool*)ip4;
     // flags:
     // GEOS_PREC_NO_TOPO (1<<0): if set, do not try to preserve topology
-    // GEOS_PREC_KEEP_COLLAPSED  (1<<1): if set: keep collapsed coordinates
-    int flags = (!in3) << 0 | in4 << 1;
+    // GEOS_PREC_KEEP_COLLAPSED  (1<<1): Not used because uncollapsed geometries are
+    // invalid and will not be retained in GEOS >= 3.9 anyway.
+    int flags = (!in3) << 0;
 
     if ((in1 == NULL) | npy_isnan(in2)) {
       // in case of a missing value: return NULL (None)
@@ -1597,14 +1596,13 @@ static void set_precision_func(char** args, npy_intp* dimensions, npy_intp* step
 
   // fill the numpy array with PyObjects while holding the GIL
   if (errstate == PGERR_SUCCESS) {
-    geom_arr_to_npy(geom_arr, args[4], steps[4], dimensions[0]);
+    geom_arr_to_npy(geom_arr, args[3], steps[3], dimensions[0]);
   }
   free(geom_arr);
 }
 
 static PyUFuncGenericFunction set_precision_funcs[1] = {&set_precision_func};
 #endif
-
 
 /* define double -> geometry construction functions */
 static char points_dtypes[2] = {NPY_DOUBLE, NPY_OBJECT};
@@ -2476,7 +2474,7 @@ int init_ufuncs(PyObject* m, PyObject* d) {
 #if GEOS_SINCE_3_6_0
   DEFINE_Y_d(minimum_clearance);
   DEFINE_Y_d(get_precision);
-  DEFINE_CUSTOM(set_precision, 4);
+  DEFINE_CUSTOM(set_precision, 3);
 #endif
 
 #if GEOS_SINCE_3_7_0

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -868,7 +868,6 @@ static int GetPrecision(void* context, void* a, double* b) {
   // GEOS returns -1 on error; 0 indicates floating point precision
   double out = GEOSGeom_getPrecision_r(context, a);
   if (out == -1) {
-    *(double*)b = NPY_NAN;
     return 0;
   }
   *(double*)b = out;
@@ -1637,7 +1636,7 @@ static void set_precision_func(char** args, npy_intp* dimensions, npy_intp* step
     // GEOS_PREC_NO_TOPO (1<<0): if set, do not try to preserve topology
     // GEOS_PREC_KEEP_COLLAPSED  (1<<1): Not used because uncollapsed geometries are
     // invalid and will not be retained in GEOS >= 3.9 anyway.
-    int flags = (!in3) << 0;
+    int flags = in3 ? 0 : GEOS_PREC_NO_TOPO;
 
     if ((in1 == NULL) | npy_isnan(in2)) {
       // in case of a missing value: return NULL (None)


### PR DESCRIPTION
This adds get / set precision functions.

A few things to be aware of:
The Default value for `preserve_topology` is `False` to match simplify function; however, in GEOS it defaults to `True`; the choice was out of consistency, but it may well be appropriate to match GEOS.


There may be a couple GEOS bugs discovered in the tests here: 
1. geometrically invalid inputs do not behave as expected with `preserve_topology = True` (we get back only one of the polygons in the expected multipolygon).
2. polygons always collapse to empty polygons regardless of `keep_collapsed` even though linear rings are preserved.

Will need to dig into GEOS a bit more and log bugs there if appropriate.


I did not yet add additional tests to trace the precision through intersection, etc operations to verify the comment (adapted from GEOS) that the highest precision is used and assigned to outputs of those operations.