### PR TITLE
ENH: add contains_properly predicate function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Version 0.10 (unreleased)
 
 * ...
 
+**Added GEOS functions**
+
+* Addition of a ``contains_properly`` function (#267).
+
 **Acknowledgments**
 
 Thanks to everyone who contributed to this release!

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -196,7 +196,7 @@ def prepare(geometry, **kwargs):
     --------
     destroy_prepared
     """
-    return lib.prepare(geometry, **kwargs)
+    lib.prepare(geometry, **kwargs)
 
 
 def destroy_prepared(geometry, **kwargs):
@@ -214,4 +214,4 @@ def destroy_prepared(geometry, **kwargs):
     --------
     prepare
     """
-    return lib.destroy_prepared(geometry, **kwargs)
+    lib.destroy_prepared(geometry, **kwargs)

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -470,7 +470,9 @@ def contains_properly(a, b, **kwargs):
     "contain properly" itself, which contrasts with the `contains` function,
     where common points on the boundary are allowed.
 
-    Important: this function only works for prepared geometries.
+    Note: this function will prepare the geometries under the hood if needed.
+    You can prepare the geometries in advance to avoid repeated preparation
+    when calling this function multiple times.
 
     Parameters
     ----------
@@ -486,8 +488,6 @@ def contains_properly(a, b, **kwargs):
     >>> area1 = Geometry("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))")
     >>> area2 = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))")
     >>> area3 = Geometry("POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))")
-    >>> from pygeos import prepare
-    >>> prepare(area1);
 
     ``area1`` and ``area2`` have a common border:
 
@@ -503,8 +503,6 @@ def contains_properly(a, b, **kwargs):
     >>> contains_properly(area1, area3)
     True
     """
-    # TODO Do this always or leave to the user?
-    # pygeos.prepare(a)
     return lib.contains_properly(a, b, **kwargs)
 
 

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -452,7 +452,7 @@ def contains_properly(a, b, **kwargs):
     >>> area2 = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))")
     >>> area3 = Geometry("POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))")
     >>> from pygeos import prepare
-    >>> prepare(area1)
+    >>> prepare(area1);
 
     ``area1`` and ``area2`` have a common border:
 

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -18,6 +18,7 @@ __all__ = [
     "is_valid_reason",
     "crosses",
     "contains",
+    "contains_properly",
     "covered_by",
     "covers",
     "disjoint",
@@ -381,6 +382,10 @@ def contains(a, b, **kwargs):
     A contains B if no points of B lie in the exterior of A and at least one
     point of the interior of B lies in the interior of A.
 
+    Note: following this definition, a geometry does not contain its boundary,
+    but it does contain itself. See `contains_properly` for a version where
+    a geometry does not contain itself.
+
     Parameters
     ----------
     a, b : Geometry or array_like
@@ -388,6 +393,7 @@ def contains(a, b, **kwargs):
     See also
     --------
     within : ``contains(A, B) == within(B, A)``
+    contains_properly : contains with no common boundary points
     prepare : improve performance by preparing ``a`` (the first argument)
 
     Examples
@@ -417,6 +423,54 @@ def contains(a, b, **kwargs):
     False
     """
     return lib.contains(a, b, **kwargs)
+
+
+@multithreading_enabled
+def contains_properly(a, b, **kwargs):
+    """Returns True if geometry B is completely inside geometry A, with no
+    common boundary points.
+
+    A contains B properly if B intersects the interior of A but not the
+    boundary (or exterior). This means that a geometry A does not
+    "contain properly" itself, which contrasts with the `contains` function,
+    where common points on the boundary are allowed.
+
+    Important: this function only works for prepared geometries.
+
+    Parameters
+    ----------
+    a, b : Geometry or array_like
+
+    See also
+    --------
+    contains : contains which allows common boundary points
+    prepare : improve performance by preparing ``a`` (the first argument)
+
+    Examples
+    --------
+    >>> area1 = Geometry("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))")
+    >>> area2 = Geometry("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))")
+    >>> area3 = Geometry("POLYGON((1 1, 2 1, 2 2, 1 2, 1 1))")
+    >>> from pygeos import prepare
+    >>> prepare(area1)
+
+    ``area1`` and ``area2`` have a common border:
+
+    >>> contains(area1, area2)
+    True
+    >>> contains_properly(area1, area2)
+    False
+
+    ``area3`` is completely inside ``area1`` with no common border:
+
+    >>> contains(area1, area3)
+    True
+    >>> contains_properly(area1, area3)
+    True
+    """
+    # TODO Do this always or leave to the user?
+    # pygeos.prepare(a)
+    return lib.contains_properly(a, b, **kwargs)
 
 
 @multithreading_enabled

--- a/pygeos/test/test_predicates.py
+++ b/pygeos/test/test_predicates.py
@@ -188,4 +188,4 @@ def test_contains_properly():
         pygeos.contains_properly(polygon, polygon)
 
     polygon2 = _prepare_with_copy(polygon)
-    assert pygeos.contains_properly(polygon, polygon).item() is False
+    assert pygeos.contains_properly(polygon2, polygon).item() is False

