### PR TITLE
ENH: add polygonize_full

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Version 0.10 (unreleased)
 
 * Addition of a ``contains_properly`` function (#267)
 * Addition of a ``polygonize`` function (#275)
+* Addition of a ``polygonize_full`` function (#298)
 * Addition of a ``segmentize`` function for GEOS >= 3.10 (#299)
 
 **Bug fixes**

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -568,6 +568,9 @@ def polygonize_full(geometries, **kwargs):
         Axis along which the geometries are polygonized.
         The default is to perform a reduction over the last dimension
         of the input array. A 1D array results in a scalar geometry.
+    **kwargs
+        For other keyword-only arguments, see the
+        `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
 
     Returns
     -------

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -22,6 +22,7 @@ __all__ = [
     "normalize",
     "point_on_surface",
     "polygonize",
+    "polygonize_full",
     "reverse",
     "simplify",
     "snap",
@@ -521,6 +522,7 @@ def polygonize(geometries, **kwargs):
     See Also
     --------
     get_parts, get_geometry
+    polygonize_full
 
     Examples
     --------
@@ -533,6 +535,61 @@ def polygonize(geometries, **kwargs):
     <pygeos.Geometry GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))>
     """
     return lib.polygonize(geometries, **kwargs)
+
+
+def polygonize_full(geometries, **kwargs):
+    """Creates polygons formed from the linework of a set of Geometries and
+    return all extra outputs as well.
+
+    Polygonizes an array of Geometries that contain linework which
+    represents the edges of a planar graph. Any type of Geometry may be
+    provided as input; only the constituent lines and rings will be used to
+    create the output polygons.
+
+    This function performs the same polygonization as `polygonize` but does
+    not only return the polygonal result but all extra outputs as well. The
+    return value consists of 4 elements:
+
+    * The polygonal valid output
+    * **Cut edges**: edges connected on both ends but not part of polygonal output
+    * **dangles**: edges connected on one end but not part of polygonal output
+    * **invalid rings**: polygons formed but which are not valid
+
+    This function returns the geometries within GeometryCollections.
+    Individual geometries can be obtained using `get_geometry` to get
+    a single geometry or `get_parts` to get an array of geometries.
+
+    Parameters
+    ----------
+    geometries : array_like
+        An array of geometries.
+    axis : int
+        Axis along which the geometries are polygonized.
+        The default is to perform a reduction over the last dimension
+        of the input array. A 1D array results in a scalar geometry.
+
+    Returns
+    -------
+    tuple of 4 GeometryCollections or array of shape (N, 4) of GeometryCollections
+
+    See Also
+    --------
+    polygonize
+
+    Examples
+    --------
+    >>> lines = [
+    ...     Geometry("LINESTRING (0 0, 1 1)"),
+    ...     Geometry("LINESTRING (0 0, 0 1, 1 1)"),
+    ...     Geometry("LINESTRING (0 1, 1 1)"),
+    ... ]
+    >>> polygonize_full(lines)
+    (<pygeos.Geometry GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))>,
+     <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>,
+     <pygeos.Geometry GEOMETRYCOLLECTION (LINESTRING (0 1, 1 1))>,
+     <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>)
+    """
+    return lib.polygonize_full(geometries, **kwargs)
 
 
 @requires_geos("3.7.0")

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -584,7 +584,7 @@ def polygonize_full(geometries, **kwargs):
     ...     Geometry("LINESTRING (0 0, 0 1, 1 1)"),
     ...     Geometry("LINESTRING (0 1, 1 1)"),
     ... ]
-    >>> polygonize_full(lines)
+    >>> polygonize_full(lines)  # doctest: +NORMALIZE_WHITESPACE
     (<pygeos.Geometry GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))>,
      <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>,
      <pygeos.Geometry GEOMETRYCOLLECTION (LINESTRING (0 1, 1 1))>,

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -570,7 +570,8 @@ def polygonize_full(geometries, **kwargs):
 
     Returns
     -------
-    tuple of 4 GeometryCollections or array of shape (N, 4) of GeometryCollections
+    (polgyons, cuts, dangles, invalid)
+        tuple of 4 GeometryCollections or arrays of GeometryCollections
 
     See Also
     --------

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -482,10 +482,12 @@ def test_polygonize_missing():
 
 def test_polygonize_full():
     lines = [
+        None,
         pygeos.Geometry("LINESTRING (0 0, 1 1)"),
         pygeos.Geometry("LINESTRING (0 0, 0 1)"),
         pygeos.Geometry("LINESTRING (0 1, 1 1)"),
         pygeos.Geometry("LINESTRING (1 1, 1 0)"),
+        None,
         pygeos.Geometry("LINESTRING (1 0, 0 0)"),
         pygeos.Geometry("LINESTRING (5 5, 6 6)"),
         pygeos.Geometry("LINESTRING (1 1, 100 100)"),

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -521,12 +521,18 @@ def test_polygonize_full_array():
     assert len(result) == 4
     assert all(isinstance(geom, pygeos.Geometry) for geom in result)
     assert result[0] == expected
+    assert all(
+        geom == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY") for geom in result[1:]
+    )
 
     result = pygeos.polygonize_full(np.array([lines]))
     assert len(result) == 4
     assert all(isinstance(geom, np.ndarray) for geom in result)
     assert all(geom.shape == (1,) for geom in result)
     assert result[0][0] == expected
+    assert all(
+        geom[0] == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY") for geom in result[1:]
+    )
 
     arr = np.array([lines, lines])
     assert arr.shape == (2, 3)
@@ -536,6 +542,10 @@ def test_polygonize_full_array():
     assert all(arr.shape == (2,) for arr in result)
     assert result[0][0] == expected
     assert result[0][1] == expected
+    assert all(
+        g == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY")
+        for geom in result[1:] for g in geom
+    )
 
     arr = np.array([[lines, lines], [lines, lines], [lines, lines]])
     assert arr.shape == (3, 2, 3)
@@ -545,6 +555,9 @@ def test_polygonize_full_array():
     assert all(arr.shape == (3, 2) for arr in result)
     for res in result[0].flatten():
         assert res == expected
+    for arr in result[1:]:
+        for res in arr.flatten():
+            assert res == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY")
 
 
 @pytest.mark.skipif(

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -513,9 +513,7 @@ def test_polygonize_full_array():
         pygeos.Geometry("LINESTRING (0 0, 0 1)"),
         pygeos.Geometry("LINESTRING (0 1, 1 1)"),
     ]
-    expected = pygeos.Geometry(
-        "GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))"
-    )
+    expected = pygeos.Geometry("GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))")
     result = pygeos.polygonize_full(np.array(lines))
     assert len(result) == 4
     assert all(isinstance(geom, pygeos.Geometry) for geom in result)
@@ -543,7 +541,8 @@ def test_polygonize_full_array():
     assert result[0][1] == expected
     assert all(
         g == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY")
-        for geom in result[1:] for g in geom
+        for geom in result[1:]
+        for g in geom
     )
 
     arr = np.array([[lines, lines], [lines, lines], [lines, lines]])

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -468,3 +468,96 @@ def test_polygonize_missing():
     # set of geometries that is all missing
     result = pygeos.polygonize([None, None])
     assert result == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY")
+
+
+def test_polygonize_full():
+    lines = [
+        pygeos.Geometry("LINESTRING (0 0, 1 1)"),
+        pygeos.Geometry("LINESTRING (0 0, 0 1)"),
+        pygeos.Geometry("LINESTRING (0 1, 1 1)"),
+        pygeos.Geometry("LINESTRING (1 1, 1 0)"),
+        pygeos.Geometry("LINESTRING (1 0, 0 0)"),
+        pygeos.Geometry("LINESTRING (5 5, 6 6)"),
+        pygeos.Geometry("LINESTRING (1 1, 100 100)"),
+        pygeos.Geometry("POINT (0 0)"),
+        None,
+    ]
+    result = pygeos.polygonize_full(lines)
+    assert len(result) == 4
+    assert all(pygeos.get_type_id(geom) == 7 for geom in result)  # GeometryCollection
+    polygons, cuts, dangles, invalid = result
+    expected_polygons = pygeos.Geometry(
+        "GEOMETRYCOLLECTION (POLYGON ((0 0, 1 1, 1 0, 0 0)), POLYGON ((1 1, 0 0, 0 1, 1 1)))"
+    )
+    assert polygons == expected_polygons
+    assert cuts == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY")
+    expected_dangles = pygeos.Geometry(
+        "GEOMETRYCOLLECTION (LINESTRING (1 1, 100 100), LINESTRING (5 5, 6 6))"
+    )
+    assert dangles == expected_dangles
+    assert invalid == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY")
+
+
+def test_polygonize_full_array():
+    lines = [
+        pygeos.Geometry("LINESTRING (0 0, 1 1)"),
+        pygeos.Geometry("LINESTRING (0 0, 0 1)"),
+        pygeos.Geometry("LINESTRING (0 1, 1 1)"),
+    ]
+    expected = pygeos.Geometry(
+        "GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))"
+    )
+    result = pygeos.polygonize_full(np.array(lines))
+    assert len(result) == 4
+    assert all(isinstance(geom, pygeos.Geometry) for geom in result)
+    assert result[0] == expected
+
+    result = pygeos.polygonize_full(np.array([lines]))
+    assert len(result) == 4
+    assert all(isinstance(geom, np.ndarray) for geom in result)
+    assert all(geom.shape == (1,) for geom in result)
+    assert result[0][0] == expected
+
+    arr = np.array([lines, lines])
+    assert arr.shape == (2, 3)
+    result = pygeos.polygonize_full(arr)
+    assert len(result) == 4
+    assert all(isinstance(arr, np.ndarray) for arr in result)
+    assert all(arr.shape == (2,) for arr in result)
+    assert result[0][0] == expected
+    assert result[0][1] == expected
+
+    arr = np.array([[lines, lines], [lines, lines], [lines, lines]])
+    assert arr.shape == (3, 2, 3)
+    result = pygeos.polygonize_full(arr)
+    assert len(result) == 4
+    assert all(isinstance(arr, np.ndarray) for arr in result)
+    assert all(arr.shape == (3, 2) for arr in result)
+    for res in result[0].flatten():
+        assert res == expected
+
+
+@pytest.mark.skipif(
+    np.__version__ < "1.15",
+    reason="axis keyword for generalized ufunc introduced in np 1.15",
+)
+def test_polygonize_full_array_axis():
+    lines = [
+        pygeos.Geometry("LINESTRING (0 0, 1 1)"),
+        pygeos.Geometry("LINESTRING (0 0, 0 1)"),
+        pygeos.Geometry("LINESTRING (0 1, 1 1)"),
+    ]
+    arr = np.array([lines, lines])  # shape (2, 3)
+    result = pygeos.polygonize_full(arr, axis=1)
+    assert len(result) == 4
+    assert all(arr.shape == (2,) for arr in result)
+    result = pygeos.polygonize_full(arr, axis=0)
+    assert len(result) == 4
+    assert all(arr.shape == (3,) for arr in result)
+
+
+def test_polygonize_full_missing():
+    # set of geometries that is all missing
+    result = pygeos.polygonize_full([None, None])
+    assert len(result) == 4
+    assert all(geom == pygeos.Geometry("GEOMETRYCOLLECTION EMPTY") for geom in result)

--- a/src/fast_loop_macros.h
+++ b/src/fast_loop_macros.h
@@ -65,6 +65,16 @@
   cp1 = ip1;                      \
   for (i_c1 = 0; i_c1 < n_c1; i_c1++, cp1 += cs1)
 
+/** (ip1, cp1) -> (op1, op2, op3, op4) */
+#define SINGLE_COREDIM_LOOP_OUTER_NOUT4                                                \
+  char *ip1 = args[0], *op1 = args[1], *op2 = args[2], *op3 = args[3], *op4 = args[4], \
+       *cp1;                                                                           \
+  npy_intp is1 = steps[0], os1 = steps[1], os2 = steps[2], os3 = steps[3],             \
+           os4 = steps[4], cs1 = steps[5];                                             \
+  npy_intp n = dimensions[0], n_c1 = dimensions[1];                                    \
+  npy_intp i, i_c1;                                                                    \
+  for (i = 0; i < n; i++, ip1 += is1, op1 += os1, op2 += os2, op3 += os3, op4 += os4)
+
 /** (ip1, cp1, cp2) -> (op1) */
 #define DOUBLE_COREDIM_LOOP_OUTER                                          \
   char *ip1 = args[0], *op1 = args[1], *cp1, *cp2;                         \

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1900,11 +1900,13 @@ static void polygonize_full_func(char** args, npy_intp* dimensions, npy_intp* st
     OUTPUT_Y_I(2, cuts);
     OUTPUT_Y_I(3, dangles);
     OUTPUT_Y_I(4, invalidRings);
+    GEOSGeom_destroy_r(ctx, collection);
+    collection = NULL;
   }
 
 finish:
   if (collection != NULL) {
-    free(collection);
+    GEOSGeom_destroy_r(ctx, collection);
   }
   if (geoms != NULL) {
     free(geoms);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1900,7 +1900,7 @@ static void polygonize_full_func(char** args, npy_intp* dimensions, npy_intp* st
     OUTPUT_Y_I(2, cuts);
     OUTPUT_Y_I(3, dangles);
     OUTPUT_Y_I(4, invalidRings);
-    GEOSGeom_destroy_r(ctx, collection);
+    // GEOSGeom_destroy_r(ctx, collection);
     collection = NULL;
   }
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1235,7 +1235,7 @@ static PyUFuncGenericFunction YYd_Y_funcs[1] = {&YYd_Y_func};
 
 /* Define functions with unique call signatures */
 static char box_dtypes[6] = {NPY_DOUBLE, NPY_DOUBLE, NPY_DOUBLE,
-                             NPY_DOUBLE, NPY_BOOL, NPY_OBJECT};
+                             NPY_DOUBLE, NPY_BOOL,   NPY_OBJECT};
 static void box_func(char** args, npy_intp* dimensions, npy_intp* steps, void* data) {
   char *ip1 = args[0], *ip2 = args[1], *ip3 = args[2], *ip4 = args[3], *ip5 = args[4];
   npy_intp is1 = steps[0], is2 = steps[1], is3 = steps[2], is4 = steps[3], is5 = steps[4];
@@ -1884,6 +1884,11 @@ static void polygonize_full_func(char** args, npy_intp* dimensions, npy_intp* st
       // need to copy the input geometries, because the Collection takes ownership
       geom_copy = GEOSGeom_clone_r(ctx, geom);
       if (geom_copy == NULL) {
+        // if something went wrong before creating the collection, destroy previously
+        // cloned geoms
+        for (i = 0; i < n_geoms; i++) {
+          GEOSGeom_destroy_r(ctx, geoms[i]);
+        }
         errstate = PGERR_GEOS_EXCEPTION;
         goto finish;
       }


### PR DESCRIPTION
Follow-up on https://github.com/pygeos/pygeos/pull/275, adding the "full" version.

Current behaviour: returns 4 collections (polygons, dangles, cut edges, invalid rings):

```
In [17]: lines = np.array([pygeos.Geometry("LINESTRING (0 0, 1 1)"), pygeos.Geometry("LINESTRING (0 0, 0 1, 1 1)"), pygeos.Geometry("LINESTRING (0 1, 1 1)")])

In [18]: pygeos.lib.polygonize_full(lines)
Out[18]: 
(<pygeos.Geometry GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))>,
 <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>,
 <pygeos.Geometry GEOMETRYCOLLECTION (LINESTRING (0 1, 1 1))>,
 <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>)
```