### PR TITLE
DOC: fix style issue with numpydoc parameter names and sphinx_rtd_theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,12 @@
+/*Copied from sphinx' basic.css to ensure the sphinx >2.0 docstrings are
+rendered somewhat properly (xref https://github.com/numpy/numpydoc/issues/215) */
+
+.classifier {
+    font-style: oblique;
+}
+
+.classifier:before {
+    font-style: normal;
+    margin: 0.5em;
+    content: ":";
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,3 +50,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_css_files = [
+    'custom.css',
+]

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,6 +7,3 @@ dependencies:
   - numpy==1.19.*
   - numpydoc==1.1.*
   - Cython==0.29.*
-  # include those here to ensure we get the latest versions
-  - sphinx
-  - sphinx_rtd_theme

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,6 @@
 name: pygeos
 channels:
-  - conda-forge
+  - defaults
 dependencies:
   - python==3.8.*
   - geos==3.8.*

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,9 +1,12 @@
 name: pygeos
 channels:
-  - defaults
+  - conda-forge
 dependencies:
   - python==3.8.*
   - geos==3.8.*
   - numpy==1.19.*
   - numpydoc==1.1.*
   - Cython==0.29.*
+  # include those here to ensure we get the latest versions
+  - sphinx
+  - sphinx_rtd_theme


### PR DESCRIPTION
So I think the issue is due to a sphinx > 2 compatibility issue with numpydoc (https://github.com/numpy/numpydoc/issues/215). I included a workaround for that in the past in geopandas (https://github.com/geopandas/geopandas/pull/1299). 
But, it should normally now also be fixed in the rtd theme itself in the latest versions. The problem seems to be that we are getting an older version (I assume because rtd installs it from defaults). So testing if installing it in our specified env from conda-forge solves that.