### PR TITLE
Update for compatibility with numpy 1.20 (builtin type aliases, array coercion)

### DIFF
--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -38,11 +38,11 @@ def get_parts(object[:] array):
     if count == 0:
         # return immediately if there are no geometries to return
         return (
-            np.empty(shape=(0, ), dtype=np.object),
+            np.empty(shape=(0, ), dtype=np.object_),
             np.empty(shape=(0, ), dtype=np.intp)
         )
 
-    parts = np.empty(shape=(count, ), dtype=np.object)
+    parts = np.empty(shape=(count, ), dtype=np.object_)
     index = np.empty(shape=(count, ), dtype=np.intp)
 
     cdef int[:] counts_view = counts

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -166,7 +166,7 @@ def buffer(
         np.intc(cap_style),
         np.intc(join_style),
         mitre_limit,
-        np.bool(single_sided),
+        np.bool_(single_sided),
         **kwargs
     )
 

--- a/pygeos/coordinates.py
+++ b/pygeos/coordinates.py
@@ -43,7 +43,7 @@ def apply(geometry, transformation, include_z=False):
     >>> apply(Geometry("POINT Z (0 0 0)"), lambda x: x + 1, include_z=True)
     <pygeos.Geometry POINT Z (1 1 1)>
     """
-    geometry_arr = np.array(geometry, dtype=np.object)  # makes a copy
+    geometry_arr = np.array(geometry, dtype=np.object_)  # makes a copy
     coordinates = lib.get_coordinates(geometry_arr, include_z)
     new_coordinates = transformation(coordinates)
     # check the array to yield understandable error messages
@@ -84,7 +84,7 @@ def count_coordinates(geometry):
     >>> count_coordinates([Geometry("POINT (0 0)"), None])
     1
     """
-    return lib.count_coordinates(np.asarray(geometry, dtype=np.object))
+    return lib.count_coordinates(np.asarray(geometry, dtype=np.object_))
 
 
 def get_coordinates(geometry, include_z=False):
@@ -118,7 +118,7 @@ def get_coordinates(geometry, include_z=False):
     >>> get_coordinates(Geometry("POINT Z (0 0 0)"), include_z=True).tolist()
     [[0.0, 0.0, 0.0]]
     """
-    return lib.get_coordinates(np.asarray(geometry, dtype=np.object), include_z)
+    return lib.get_coordinates(np.asarray(geometry, dtype=np.object_), include_z)
 
 
 def set_coordinates(geometry, coordinates):
@@ -151,7 +151,7 @@ def set_coordinates(geometry, coordinates):
     >>> set_coordinates(Geometry("POINT Z (0 0 0)"), [[1, 1, 1]])
     <pygeos.Geometry POINT Z (1 1 1)>
     """
