### PR TITLE
ENH: Add STRtree benchmarks

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -81,9 +81,7 @@ class STRtree:
     """Benchmarks queries against STRtree"""
 
     def setup(self):
-        # create irregular polygons using union of buffered random points
-        points = pygeos.points(np.random.random((1000, 2)))
-        self.polygons = pygeos.get_parts(pygeos.union_all(pygeos.buffer(points, 0.025)))
+        self.polygons = pygeos.polygons(np.random.random((100, 3, 2)))
         self.tree = pygeos.STRtree(self.polygons)
 
     def time_tree_create(self):

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -56,9 +56,9 @@ class ConstructiveSuite:
         pygeos.delaunay_triangles(self.points)
 
 
-
 class GetParts:
     """Benchmarks for getting individual parts from 100 multipolygons of 100 polygons each"""
+
     def setup(self):
         self.multipolygons = np.array([pygeos.multipolygons(pygeos.polygons(np.random.random((2, 100, 2)))) for i in range(10000)], dtype=object)
 
@@ -75,3 +75,46 @@ class GetParts:
             parts.append(pygeos.get_geometry(self.multipolygons[i], range(num_parts)))
 
         parts = np.concatenate(parts)
+
+
+class STRtree:
+    """Benchmarks queries against STRtree"""
+
+    def setup(self):
+        # create irregular polygons using union of buffered random points
+        points = pygeos.points(np.random.random((1000, 2)))
+        self.polygons = pygeos.get_parts(pygeos.union_all(pygeos.buffer(points, 0.025)))
+        self.tree = pygeos.STRtree(self.polygons)
+
+    def time_tree_create(self):
+        pygeos.STRtree(self.polygons)
+
+    def time_tree_query_bulk(self):
+        self.tree.query_bulk(self.polygons)
+
+    def time_tree_query_bulk_intersects(self):
+        self.tree.query_bulk(self.polygons, predicate="intersects")
+
+    def time_tree_query_bulk_within(self):
+        self.tree.query_bulk(self.polygons, predicate="within")
+
+    def time_tree_query_bulk_contains(self):
+        self.tree.query_bulk(self.polygons, predicate="contains")
+
+    def time_tree_query_bulk_overlaps(self):
+        self.tree.query_bulk(self.polygons, predicate="overlaps")
+
+    def time_tree_query_bulk_crosses(self):
+        self.tree.query_bulk(self.polygons, predicate="crosses")
+
+    def time_tree_query_bulk_touches(self):
+        self.tree.query_bulk(self.polygons, predicate="touches")
+
+    def time_tree_query_bulk_covers(self):
+        self.tree.query_bulk(self.polygons, predicate="covers")
+
+    def time_tree_query_bulk_covered_by(self):
+        self.tree.query_bulk(self.polygons, predicate="covered_by")
+
+    def time_tree_query_bulk_contains_properly(self):
+        self.tree.query_bulk(self.polygons, predicate="contains_properly")

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -2,6 +2,10 @@ import numpy as np
 import pygeos
 
 
+# Seed the numpy random generator for more reproducible benchmarks
+np.random.seed(0)
+
+
 class PointPolygonTimeSuite:
     """Benchmarks running on 100000 points and one polygon"""
     def setup(self):

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -81,11 +81,19 @@ class STRtree:
     """Benchmarks queries against STRtree"""
 
     def setup(self):
-        self.polygons = pygeos.polygons(np.random.random((100, 3, 2)))
+        # create irregular polygons my merging overlapping point buffers
+        self.polygons = pygeos.get_parts(
+            pygeos.union_all(
+                pygeos.buffer(pygeos.points(np.random.random((2000, 2)) * 500), 5)
+            )
+        )
         self.tree = pygeos.STRtree(self.polygons)
+        # initialize the tree by making a tiny query first
+        self.tree.query(pygeos.points(0, 0))
 
     def time_tree_create(self):
-        pygeos.STRtree(self.polygons)
+        tree = pygeos.STRtree(self.polygons)
+        tree.query(pygeos.points(0, 0))
 
     def time_tree_query_bulk(self):
         self.tree.query_bulk(self.polygons)


### PR DESCRIPTION
Adds basic benchmarks of STRtree query bulk functionality against polygons.

On my local machine, this shows:
```
time_tree_create                                                                                 4.47±0.4μs
time_tree_query_bulk                                                                             3.39±0.5μs
time_tree_query_bulk_contains                                                                      67.6±4ms
time_tree_query_bulk_contains_properly                                                          1.04±0.06ms
time_tree_query_bulk_covered_by                                                                    51.2±6ms
time_tree_query_bulk_covers                                                                        65.0±3ms
time_tree_query_bulk_crosses                                                                       59.8±4ms
time_tree_query_bulk_intersects                                                                    5.70±1ms
time_tree_query_bulk_overlaps                                                                      48.3±4ms
time_tree_query_bulk_touches                                                                       55.2±7ms
time_tree_query_bulk_within                                                                        49.8±3ms
```

Among other things, this highlights which predicates have a prepared predicate implementation in GEOS (`intersects`, `contains_properly`).
