### PR TITLE
ENH: STRtree: use addresses of tree geometries to calculate their index

### DIFF
--- a/src/strtree.c
+++ b/src/strtree.c
@@ -61,16 +61,22 @@ FuncGEOS_YpY_b* get_predicate_func(int predicate_id) {
   }
 }
 
-/* Copy values from arr to a new numpy integer array.
+/* Calculate indices of tree geometries.
+ * This uses pointer offsets of geometries from the head of tree geometries to calculate
+ * corresponding indices.
  *
  * Parameters
  * ----------
- * arr: dynamic vector array to convert to ndarray
+ * tree_geoms: array of tree geometries
+ *
+ * arr: dynamic vector of addresses of geometries within tree geometries array
  */
-
-static PyArrayObject* copy_kvec_to_npy(npy_intp_vec* arr) {
-  npy_intp i;
-  npy_intp size = kv_size(*arr);
+static PyArrayObject* tree_geom_offsets_to_npy_arr(GeometryObject** tree_geoms,
+                                                   tree_geom_vec_t* geoms) {
+  size_t i;
+  size_t size = kv_size(*geoms);
+  npy_intp geom_index;
+  char* head_ptr = (char*)tree_geoms;  // head of tree geometry array
 
   npy_intp dims[1] = {size};
   // the following raises a compiler warning based on how the macro is defined
@@ -82,15 +88,19 @@ static PyArrayObject* copy_kvec_to_npy(npy_intp_vec* arr) {
   }
 
   for (i = 0; i < size; i++) {
+    // Calculate index using offset of its address compared to head of tree geometries
+    geom_index =
+        (npy_intp)(((char*)kv_A(*geoms, i) - head_ptr) / sizeof(GeometryObject*));
+
     // assign value into numpy array
-    *(npy_intp*)PyArray_GETPTR1(result, i) = kv_A(*arr, i);
+    *(npy_intp*)PyArray_GETPTR1(result, i) = geom_index;
   }
 
   return (PyArrayObject*)result;
 }
 
 static void STRtree_dealloc(STRtreeObject* self) {
-  size_t i, size;
+  size_t i;
 
   // free the tree
   if (self->ptr != NULL) {
@@ -99,11 +109,11 @@ static void STRtree_dealloc(STRtreeObject* self) {
     GEOS_FINISH;
   }
   // free the geometries
-  size = kv_size(self->_geoms);
-  for (i = 0; i < size; i++) {
-    Py_XDECREF(kv_A(self->_geoms, i));
+  for (i = 0; i < self->_size; i++) {
+    Py_XDECREF(self->_geoms[i]);
   }
-  kv_destroy(self->_geoms);
+
+  free(self->_geoms);
   // free the PyObject
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
@@ -114,8 +124,8 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
   void *tree, *ptr;
   npy_intp n, i, count = 0;
   GEOSGeometry* geom;
-  pg_geom_obj_vec _geoms;
   GeometryObject* obj;
+  GeometryObject** _geoms;
 
   if (!PyArg_ParseTuple(args, "Oi", &arr, &node_capacity)) {
     return NULL;
@@ -144,7 +154,8 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
   n = PyArray_SIZE((PyArrayObject*)arr);
 
-  kv_init(_geoms);
+  _geoms = (GeometryObject**)malloc(n * sizeof(GeometryObject*));
+
   for (i = 0; i < n; i++) {
     /* get the geometry */
     ptr = PyArray_GETPTR1((PyArrayObject*)arr, i);
@@ -153,12 +164,12 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
     if (!get_geom(obj, &geom)) {
       errstate = PGERR_NOT_A_GEOMETRY;
       GEOSSTRtree_destroy_r(ctx, tree);
+
       // free the geometries
-      count = kv_size(_geoms);
       for (i = 0; i < count; i++) {
-        Py_XDECREF(kv_A(_geoms, i));
+        Py_XDECREF(_geoms[i]);
       }
-      kv_destroy(_geoms);
+      free(_geoms);
       GEOS_FINISH;
       return NULL;
     }
@@ -166,13 +177,18 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
      * Set it as NULL for the internal geometries used for predicate tests.
      */
     if (geom == NULL || GEOSisEmpty_r(ctx, geom)) {
-      kv_push(GeometryObject*, _geoms, NULL);
+      _geoms[i] = NULL;
     } else {
       /* perform the insert */
       Py_INCREF(obj);
-      kv_push(GeometryObject*, _geoms, obj);
+      _geoms[i] = obj;
       count++;
-      GEOSSTRtree_insert_r(ctx, tree, geom, (void*)i);
+
+      // Store the address of this geometry within _geoms array as the item data in the
+      // tree.  This address is used to calculate the original index of the geometry in
+      // the input array.
+      // NOTE: the type of item data we store is GeometryObject**.
+      GEOSSTRtree_insert_r(ctx, tree, geom, &(_geoms[i]));
     }
   }
 
@@ -185,21 +201,24 @@ static PyObject* STRtree_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
   GEOS_FINISH;
   self->ptr = tree;
   self->count = count;
+  self->_size = n;
   self->_geoms = _geoms;
   return (PyObject*)self;
 }
 
-/* Callback called by strtree_query with the index of each intersecting geometry
- * and a dynamic vector to push that index onto.
+/* Callback called by strtree_query with item data of each intersecting geometry
+ * and a dynamic vector to push that item onto.
+ *
+ * Item data is the address of that geometry within the tree geometries (_geoms) array.
  *
  * Parameters
  * ----------
  * item: index of intersected geometry in the tree
- * user_data: pointer to dynamic vector; index is pushed onto this vector
+ *
+ * user_data: pointer to dynamic vector
  * */
-
 void query_callback(void* item, void* user_data) {
-  kv_push(npy_intp, *(npy_intp_vec*)user_data, (npy_intp)item);
+  kv_push(GeometryObject**, *(tree_geom_vec_t*)user_data, item);
 }
 
 /* Evaluate the predicate function against a prepared version of geom
@@ -218,12 +237,11 @@ void query_callback(void* item, void* user_data) {
  * prepared_geom: input prepared geometry, only if previously created.  If NULL, geom
  *   will be prepared instead.
  *
- * tree_geometries: pointer to ndarray of all geometries in the tree
+ * in_geoms: pointer to dynamic vector of addresses in tree geometries (_geoms) that have
+ *   overlapping envelopes with envelope of input geometry.
  *
- * in_indexes: dynamic vector of indexes of tree geometries that have overlapping
- *   envelopes with envelope of input geometry.
- *
- * out_indexes: dynamic vector of indexes of tree geometries that meet predicate function.
+ * out_geoms: pointer to dynamic vector of addresses in tree geometries (_geoms) that meet
+ *   predicate function.
  *
  * count: pointer to an integer where the number of geometries that met the predicate will
  *   be written.
@@ -233,12 +251,13 @@ void query_callback(void* item, void* user_data) {
 
 static char evaluate_predicate(void* context, FuncGEOS_YpY_b* predicate_func,
                                GEOSGeometry* geom, GEOSPreparedGeometry* prepared_geom,
-                               pg_geom_obj_vec* tree_geometries, npy_intp_vec* in_indexes,
-                               npy_intp_vec* out_indexes, npy_intp* count) {
+                               tree_geom_vec_t* in_geoms, tree_geom_vec_t* out_geoms,
+                               npy_intp* count) {
   GeometryObject* pg_geom;
+  GeometryObject** pg_geom_loc;  // address of geometry in tree geometries (_geoms)
   GEOSGeometry* target_geom;
   const GEOSPreparedGeometry* prepared_geom_tmp;
-  npy_intp i, size, index;
+  npy_intp i, size;
 
   if (prepared_geom == NULL) {
     // geom was not previously prepared, prepare it now
@@ -251,22 +270,22 @@ static char evaluate_predicate(void* context, FuncGEOS_YpY_b* predicate_func,
     prepared_geom_tmp = (const GEOSPreparedGeometry*)prepared_geom;
   }
 
-  size = kv_size(*in_indexes);
+  size = kv_size(*in_geoms);
   *count = 0;
   for (i = 0; i < size; i++) {
-    // get index for right geometries from in_indexes
-    index = kv_A(*in_indexes, i);
+    // get address of geometry in tree geometries, then use that to get associated
+    // GEOS geometry
+    pg_geom_loc = kv_A(*in_geoms, i);
+    pg_geom = *pg_geom_loc;
 
-    // get GEOS geometry from pygeos geometry at index in tree geometries
-    pg_geom = kv_A(*tree_geometries, index);
     if (pg_geom == NULL) {
       continue;
     }
-    get_geom((GeometryObject*)pg_geom, &target_geom);
+    get_geom(pg_geom, &target_geom);
 
-    // keep the index value if it passes the predicate
+    // keep the geometry if it passes the predicate
     if (predicate_func(context, prepared_geom_tmp, target_geom)) {
-      kv_push(npy_intp, *out_indexes, index);
+      kv_push(GeometryObject**, *out_geoms, pg_geom_loc);
       (*count)++;
     }
   }
@@ -296,11 +315,15 @@ static PyObject* STRtree_query(STRtreeObject* self, PyObject* args) {
   int predicate_id = 0;  // default no predicate
   GEOSGeometry* geom = NULL;
   GEOSPreparedGeometry* prepared_geom = NULL;
-  npy_intp_vec query_indexes,
-      predicate_indexes;  // Resizable array for matches for each geometry
   npy_intp count;
   FuncGEOS_YpY_b* predicate_func = NULL;
   PyArrayObject* result;
+
+  // Addresses in tree geometries (_geoms) that match tree
+  tree_geom_vec_t query_geoms;
+
+  // Addresses in tree geometries (_geoms) that meet predicate (if present)
+  tree_geom_vec_t predicate_geoms;
 
   if (self->ptr == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Tree is uninitialized");
@@ -330,37 +353,39 @@ static PyObject* STRtree_query(STRtreeObject* self, PyObject* args) {
 
   GEOS_INIT;
 
-  // query the tree for indices of geometries in the tree with
+  // query the tree for addresses of tree geometries (_geoms) in the tree with
   // envelopes that intersect the geometry.
-  kv_init(query_indexes);
+  kv_init(query_geoms);
   if (geom != NULL && !GEOSisEmpty_r(ctx, geom)) {
-    GEOSSTRtree_query_r(ctx, self->ptr, geom, query_callback, &query_indexes);
+    GEOSSTRtree_query_r(ctx, self->ptr, geom, query_callback, &query_geoms);
   }
 
-  if (predicate_id == 0 || kv_size(query_indexes) == 0) {
+  if (predicate_id == 0 || kv_size(query_geoms) == 0) {
     // No predicate function provided, return all geometry indexes from
     // query.  If array is empty, return an empty numpy array
-    result = copy_kvec_to_npy(&query_indexes);
-    kv_destroy(query_indexes);
+    result = tree_geom_offsets_to_npy_arr(self->_geoms, &query_geoms);
+    kv_destroy(query_geoms);
     GEOS_FINISH;
     return (PyObject*)result;
   }
 
-  kv_init(predicate_indexes);
-  errstate = evaluate_predicate(ctx, predicate_func, geom, prepared_geom, &self->_geoms,
-                                &query_indexes, &predicate_indexes, &count);
+  kv_init(predicate_geoms);
+  errstate = evaluate_predicate(ctx, predicate_func, geom, prepared_geom, &query_geoms,
+                                &predicate_geoms, &count);
   if (errstate != PGERR_SUCCESS) {
     // error performing predicate
-    kv_destroy(query_indexes);
-    kv_destroy(predicate_indexes);
+    kv_destroy(query_geoms);
+    kv_destroy(predicate_geoms);
     GEOS_FINISH;
     return NULL;
   }
 
-  result = copy_kvec_to_npy(&predicate_indexes);
+  // calculate indices of tree geometries and output to array
+  result = tree_geom_offsets_to_npy_arr(self->_geoms, &predicate_geoms);
 
-  kv_destroy(query_indexes);
-  kv_destroy(predicate_indexes);
+  kv_destroy(query_geoms);
+  kv_destroy(predicate_geoms);
+
   GEOS_FINISH;
   return (PyObject*)result;
 }
@@ -386,10 +411,18 @@ static PyObject* STRtree_query_bulk(STRtreeObject* self, PyObject* args) {
   int predicate_id = 0;  // default no predicate
   GEOSGeometry* geom = NULL;
   GEOSPreparedGeometry* prepared_geom = NULL;
-  npy_intp_vec query_indexes, src_indexes, target_indexes;
-  npy_intp i, j, n, size;
+  npy_intp_vec src_indexes;  // Indices of input geometries
+  npy_intp i, j, n, size, geom_index;
   FuncGEOS_YpY_b* predicate_func = NULL;
+  char* head_ptr = (char*)self->_geoms;
   PyArrayObject* result;
+
+  // Addresses in tree geometries (_geoms) that match tree
+  tree_geom_vec_t query_geoms;
+
+  // Aggregated addresses in tree geometries (_geoms) that also meet predicate (if
+  // present)
+  tree_geom_vec_t target_geoms;
 
   if (self->ptr == NULL) {
     PyErr_SetString(PyExc_RuntimeError, "Tree is uninitialized");
@@ -431,7 +464,7 @@ static PyObject* STRtree_query_bulk(STRtreeObject* self, PyObject* args) {
   }
 
   kv_init(src_indexes);
-  kv_init(target_indexes);
+  kv_init(target_geoms);
 
   GEOS_INIT_THREADS;
 
@@ -446,32 +479,34 @@ static PyObject* STRtree_query_bulk(STRtreeObject* self, PyObject* args) {
       continue;
     }
 
-    kv_init(query_indexes);
-    GEOSSTRtree_query_r(ctx, self->ptr, geom, query_callback, &query_indexes);
+    kv_init(query_geoms);
+    GEOSSTRtree_query_r(ctx, self->ptr, geom, query_callback, &query_geoms);
 
-    if (kv_size(query_indexes) == 0) {
+    if (kv_size(query_geoms) == 0) {
       // no target geoms in query window, skip this source geom
-      kv_destroy(query_indexes);
+      kv_destroy(query_geoms);
       continue;
     }
 
     if (predicate_id == 0) {
-      // no predicate, push results directly onto target_indexes
-      size = kv_size(query_indexes);
+      // no predicate, push results directly onto target_geoms
+      size = kv_size(query_geoms);
       for (j = 0; j < size; j++) {
+        // push index of source geometry onto src_indexes
         kv_push(npy_intp, src_indexes, i);
-        kv_push(npy_intp, target_indexes, kv_A(query_indexes, j));
+
+        // push geometry that matched tree onto target_geoms
+        kv_push(GeometryObject**, target_geoms, kv_A(query_geoms, j));
       }
     } else {
-      // this pushes directly onto target_indexes
-      errstate =
-          evaluate_predicate(ctx, predicate_func, geom, prepared_geom, &self->_geoms,
-                             &query_indexes, &target_indexes, &size);
+      // Tree geometries that meet the predicate are pushed onto target_geoms
+      errstate = evaluate_predicate(ctx, predicate_func, geom, prepared_geom,
+                                    &query_geoms, &target_geoms, &size);
 
       if (errstate != PGERR_SUCCESS) {
-        kv_destroy(query_indexes);
+        kv_destroy(query_geoms);
         kv_destroy(src_indexes);
-        kv_destroy(target_indexes);
+        kv_destroy(target_geoms);
         break;
       }
 
@@ -480,7 +515,7 @@ static PyObject* STRtree_query_bulk(STRtreeObject* self, PyObject* args) {
       }
     }
 
-    kv_destroy(query_indexes);
+    kv_destroy(query_geoms);
   }
 
   GEOS_FINISH_THREADS;
@@ -503,11 +538,15 @@ static PyObject* STRtree_query_bulk(STRtreeObject* self, PyObject* args) {
   for (i = 0; i < size; i++) {
     // assign value into numpy arrays
     *(npy_intp*)PyArray_GETPTR2(result, 0, i) = kv_A(src_indexes, i);
-    *(npy_intp*)PyArray_GETPTR2(result, 1, i) = kv_A(target_indexes, i);
+
+    // Calculate index using offset of its address compared to head of _geoms
+    geom_index =
+        (npy_intp)(((char*)kv_A(target_geoms, i) - head_ptr) / sizeof(GeometryObject*));
+    *(npy_intp*)PyArray_GETPTR2(result, 1, i) = geom_index;
   }
 
   kv_destroy(src_indexes);
-  kv_destroy(target_indexes);
+  kv_destroy(target_geoms);
   return (PyObject*)result;
 }
 

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -15,7 +15,7 @@ typedef struct {
 typedef struct {
   PyObject_HEAD void* ptr;
   npy_intp count;           // count of geometries added to the tree
-  size_t _size;             // size of _geoms array (same as original size of input array)
+  size_t _geoms_size;       // size of _geoms array (same as original size of input array)
   GeometryObject** _geoms;  // array of input geometries
 } STRtreeObject;
 

--- a/src/strtree.h
+++ b/src/strtree.h
@@ -12,16 +12,17 @@ typedef struct {
   npy_intp* a;
 } npy_intp_vec;
 
-/* A resizable vector with pointers to pygeos GeometryObjects */
+/* A resizable vector with addresses of geometries within tree geometries array */
 typedef struct {
   size_t n, m;
-  GeometryObject** a;
-} pg_geom_obj_vec;
+  GeometryObject*** a;
+} tree_geom_vec_t;
 
 typedef struct {
   PyObject_HEAD void* ptr;
-  npy_intp count;
-  pg_geom_obj_vec _geoms;
+  npy_intp count;           // count of geometries added to the tree
+  size_t _size;             // size of _geoms array (same as original size of input array)
+  GeometryObject** _geoms;  // array of input geometries
 } STRtreeObject;
 
 extern PyTypeObject STRtreeType;

--- a/src/vector.h
+++ b/src/vector.h
@@ -13,14 +13,6 @@ typedef struct {
   npy_intp* a;
 } index_vec_t;
 
-/* A resizable vector with pointers to pygeos GeometryObjects.
- * Wraps the vector implementation in kvec.h as a type.
- */
-typedef struct {
-  size_t n, m;
-  GeometryObject** a;
-} geom_obj_vec_t;
-
 /* Copy values from arr to a new numpy integer array.
  *
  * Parameters


### PR DESCRIPTION
Supersedes #261.

See #261 for a more complete description of the underlying issue with how we were adding indexes of geometries from the input array of the tree to the item data for each GEOSGeometry added to the STRtree.  The problem was that we were providing the address of a local integer in a loop.

In order to avoid adding a second array to track these indices, this PR instead makes a few adjustments:
* tree geometries are managed as an array on the tree (instead of resizeable vector); their size is known in advance, and this allows us to calculate pointer offsets to determine item indices
* the address of the pointer to `GeometryObject` in this array is then added to the item data for each `GEOSGeometry` added to the tree
* for any geometries that match the tree, we add this address onto resizeable vectors - just as we were doing with indices before
* during predicate testing, we then use this to lookup the underlying `GeometryObject`; this simplifies the input parameters to that function and saves one lookup of index to geometry
* we then use the offsets of these addresses compared to the head of the tree geometry array to determine their index

Since this involves pointers instead of index vectors, it is just a little bit harder to follow.  I tried to add comments to help overcome this, but we can certainly add more to make things more clear.


Credit to @dbaston for the idea to use pointer offsets to calculate indices.
