### PR TITLE
Fix signed char portability issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Version 0.10 (unreleased)
 
 * Addition of a ``contains_properly`` function (#267).
 
+**Bug fixes**
+* Fixed portability issue for ARM architecture (#293)
+
 **Acknowledgments**
 
 Thanks to everyone who contributed to this release!

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,0 +1,17 @@
+# This docker container is used for testing pygeos in ARM64 emulation mode.
+# To build it:
+# docker build . -f ./docker/Dockerfile.arm64 -t pygeos/arm64
+# Then run the pygeos test suite:
+# docker run --rm pygeos/arm64:latest python3 -m pytest -vv
+
+FROM --platform=linux/arm64/v8 arm64v8/ubuntu:20.04
+
+RUN apt-get update && apt-get install -y build-essential libgeos-dev python3-dev python3-pip --no-install-recommends
+
+RUN pip3 install numpy Cython pytest
+
+COPY . /code
+
+WORKDIR /code
+
+RUN python3 setup.py build_ext --inplace

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1988,8 +1988,7 @@ static char create_collection_dtypes[3] = {NPY_OBJECT, NPY_INT, NPY_OBJECT};
 static void create_collection_func(char** args, npy_intp* dimensions, npy_intp* steps,
                                    void* data) {
   GEOSGeometry *g, *g_copy;
-  int n_geoms, type;
-  char actual_type, expected_type, alt_expected_type;
+  int n_geoms, type, actual_type, expected_type, alt_expected_type;
 
   GEOS_INIT;
 


### PR DESCRIPTION
Resolves #291 

We were using a `char` with a -1 sentinel value, which fails on ARM architectures because it is unsigned.  This PR assigns it to an `int` which is the proper return value for `GEOSGeomTypeId_r` in this case anyway.