-    geometry_arr = np.asarray(geometry, dtype=np.object)
+    geometry_arr = np.asarray(geometry, dtype=np.object_)
     coordinates = np.atleast_2d(np.asarray(coordinates)).astype(np.float64)
     n_coords = lib.count_coordinates(geometry_arr)
     if coordinates.ndim != 2:

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -498,7 +498,7 @@ def get_parts(geometry, return_index=False):
     >>> index.tolist()
     [0, 1, 1]
     """
-    geometry = np.asarray(geometry, dtype=np.object)
+    geometry = np.asarray(geometry, dtype=np.object_)
     geometry = np.atleast_1d(geometry)
 
     if geometry.ndim != 1:

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -241,13 +241,11 @@ def from_shapely(geometry, **kwargs):
         arr = np.empty(1, dtype=object)
         arr[0] = geometry
         arr.shape = ()
-    elif geometry is None:
-        arr = geometry
     elif not isinstance(geometry, np.ndarray) and isinstance(geometry, Collection):
         # geometry is a list/array-like
         arr = np.empty(len(geometry), dtype=object)
         arr[:] = geometry
     else:
-        # we already have a numpy array
+        # we already have a numpy array or we are None
         arr = geometry
     return lib.from_shapely(arr, **kwargs)

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -93,9 +93,9 @@ def to_wkt(
     return lib.to_wkt(
         geometry,
         np.intc(rounding_precision),
-        np.bool(trim),
+        np.bool_(trim),
         np.intc(output_dimension),
-        np.bool(old_3d),
+        np.bool_(old_3d),
         **kwargs,
     )
 
@@ -151,10 +151,10 @@ def to_wkb(
 
     return lib.to_wkb(
         geometry,
-        np.bool(hex),
+        np.bool_(hex),
         np.intc(output_dimension),
         np.intc(byte_order),
-        np.bool(include_srid),
+        np.bool_(include_srid),
         **kwargs,
     )
 
@@ -239,6 +239,8 @@ def from_shapely(geometry, **kwargs):
         arr = np.empty(1, dtype=object)
         arr[0] = geometry
         arr.shape = ()
-    else:
-        arr = np.asarray(geometry, dtype=object)
+    elif not isinstance(geometry, np.ndarray):
+        # geometry is a list/array-like
+        arr = np.empty(len(geometry), dtype=object)
+        arr[:] = geometry
     return lib.from_shapely(arr, **kwargs)

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection
+from collections.abc import Sized
 
 import numpy as np
 
@@ -241,7 +241,7 @@ def from_shapely(geometry, **kwargs):
         arr = np.empty(1, dtype=object)
         arr[0] = geometry
         arr.shape = ()
-    elif not isinstance(geometry, np.ndarray) and isinstance(geometry, Collection):
+    elif not isinstance(geometry, np.ndarray) and isinstance(geometry, Sized):
         # geometry is a list/array-like
         arr = np.empty(len(geometry), dtype=object)
         arr[:] = geometry

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -239,8 +239,13 @@ def from_shapely(geometry, **kwargs):
         arr = np.empty(1, dtype=object)
         arr[0] = geometry
         arr.shape = ()
+    elif geometry is None:
+        arr = geometry
     elif not isinstance(geometry, np.ndarray):
         # geometry is a list/array-like
         arr = np.empty(len(geometry), dtype=object)
         arr[:] = geometry
+    else:
+        # we already have a numpy array
+        arr = geometry
     return lib.from_shapely(arr, **kwargs)

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,3 +1,5 @@
+from collections.abc import Collection
+
 import numpy as np
 
 from . import Geometry  # noqa
@@ -241,7 +243,7 @@ def from_shapely(geometry, **kwargs):
         arr.shape = ()
     elif geometry is None:
         arr = geometry
-    elif not isinstance(geometry, np.ndarray):
+    elif not isinstance(geometry, np.ndarray) and isinstance(geometry, Collection):
         # geometry is a list/array-like
         arr = np.empty(len(geometry), dtype=object)
         arr[:] = geometry

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -81,7 +81,7 @@ def bounds(geometry, **kwargs):
     """
     # We need to provide the `out` argument here for compatibility with
     # numpy < 1.16. See https://github.com/numpy/numpy/issues/14949
