### PR TITLE
Change default STRtree leaf lize (node capacity) to 10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Version 0.10 (unreleased)
 
 * ...
 
+**API Changes**
+
+* STRtree default leaf size is now 10 instead of 5, for somewhat better performance
+  under normal conditions.
+
 **Added GEOS functions**
 
 * Addition of a ``contains_properly`` function (#267).

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -51,7 +51,7 @@ class STRtree:
     [[0, 0, 0, 1, 1], [2, 3, 4, 5, 6]]
     """
 
-    def __init__(self, geometries, leafsize=5):
+    def __init__(self, geometries, leafsize=10):
         self.geometries = np.asarray(geometries, dtype=np.object_)
         self._tree = lib.STRtree(self.geometries, leafsize)
 


### PR DESCRIPTION
I ran our STRtree benchmarks, but it didn't give any significant change (it might be that our benchmarks are too small / too "dummy" random geometries to notice a difference, if there would be one)

This came up in Shapely, where this was actually done wrong (set at size of geometry array, https://github.com/Toblerity/Shapely/pull/1064#discussion_r562376957). While this is not the case here, @dbaston mentioned that based on his experiments leaf size of 8 to 16 was optimal, and GEOS internally defauls to 10. So unless we have a good reason to deviate (@caspervdw?), probably best to just follow GEOS' default.
