### PR TITLE
Fix STRtree insert/query to avoid void nullptr

### DIFF
--- a/src/strtree.c
+++ b/src/strtree.c
@@ -172,7 +172,7 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
       Py_INCREF(obj);
       kv_push(GeometryObject*, _geoms, obj);
       count++;
-      GEOSSTRtree_insert_r(ctx, tree, geom, (void*)i);
+      GEOSSTRtree_insert_r(ctx, tree, geom, &i);
     }
   }
 
@@ -199,7 +199,7 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
  * */
 
 void query_callback(void* item, void* user_data) {
-  kv_push(npy_intp, *(npy_intp_vec*)user_data, (npy_intp)item);
+  kv_push(npy_intp, *(npy_intp_vec*)user_data, *(npy_intp*)item);
 }
 
 /* Evaluate the predicate function against a prepared version of geom

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -22,6 +22,7 @@ typedef struct {
   PyObject_HEAD void* ptr;
   npy_intp count;
   pg_geom_obj_vec _geoms;
+  npy_intp_vec _tree_indexes;
 } STRtreeObject;
 
 extern PyTypeObject STRtreeType;


### PR DESCRIPTION
xref https://github.com/pygeos/pygeos/issues/233#issuecomment-735285534 and the discussion the geos-devel mailing list (https://lists.osgeo.org/pipermail/geos-devel/2020-November/009870.html). 

This change is what I understand from that discussion should be the solution, but this is not actually working (it's giving garbage / crashing).

One thing I am wondering: I am now passing the address of an integer, but this int is a loop variable, so that is only a local variable that I suppose is cleaned up at the end of `STRtree_new`. 
So if we want to be able to access those integers in `STRtree_query` we might need to store them on the STRtree object? (the python wrapper object, not the GEOS STRtree).