### PR TITLE
ENH: Consolidate validation of enum values and raise ValueError on invalid values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,8 @@ Version 0.9 (unreleased)
 * Ensure that ``python setup.py clean`` removes all previously Cythonized and compiled
   files (#239).
 * Addition of a ``reverse`` function for GEOS >= 3.7 (#254).
+* Removes ``VALID_PREDICATES`` set from ``pygeos.strtree`` package; these can be constructed
+  in downstream libraries using the ``pygeos.strtree.BinaryPredicate`` enum.
 
 Version 0.8 (2020-09-06)
 ------------------------

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -1,8 +1,8 @@
-from enum import IntEnum
 import numpy as np
 from . import Geometry  # NOQA
 from . import lib
 from .decorators import requires_geos, multithreading_enabled
+from .enum import ParamEnum
 
 
 __all__ = [
@@ -27,22 +27,16 @@ __all__ = [
 ]
 
 
-class BufferCapStyles(IntEnum):
+class BufferCapStyles(ParamEnum):
     round = 1
     flat = 2
     square = 3
 
 
-VALID_BUFFER_CAP_STYLES = {e.name for e in BufferCapStyles}
-
-
-class BufferJoinStyles(IntEnum):
+class BufferJoinStyles(ParamEnum):
     round = 1
     mitre = 2
     bevel = 3
-
-
-VALID_BUFFER_JOIN_STYLES = {e.name for e in BufferJoinStyles}
 
 
 @multithreading_enabled
@@ -152,21 +146,9 @@ def buffer(
     True
     """
     if isinstance(cap_style, str):
-        if not cap_style in VALID_BUFFER_CAP_STYLES:
-            raise ValueError(
-                "cap_style '{}' is not valid, must be one of {}".format(
-                    cap_style, ", ".join(VALID_BUFFER_CAP_STYLES)
-                )
-            )
-        cap_style = BufferCapStyles[cap_style].value
+        cap_style = BufferCapStyles.get_value(cap_style)
     if isinstance(join_style, str):
-        if not join_style in VALID_BUFFER_JOIN_STYLES:
-            raise ValueError(
-                "join_style '{}' is not valid, must be one of {}".format(
-                    join_style, ", ".join(VALID_BUFFER_JOIN_STYLES)
-                )
-            )
-        join_style = BufferJoinStyles[join_style].value
+        join_style = BufferJoinStyles.get_value(join_style)
     if not np.isscalar(quadsegs):
         raise TypeError("quadsegs only accepts scalar values")
     if not np.isscalar(cap_style):
@@ -229,13 +211,7 @@ def offset_curve(
     <pygeos.Geometry LINESTRING (2 2, 2 0)>
     """
     if isinstance(join_style, str):
-        if not join_style in VALID_BUFFER_JOIN_STYLES:
-            raise ValueError(
-                "join_style '{}' is not valid, must be one of {}".format(
-                    join_style, ", ".join(VALID_BUFFER_JOIN_STYLES)
-                )
-            )
-        join_style = BufferJoinStyles[join_style].value
+        join_style = BufferJoinStyles.get_value(join_style)
     if not np.isscalar(quadsegs):
         raise TypeError("quadsegs only accepts scalar values")
     if not np.isscalar(join_style):

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -28,15 +28,21 @@ __all__ = [
 
 
 class BufferCapStyles(IntEnum):
-    ROUND = 1
-    FLAT = 2
-    SQUARE = 3
+    round = 1
+    flat = 2
+    square = 3
+
+
+VALID_BUFFER_CAP_STYLES = {e.name for e in BufferCapStyles}
 
 
 class BufferJoinStyles(IntEnum):
-    ROUND = 1
-    MITRE = 2
-    BEVEL = 3
+    round = 1
+    mitre = 2
+    bevel = 3
+
+
+VALID_BUFFER_JOIN_STYLES = {e.name for e in BufferJoinStyles}
 
 
 @multithreading_enabled
@@ -102,7 +108,7 @@ def buffer(
         circular line endings (see ``quadsegs``). Both 'square' and 'flat'
         result in rectangular line endings, only 'flat' will end at the
         original vertex, while 'square' involves adding the buffer width.
-    join_style : {'round', 'bevel', 'sharp'}
+    join_style : {'round', 'bevel', 'mitre'}
         Specifies the shape of buffered line midpoints. 'round' results in
         rounded shapes. 'bevel' results in a beveled edge that touches the
         original vertex. 'mitre' results in a single vertex that is beveled
@@ -146,9 +152,21 @@ def buffer(
     True
     """
     if isinstance(cap_style, str):
-        cap_style = BufferCapStyles[cap_style.upper()].value
+        if not cap_style in VALID_BUFFER_CAP_STYLES:
+            raise ValueError(
+                "cap_style '{}' is not valid, must be one of {}".format(
+                    cap_style, ", ".join(VALID_BUFFER_CAP_STYLES)
+                )
+            )
+        cap_style = BufferCapStyles[cap_style].value
     if isinstance(join_style, str):
-        join_style = BufferJoinStyles[join_style.upper()].value
+        if not join_style in VALID_BUFFER_JOIN_STYLES:
+            raise ValueError(
+                "join_style '{}' is not valid, must be one of {}".format(
+                    join_style, ", ".join(VALID_BUFFER_JOIN_STYLES)
+                )
+            )
+        join_style = BufferJoinStyles[join_style].value
     if not np.isscalar(quadsegs):
         raise TypeError("quadsegs only accepts scalar values")
     if not np.isscalar(cap_style):
@@ -193,7 +211,7 @@ def offset_curve(
     quadsegs : int
         Specifies the number of linear segments in a quarter circle in the
         approximation of circular arcs.
-    join_style : {'round', 'bevel', 'sharp'}
+    join_style : {'round', 'bevel', 'mitre'}
         Specifies the shape of outside corners. 'round' results in
         rounded shapes. 'bevel' results in a beveled edge that touches the
         original vertex. 'mitre' results in a single vertex that is beveled
@@ -211,7 +229,13 @@ def offset_curve(
     <pygeos.Geometry LINESTRING (2 2, 2 0)>
     """
     if isinstance(join_style, str):
-        join_style = BufferJoinStyles[join_style.upper()].value
+        if not join_style in VALID_BUFFER_JOIN_STYLES:
+            raise ValueError(
+                "join_style '{}' is not valid, must be one of {}".format(
+                    join_style, ", ".join(VALID_BUFFER_JOIN_STYLES)
+                )
+            )
+        join_style = BufferJoinStyles[join_style].value
     if not np.isscalar(quadsegs):
         raise TypeError("quadsegs only accepts scalar values")
     if not np.isscalar(join_style):

--- a/pygeos/enum.py
+++ b/pygeos/enum.py
@@ -1,0 +1,23 @@
+from enum import IntEnum
+
+
+class ParamEnum(IntEnum):
+    """Wraps IntEnum to provide validation of a requested item.
+
+    Intended for enums used for function parameters.
+
+    Use enum.get_value(item) for this behavior instead of builtin enum[item].
+    """
+
+    @classmethod
+    def get_value(cls, item):
+        """Validate incoming item and raise a ValueError with valid options if not present."""
+        try:
+            return cls[item].value
+        except KeyError:
+            valid_options = {e.name for e in cls}
+            raise ValueError(
+                "'{}' is not a valid option, must be one of '{}'".format(
+                    item, "', '".join(valid_options)
+                )
+            )

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -1,12 +1,11 @@
-from enum import IntEnum
 import numpy as np
 from . import lib
-
+from .enum import ParamEnum
 
 __all__ = ["STRtree"]
 
 
-class BinaryPredicate(IntEnum):
+class BinaryPredicate(ParamEnum):
     """The enumeration of GEOS binary predicates types"""
 
     intersects = 1
@@ -18,9 +17,6 @@ class BinaryPredicate(IntEnum):
     covers = 7
     covered_by = 8
     contains_properly = 9
-
-
-VALID_PREDICATES = {e.name for e in BinaryPredicate}
 
 
 class STRtree:
@@ -102,14 +98,7 @@ class STRtree:
             predicate = 0
 
         else:
-            if not predicate in VALID_PREDICATES:
-                raise ValueError(
-                    "Predicate {} is not valid; must be one of {}".format(
-                        predicate, ", ".join(VALID_PREDICATES)
-                    )
-                )
-
-            predicate = BinaryPredicate[predicate].value
+            predicate = BinaryPredicate.get_value(predicate)
 
         return self._tree.query(geometry, predicate)
 
@@ -176,13 +165,6 @@ class STRtree:
             predicate = 0
 
         else:
-            if not predicate in VALID_PREDICATES:
-                raise ValueError(
-                    "Predicate {} is not valid; must be one of {}".format(
-                        predicate, ", ".join(VALID_PREDICATES)
-                    )
-                )
-
-            predicate = BinaryPredicate[predicate].value
+            predicate = BinaryPredicate.get_value(predicate)
 
         return self._tree.query_bulk(geometry, predicate)

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -244,7 +244,7 @@ def test_offset_curve_non_scalar_kwargs():
 
 
 def test_offset_curve_join_style_invalid():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="join_style 'invalid' is not valid"):
         pygeos.offset_curve(line_string, 1.0, join_style="invalid")
 
 

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -83,6 +83,16 @@ def test_float_arg_nan(geometry, func):
     assert actual is None
 
 
+def test_buffer_cap_style_invalid():
+    with pytest.raises(ValueError, match="cap_style 'invalid' is not valid"):
+        pygeos.buffer(point, 1, cap_style="invalid")
+
+
+def test_buffer_join_style_invalid():
+    with pytest.raises(ValueError, match="join_style 'invalid' is not valid"):
+        pygeos.buffer(point, 1, join_style="invalid")
+
+
 def test_snap_none():
     actual = pygeos.snap(None, point, tolerance=1.0)
     assert actual is None
@@ -233,9 +243,9 @@ def test_offset_curve_non_scalar_kwargs():
         pygeos.offset_curve([line_string, line_string], 1, mitre_limit=[5.0, 6.0])
 
 
-def test_offset_curve_join_style():
-    with pytest.raises(KeyError):
-        pygeos.offset_curve(line_string, 1.0, join_style="nonsense")
+def test_offset_curve_join_style_invalid():
+    with pytest.raises(ValueError):
+        pygeos.offset_curve(line_string, 1.0, join_style="invalid")
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -84,12 +84,12 @@ def test_float_arg_nan(geometry, func):
 
 
 def test_buffer_cap_style_invalid():
-    with pytest.raises(ValueError, match="cap_style 'invalid' is not valid"):
+    with pytest.raises(ValueError, match="'invalid' is not a valid option"):
         pygeos.buffer(point, 1, cap_style="invalid")
 
 
 def test_buffer_join_style_invalid():
-    with pytest.raises(ValueError, match="join_style 'invalid' is not valid"):
+    with pytest.raises(ValueError, match="'invalid' is not a valid option"):
         pygeos.buffer(point, 1, join_style="invalid")
 
 
@@ -244,7 +244,7 @@ def test_offset_curve_non_scalar_kwargs():
 
 
 def test_offset_curve_join_style_invalid():
-    with pytest.raises(ValueError, match="join_style 'invalid' is not valid"):
+    with pytest.raises(ValueError, match="'invalid' is not a valid option"):
         pygeos.offset_curve(line_string, 1.0, join_style="invalid")
 
 


### PR DESCRIPTION
This fixes a minor bug in the docstring for buffer; it listed an invalid `join_style` option.

While I was at it, I made the enums lowercase to match their usage in the functions for usability, and added a validation of values to give better error message than what you get back now when a value isn't in an `IntEnum`.

Note: this changes the original `KeyError` that would have been emitted to a `ValueError`, which seems more appropriate in this case (it is the _value_ that is wrong; that it is a key in an `IntEnum` is an implementation detail).