### PR TITLE
Update ASV configuration

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -55,11 +55,11 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.7"],
+    "pythons": ["3.8"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order
-    "conda_channels": ["defaults"],
+    "conda_channels": ["conda-forge"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
@@ -72,8 +72,9 @@
     // followed by the pip installed packages).
     //
      "matrix": {
-         "numpy": [""],
-         "geos": [""]
+         "Cython": [],
+         "numpy": [],
+         "geos": [],
      },
 
     // Combinations of libraries/python versions can be excluded/included


### PR DESCRIPTION
Add cython, which is now needed to build pygeos, and update the python version. I also set conda-forge as channel, because defaults is typically a bit lagging behind (eg in GEOS version)