-    geometry_arr = np.asarray(geometry, dtype=np.object)
+    geometry_arr = np.asarray(geometry, dtype=np.object_)
     out = np.empty(geometry_arr.shape + (4,), dtype="float64")
     return lib.bounds(geometry_arr, out=out, **kwargs)
 

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -52,7 +52,7 @@ class STRtree:
     """
 
     def __init__(self, geometries, leafsize=5):
-        self.geometries = np.asarray(geometries, dtype=np.object)
+        self.geometries = np.asarray(geometries, dtype=np.object_)
         self._tree = lib.STRtree(self.geometries, leafsize)
 
     def __len__(self):

--- a/pygeos/test/test_coordinates.py
+++ b/pygeos/test/test_coordinates.py
@@ -46,7 +46,7 @@ nested_3 = pygeos.geometrycollections([nested_2, point])
     ],
 )
 def test_count_coords(geoms, count):
-    actual = count_coordinates(np.array(geoms, np.object))
+    actual = count_coordinates(np.array(geoms, np.object_))
     assert actual == count
 
 
@@ -73,7 +73,7 @@ def test_count_coords(geoms, count):
     ],
 )  # fmt: on
 def test_get_coords(geoms, x, y, include_z):
-    actual = get_coordinates(np.array(geoms, np.object), include_z=include_z)
+    actual = get_coordinates(np.array(geoms, np.object_), include_z=include_z)
     if not include_z:
         expected = np.array([x, y], np.float64).T
     else:
@@ -93,7 +93,7 @@ def test_get_coords(geoms, x, y, include_z):
     ],
 )  # fmt: on
 def test_get_coords_3d(geoms, x, y, z, include_z):
-    actual = get_coordinates(np.array(geoms, np.object), include_z=include_z)
+    actual = get_coordinates(np.array(geoms, np.object_), include_z=include_z)
     if include_z:
         expected = np.array([x, y, z], np.float64).T
     else:
@@ -128,7 +128,7 @@ def test_get_coords_3d(geoms, x, y, z, include_z):
     ],
 )
 def test_set_coords(geoms, count, has_ring, include_z):
-    arr_geoms = np.array(geoms, np.object)
+    arr_geoms = np.array(geoms, np.object_)
     n = 3 if include_z else 2
     coords = get_coordinates(arr_geoms, include_z=include_z) + np.random.random((1, n))
     new_geoms = set_coordinates(arr_geoms, coords)
@@ -177,7 +177,7 @@ def test_set_coords_mixed_dimension(include_z):
     [[], [empty], [None, point, None], [nested_3], [point, point_z], [line_string_z]],
 )
 def test_apply(geoms, include_z):
-    geoms = np.array(geoms, np.object)
+    geoms = np.array(geoms, np.object_)
     coordinates_before = get_coordinates(geoms, include_z=include_z)
     new_geoms = apply(geoms, lambda x: x + 1, include_z=include_z)
     assert new_geoms is not geoms

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -25,6 +25,7 @@ class ShapelyGeometryMock:
         self.g = g
         self.__geom__ = g._ptr if hasattr(g, "_ptr") else g
 
+    @property
     def __array_interface__(self):
         # this should not be called
         raise NotImplementedError()

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -28,7 +28,8 @@ class ShapelyGeometryMock:
     @property
     def __array_interface__(self):
         # this should not be called
-        raise NotImplementedError()
+        # (starting with numpy 1.20 it is called, but not used)
+        raise None
 
 
 def test_from_wkt():

--- a/pygeos/test/test_predicates.py
+++ b/pygeos/test/test_predicates.py
@@ -41,7 +41,7 @@ BINARY_PREPARED_PREDICATES = tuple(
 def test_unary_array(geometry, func):
     actual = func([geometry, geometry])
     assert actual.shape == (2,)
-    assert actual.dtype == np.bool
+    assert actual.dtype == np.bool_
 
 
 @pytest.mark.parametrize("func", UNARY_PREDICATES)
@@ -65,7 +65,7 @@ def test_unary_missing(func):
 def test_binary_array(a, func):
     actual = func([a, a], point)
     assert actual.shape == (2,)
-    assert actual.dtype == np.bool
+    assert actual.dtype == np.bool_
 
 
 @pytest.mark.parametrize("func", BINARY_PREDICATES)
@@ -88,10 +88,10 @@ def test_equals_exact_tolerance():
     p2 = pygeos.points(50.1, 4.1)
     actual = pygeos.equals_exact([p1, p2, None], p1, tolerance=0.05)
     np.testing.assert_allclose(actual, [True, False, False])
-    assert actual.dtype == np.bool
+    assert actual.dtype == np.bool_
     actual = pygeos.equals_exact([p1, p2, None], p1, tolerance=0.2)
     np.testing.assert_allclose(actual, [True, True, False])
-    assert actual.dtype == np.bool
+    assert actual.dtype == np.bool_
 
     # default value for tolerance
     assert pygeos.equals_exact(p1, p1).item() is True


### PR DESCRIPTION
Closes https://github.com/pygeos/pygeos/issues/268

Mostly fixing warnings. In addition (the example shown in #268), the `from_shapely` function was broken in case the input was a list-like (not already an array, or not a scalar geometry)