--- a/pygeos/test/test_predicates.py
+++ b/pygeos/test/test_predicates.py
@@ -25,6 +25,7 @@ BINARY_PREDICATES = (
     pygeos.crosses,
     pygeos.within,
     pygeos.contains,
+    pygeos.contains_properly,
     pygeos.overlaps,
     pygeos.equals,
     pygeos.covers,
@@ -194,9 +195,4 @@ def test_is_prepared_false(geometry):
 def test_contains_properly():
     # polygon contains itself, but does not properly contains itself
     assert pygeos.contains(polygon, polygon).item() is True
-
-    with pytest.raises(pygeos.GEOSException):
-        pygeos.contains_properly(polygon, polygon)
-
-    polygon2 = _prepare_with_copy(polygon)
-    assert pygeos.contains_properly(polygon2, polygon).item() is False
+    assert pygeos.contains_properly(polygon, polygon).item() is False

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -256,7 +256,19 @@ static PyUFuncGenericFunction YY_b_funcs[1] = {&YY_b_func};
 /* Define the geom, geom -> bool functions (YY_b) prepared */
 static void* contains_func_tuple[2] = {GEOSContains_r, GEOSPreparedContains_r};
 static void* contains_data[1] = {contains_func_tuple};
-static void* contains_properly_func_tuple[2] = {NULL, GEOSPreparedContainsProperly_r};
+static char GEOSContainsProperly(void* context, void* g1, void* g2) {
+  const GEOSPreparedGeometry* prepared_geom_tmp;
+  char ret;
+
+  prepared_geom_tmp = GEOSPrepare_r(context, g1);
+  if (prepared_geom_tmp == NULL) {
+      return 2;
+    }
+  ret = GEOSPreparedContainsProperly_r(context, prepared_geom_tmp, g2);
+  GEOSPreparedGeom_destroy_r(context, prepared_geom_tmp);
+  return ret;
+}
+static void* contains_properly_func_tuple[2] = {GEOSContainsProperly, GEOSPreparedContainsProperly_r};
 static void* contains_properly_data[1] = {contains_properly_func_tuple};
 static void* covered_by_func_tuple[2] = {GEOSCoveredBy_r, GEOSPreparedCoveredBy_r};
 static void* covered_by_data[1] = {covered_by_func_tuple};
@@ -300,10 +312,6 @@ static void YY_b_p_func(char** args, npy_intp* dimensions, npy_intp* steps, void
       ret = 0;
     } else {
       if (in1_prepared == NULL) {
-        if (func == NULL) {
-          errstate = PGERR_GEOS_EXCEPTION;
-          goto finish;
-        }
         /* call the GEOS function */
         ret = func(ctx, in1, in2);
       } else {

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -257,7 +257,7 @@ static PyUFuncGenericFunction YY_b_funcs[1] = {&YY_b_func};
 static void* contains_func_tuple[2] = {GEOSContains_r, GEOSPreparedContains_r};
 static void* contains_data[1] = {contains_func_tuple};
 static char GEOSContainsProperly(void* context, void* g1, void* g2) {
-  const GEOSPreparedGeometry* prepared_geom_tmp;
+  const GEOSPreparedGeometry* prepared_geom_tmp = NULL;
   char ret;
 
   prepared_geom_tmp = GEOSPrepare_r(context, g1);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -256,8 +256,8 @@ static PyUFuncGenericFunction YY_b_funcs[1] = {&YY_b_func};
 /* Define the geom, geom -> bool functions (YY_b) prepared */
 static void* contains_func_tuple[2] = {GEOSContains_r, GEOSPreparedContains_r};
 static void* contains_data[1] = {contains_func_tuple};
-// static void* contains_properly_func_tuple[2] = {..., GEOSPreparedContainsProperly_r};
-// static void* contains_properly_data[1] = {contains_properly_func_tuple};
+static void* contains_properly_func_tuple[2] = {NULL, GEOSPreparedContainsProperly_r};
+static void* contains_properly_data[1] = {contains_properly_func_tuple};
 static void* covered_by_func_tuple[2] = {GEOSCoveredBy_r, GEOSPreparedCoveredBy_r};
 static void* covered_by_data[1] = {covered_by_func_tuple};
 static void* covers_func_tuple[2] = {GEOSCovers_r, GEOSPreparedCovers_r};
@@ -300,6 +300,10 @@ static void YY_b_p_func(char** args, npy_intp* dimensions, npy_intp* steps, void
       ret = 0;
     } else {
       if (in1_prepared == NULL) {
+        if (func == NULL) {
+          errstate = PGERR_GEOS_EXCEPTION;
+          goto finish;
+        }
         /* call the GEOS function */
         ret = func(ctx, in1, in2);
       } else {
@@ -2396,6 +2400,7 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_YY_b_p(crosses);
   DEFINE_YY_b_p(within);
   DEFINE_YY_b_p(contains);
+  DEFINE_YY_b_p(contains_properly);
   DEFINE_YY_b_p(overlaps);
   DEFINE_YY_b(equals);
   DEFINE_YY_b_p(covers);


### PR DESCRIPTION
Closes #180

Since this is only available as a prepared function on the GEOS side, the question is what we do here:

- Automatically prepare the geometry within the `contains_properly` function (eg this can be done on the python side, by calling `pygeos.prepare` on the input before calling ``pygeos.lib.contains_properly``). 
- Still leave this as a responsibility to the user to provide prepared geometries (in which case I should probably add a custom error type on the C level so we can give a custom error message in python, because now I am just raising a GEOSException)

The second option is more consistent with the other predicates, but of course those all work out of the box for non-prepared geometries (so in terms of *usage*, the first option might look more consistent)