### PR TITLE
Update pin for numpy version for Python 3.9 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires = [
     "numpy==1.13.3; python_version=='3.6'",
     "numpy==1.14.5; python_version=='3.7'",
     "numpy==1.17.3; python_version=='3.8'",
+    "numpy==1.19.3; python_version=='3.9'",
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
-    "numpy; python_version>='3.9'",
+    "numpy; python_version>='3.10'",
     "Cython>=0.29",
 ]


### PR DESCRIPTION
@brendan-ward I _think_ this should fix #294

Now that numpy 1.20 is released, we have the problem that in the Python 3.9 build we pinned numpy to 1.19 in the environment, but pygeos itself was still built against the latest (so a newer) numpy. And when it comes to building, numpy is forward compatible (built with older version will work with newer), but not the other way around