### PR TITLE
CI: bump versions to latest GEOS-3.9.1

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -29,7 +29,7 @@ jobs:
             numpy: 1.17.5
           # 2020
           - python: 3.9
-            geos: 3.9.0
+            geos: 3.9.1
             numpy: 1.19.5
           # dev
           - python: 3.9

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
       NUMPY_VERSION: 1.17.5
     - PYTHON: "C:\\Python39-x64"
       ARCH: x64
-      GEOS_VERSION: 3.8.1
+      GEOS_VERSION: 3.9.1
       NUMPY_VERSION: 1.19.4
 
 install:


### PR DESCRIPTION
GEOS 3.9.1 was recently [announced](https://lists.osgeo.org/pipermail/geos-devel/2021-February/010138.html). Bump the following GEOS versions:

- Github Actions: 3.9.0 -> 3.9.1
- AppVeyor: 3.8.1 -> 3.9.1