### PR TITLE
[API] Set None as default axis for reduction operations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Version 0.9 (unreleased)
   all input values are None (#249).
 * API change: the default axis of ``union_all``, ``intersection_all``, ``symmetric_difference_all``,
   and ``coverage_union_all`` can now reduce over multiple axes. The default changed from the first
-  axis (``0``) all all axes (``None``) (#266).
+  axis (``0``) to all axes (``None``) (#266).
 * Fixed internal GEOS error code detection for ``get_dimensions`` and ``get_srid`` (#218).
 * Addition of ``prepare`` function that generates a GEOS prepared geometry which is stored on
   the Geometry object itself. All binary predicates (except ``equals``) make use of this (#92).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,9 @@ Version 0.9 (unreleased)
   instead of returning None if any value is None (#249).
 * API change: ``union_all`` now returns None (instead of ``GEOMETRYCOLLECTION EMPTY``) if
   all input values are None (#249).
+* API change: the default axis of ``union_all``, ``intersection_all``, ``symmetric_difference_all``,
+  and ``coverage_union_all`` can now reduce over multiple axes. The default changed from the first
+  axis (``0``) all all axes (``None``) (#266).
 * Fixed internal GEOS error code detection for ``get_dimensions`` and ``get_srid`` (#218).
 * Addition of ``prepare`` function that generates a GEOS prepared geometry which is stored on
   the Geometry object itself. All binary predicates (except ``equals``) make use of this (#92).

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -58,7 +58,7 @@ def intersection(a, b, **kwargs):
     return lib.intersection(a, b, **kwargs)
 
 @multithreading_enabled
-def intersection_all(geometries, axis=0, **kwargs):
+def intersection_all(geometries, axis=None, **kwargs):
     """Returns the intersection of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
@@ -67,10 +67,10 @@ def intersection_all(geometries, axis=0, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int
-        Axis along which the operation is performed. The default (zero)
-        performs the operation over the first dimension of the input array.
-        axis may be negative, in which case it counts from the last to the
+    axis : int (default None)
+        Axis along which the operation is performed. The default (None)
+        performs the operation over all axes, returning a scalar value.
+        Axis may be negative, in which case it counts from the last to the
         first axis.
 
     See also
@@ -111,7 +111,7 @@ def symmetric_difference(a, b, **kwargs):
     return lib.symmetric_difference(a, b, **kwargs)
 
 @multithreading_enabled
-def symmetric_difference_all(geometries, axis=0, **kwargs):
+def symmetric_difference_all(geometries, axis=None, **kwargs):
     """Returns the symmetric difference of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
@@ -120,10 +120,10 @@ def symmetric_difference_all(geometries, axis=0, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int
-        Axis along which the operation is performed. The default (zero)
-        performs the operation over the first dimension of the input array.
-        axis may be negative, in which case it counts from the last to the
+    axis : int (default None)
+        Axis along which the operation is performed. The default (None)
+        performs the operation over all axes, returning a scalar value.
+        Axis may be negative, in which case it counts from the last to the
         first axis.
 
     See also
@@ -165,7 +165,7 @@ def union(a, b, **kwargs):
     return lib.union(a, b, **kwargs)
 
 @multithreading_enabled
-def union_all(geometries, axis=0, **kwargs):
+def union_all(geometries, axis=None, **kwargs):
     """Returns the union of multiple geometries.
 
     This function ignores None values when other Geometry elements are present.
@@ -174,10 +174,10 @@ def union_all(geometries, axis=0, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int
-        Axis along which the operation is performed. The default (zero)
-        performs the operation over the first dimension of the input array.
-        axis may be negative, in which case it counts from the last to the
+    axis : int (default None)
+        Axis along which the operation is performed. The default (None)
+        performs the operation over all axes, returning a scalar value.
+        Axis may be negative, in which case it counts from the last to the
         first axis.
 
     See also
@@ -249,7 +249,7 @@ def coverage_union(a, b, **kwargs):
 
 @requires_geos("3.8.0")
 @multithreading_enabled
-def coverage_union_all(geometries, axis=0, **kwargs):
+def coverage_union_all(geometries, axis=None, **kwargs):
     """Returns the union of multiple polygons of a geometry collection.
     This is an optimized version of union which assumes the polygons
     to be non-overlapping.
@@ -259,10 +259,10 @@ def coverage_union_all(geometries, axis=0, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int
-        Axis along which the operation is performed. The default (zero)
-        performs the operation over the first dimension of the input array.
-        axis may be negative, in which case it counts from the last to the
+    axis : int (default None)
+        Axis along which the operation is performed. The default (None)
+        performs the operation over all axes, returning a scalar value.
+        Axis may be negative, in which case it counts from the last to the
         first axis.
 
     See also

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -55,9 +55,9 @@ def test_set_operation_reduce_1dim(n, func, related_func):
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS)
 def test_set_operation_reduce_axis(func, related_func):
     data = [[point] * 2] * 3  # shape = (3, 2)
-    actual = func(data)
-    assert actual.shape == (2,)
-    actual = func(data, axis=0)  # default
+    actual = func(data, axis=None)  # default
+    assert isinstance(actual, Geometry)  # scalar output
+    actual = func(data, axis=0)
     assert actual.shape == (2,)
     actual = func(data, axis=1)
     assert actual.shape == (3,)
@@ -126,9 +126,9 @@ def test_coverage_union_reduce_1dim(n):
 def test_coverage_union_reduce_axis():
     # shape = (3, 2), all polygons - none of them overlapping
     data = [[pygeos.box(i, j, i + 1, j + 1) for i in range(2)] for j in range(3)]
-    actual = pygeos.coverage_union_all(data)
-    assert actual.shape == (2,)
-    actual = pygeos.coverage_union_all(data, axis=0)  # default
+    actual = pygeos.coverage_union_all(data, axis=None)  # default
+    assert isinstance(actual, Geometry)
+    actual = pygeos.coverage_union_all(data, axis=0)
     assert actual.shape == (2,)
     actual = pygeos.coverage_union_all(data, axis=1)
     assert actual.shape == (3,)

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2339,6 +2339,11 @@ TODO relate functions
                                   PyUFunc_None, #NAME, "", 0);                   \
   PyDict_SetItemString(d, #NAME, ufunc)
 
+#define DEFINE_YY_Y_REORDERABLE(NAME)                                            \
+  ufunc = PyUFunc_FromFuncAndData(YY_Y_funcs, NAME##_data, YY_Y_dtypes, 1, 2, 1, \
+                                  PyUFunc_ReorderableNone, #NAME, "", 0);        \
+  PyDict_SetItemString(d, #NAME, ufunc)
+
 #define DEFINE_Y_d(NAME)                                                       \
   ufunc = PyUFunc_FromFuncAndData(Y_d_funcs, NAME##_data, Y_d_dtypes, 1, 1, 1, \
                                   PyUFunc_None, #NAME, "", 0);                 \
@@ -2425,10 +2430,13 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_Yd_Y(simplify);
   DEFINE_Yd_Y(simplify_preserve_topology);
 
-  DEFINE_YY_Y(intersection);
+  // 'REORDERABLE' sets PyUFunc_ReorderableNone instead of PyUFunc_None as 'identity',
+  // meaning that the order of arguments does not matter. This enables reduction over
+  // multiple (or all) axes.
+  DEFINE_YY_Y_REORDERABLE(intersection);
   DEFINE_YY_Y(difference);
-  DEFINE_YY_Y(symmetric_difference);
-  DEFINE_YY_Y(union);
+  DEFINE_YY_Y_REORDERABLE(symmetric_difference);
+  DEFINE_YY_Y_REORDERABLE(union);
   DEFINE_YY_Y(shared_paths);
 
   DEFINE_Y_d(get_x);


### PR DESCRIPTION
Closes #194

This was not as easy as expected. I got the error that I could not reduce over multiple axes because the array elements were not reorderable for this operation. I traced that back to the numpy source:

https://github.com/numpy/numpy/blob/5cae51e794d69dd553104099305e9f92db237c53/numpy/core/src/umath/reduction.c#L207
https://github.com/numpy/numpy/blob/509b5ae4a7bb3c99324fd302ead1bbf4b130c741/numpy/core/src/umath/ufunc_object.c#L3637
https://github.com/numpy/numpy/blob/4d290795d4e8c60053eb789acf173159dc4c1575/numpy/core/src/umath/ufunc_object.c#L2445

It appears to be undocumented how to signal numpy that the operation is "reorderable" (commutative?). The trick was providing `PyUFunc_ReorderableNone` as `identity` in the ufunc definition. I can see this to be present as far back as numpy 1.14.