### PR TITLE
CI: add GEOS 3.9.0 build to linux CI

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -72,7 +72,6 @@ jobs:
 
       - name: Run tests
         shell: bash
-        continue-on-error: ${{ matrix.channel == 'conda-forge' }}
         run: |
           source activate test
           pytest --doctest-modules

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -29,8 +29,8 @@ jobs:
             numpy: 1.17.5
           # 2020
           - python: 3.9
-            geos: 3.8.1
-            numpy: 1.19.4
+            geos: 3.9.0
+            numpy: 1.19.5
           # dev
           - python: 3.9
             geos: master

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -604,9 +604,10 @@ def voronoi_polygons(
 
     Examples
     --------
+    >>> from pygeos import normalize
     >>> points = Geometry("MULTIPOINT (2 2, 4 2)")
-    >>> voronoi_polygons(points)
-    <pygeos.Geometry GEOMETRYCOLLECTION (POLYGON ((3 0, 0 0, 0 4, 3 4, 3 0)), PO...>
+    >>> normalize(voronoi_polygons(points))
+    <pygeos.Geometry GEOMETRYCOLLECTION (POLYGON ((3 0, 3 4, 6 4, 6 0, 3 0)), PO...>
     >>> voronoi_polygons(points, only_edges=True)
     <pygeos.Geometry LINESTRING (3 4, 3 0)>
     >>> voronoi_polygons(Geometry("MULTIPOINT (2 2, 4 2, 4.2 2)"), 0.5, only_edges=True)


### PR DESCRIPTION
GEOS 3.9.0 is already released a while, so adding it to the Linux github actions builds. 
In addition, it was added to conda-forge a few days ago, so I think it should automatically be picked up for the "GEOS latest" builds using the conda-forge channel in the conda github action builds.