### PR TITLE
FIX: handle non-integer GEOS_VERSION_PATCH like 0beta1 as 0

### DIFF
--- a/src/lib.c
+++ b/src/lib.c
@@ -59,11 +59,18 @@ PyMODINIT_FUNC PyInit_lib(void) {
   import_array();
   import_umath();
 
+  /* add quotes to GEOS_VERSION_PATCH to handle (e.g.) 0beta1, then take the first digit */
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
+#define GEOS_VERSION_PATCH_STR QUOTE(GEOS_VERSION_PATCH)
+  PyObject* py_geos_version_patch_digit = PyUnicode_Substring(PyUnicode_FromString(GEOS_VERSION_PATCH_STR), 0, 1);
+
   /* export the GEOS versions as python tuple and string */
   PyModule_AddObject(m, "geos_version",
                      PyTuple_Pack(3, PyLong_FromLong((long)GEOS_VERSION_MAJOR),
                                   PyLong_FromLong((long)GEOS_VERSION_MINOR),
-                                  PyLong_FromLong((long)GEOS_VERSION_PATCH)));
+                                  PyLong_FromUnicodeObject(py_geos_version_patch_digit, 0)));
   PyModule_AddObject(m, "geos_capi_version",
                      PyTuple_Pack(3, PyLong_FromLong((long)GEOS_CAPI_VERSION_MAJOR),
                                   PyLong_FromLong((long)GEOS_CAPI_VERSION_MINOR),

--- a/src/lib.c
+++ b/src/lib.c
@@ -59,7 +59,9 @@ PyMODINIT_FUNC PyInit_lib(void) {
   import_array();
   import_umath();
 
-  /* add quotes to GEOS_VERSION_PATCH to handle (e.g.) 0beta1, then take the first digit */
+  /* GEOS_VERSION_PATCH may contain non-integer characters, e.g., 0beta1
+     add quotes using https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html
+     then take the first digit */
 #define Q(x) #x
 #define QUOTE(x) Q(x)
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -64,13 +64,13 @@ PyMODINIT_FUNC PyInit_lib(void) {
 #define QUOTE(x) Q(x)
 
 #define GEOS_VERSION_PATCH_STR QUOTE(GEOS_VERSION_PATCH)
-  PyObject* py_geos_version_patch_digit = PyUnicode_Substring(PyUnicode_FromString(GEOS_VERSION_PATCH_STR), 0, 1);
+  int geos_version_patch_int = GEOS_VERSION_PATCH_STR[0] - '0';
 
   /* export the GEOS versions as python tuple and string */
   PyModule_AddObject(m, "geos_version",
                      PyTuple_Pack(3, PyLong_FromLong((long)GEOS_VERSION_MAJOR),
                                   PyLong_FromLong((long)GEOS_VERSION_MINOR),
-                                  PyLong_FromUnicodeObject(py_geos_version_patch_digit, 0)));
+                                  PyLong_FromLong((long)geos_version_patch_int)));
   PyModule_AddObject(m, "geos_capi_version",
                      PyTuple_Pack(3, PyLong_FromLong((long)GEOS_CAPI_VERSION_MAJOR),
                                   PyLong_FromLong((long)GEOS_CAPI_VERSION_MINOR),


### PR DESCRIPTION
Non-releases of GEOS have `geos_c.h` headers like this:
```
#define GEOS_VERSION_PATCH 0beta1
```
which cannot be compiled, as this was expected to be an integer, not a string. This PR declares a quoted macro variable (using [this trick](https://stackoverflow.com/a/6671729/)), and takes the first substring to be the assumed patch digit. Theoretically, there could be more than one digit, but I don't think I've seen this from GEOS' history, so we could assume it will only be one character length.

Review carefully, as I seldom write C.

---

After this is merged, it should be possible to set `GEOS_VERSION: 3.9.0beta1` for CI testing along-side Python 3.9, similar to https://github.com/Toblerity/Shapely/pull/1041