### PR TITLE
TST: Handle GEOS version strings with dev / beta qualifiers in the tests

### DIFF
--- a/pygeos/test/test_misc.py
+++ b/pygeos/test/test_misc.py
@@ -1,4 +1,4 @@
-from string import ascii_letters
+from string import ascii_lowercase
 
 import pygeos
 from pygeos.decorators import requires_geos, multithreading_enabled
@@ -25,7 +25,7 @@ def test_geos_version():
     actual = pygeos.geos_version_string
 
     # strip any beta / dev qualifiers
-    actual = actual.lower().rstrip(ascii_letters)
+    actual = actual.lower().rstrip(ascii_lowercase)
 
     assert actual == expected
 
@@ -45,9 +45,7 @@ def test_geos_capi_version():
         actual_geos_api_version,
     ) = pygeos.geos_capi_version_string.split("-CAPI-")
 
-    actual_geos_version = actual_geos_version.lower().rstrip(
-        ascii_letters
-    )
+    actual_geos_version = actual_geos_version.lower().rstrip(ascii_lowercase)
 
     assert (
         "{0}-CAPI-{1}".format(actual_geos_version, actual_geos_api_version) == expected

--- a/pygeos/test/test_misc.py
+++ b/pygeos/test/test_misc.py
@@ -20,7 +20,12 @@ def test_version():
 
 def test_geos_version():
     expected = "{0:d}.{1:d}.{2:d}".format(*pygeos.geos_version)
-    assert pygeos.geos_version_string == expected
+    actual = pygeos.geos_version_string
+
+    # strip any beta / dev qualifiers
+    actual = actual.lower().rstrip("abcdefghijklmnopqrstuvwxyz")
+
+    assert actual == expected
 
 
 @pytest.mark.skipif(
@@ -31,7 +36,20 @@ def test_geos_capi_version():
     expected = "{0:d}.{1:d}.{2:d}-CAPI-{3:d}.{4:d}.{5:d}".format(
         *(pygeos.geos_version + pygeos.geos_capi_version)
     )
-    assert pygeos.geos_capi_version_string == expected
+
+    # split into component parts and strip any beta / dev qualifiers
+    (
+        actual_geos_version,
+        actual_geos_api_version,
+    ) = pygeos.geos_capi_version_string.split("-CAPI-")
+
+    actual_geos_version = actual_geos_version.lower().rstrip(
+        "abcdefghijklmnopqrstuvwxyz"
+    )
+
+    assert (
+        "{0}-CAPI-{1}".format(actual_geos_version, actual_geos_api_version) == expected
+    )
 
 
 @pytest.mark.parametrize("version", ["3.7.0", "3.7.1", "3.6.2"])

--- a/pygeos/test/test_misc.py
+++ b/pygeos/test/test_misc.py
@@ -1,3 +1,5 @@
+from string import ascii_letters
+
 import pygeos
 from pygeos.decorators import requires_geos, multithreading_enabled
 from unittest import mock
@@ -23,7 +25,7 @@ def test_geos_version():
     actual = pygeos.geos_version_string
 
     # strip any beta / dev qualifiers
-    actual = actual.lower().rstrip("abcdefghijklmnopqrstuvwxyz")
+    actual = actual.lower().rstrip(ascii_letters)
 
     assert actual == expected
 
@@ -44,7 +46,7 @@ def test_geos_capi_version():
     ) = pygeos.geos_capi_version_string.split("-CAPI-")
 
     actual_geos_version = actual_geos_version.lower().rstrip(
-        "abcdefghijklmnopqrstuvwxyz"
+        ascii_letters
     )
 
     assert (

--- a/src/lib.c
+++ b/src/lib.c
@@ -68,6 +68,16 @@ PyMODINIT_FUNC PyInit_lib(void) {
 #define GEOS_VERSION_PATCH_STR QUOTE(GEOS_VERSION_PATCH)
   int geos_version_patch_int = GEOS_VERSION_PATCH_STR[0] - '0';
 
+  char geos_version_buffer[16];
+  char geos_capi_version_buffer[32];
+
+  snprintf(geos_version_buffer, 16, "%i.%i.%i", GEOS_VERSION_MAJOR, GEOS_VERSION_MINOR,
+           geos_version_patch_int);
+
+  snprintf(geos_capi_version_buffer, 32, "%i.%i.%i-CAPI-%i.%i.%i", GEOS_VERSION_MAJOR,
+           GEOS_VERSION_MINOR, geos_version_patch_int, GEOS_CAPI_VERSION_MAJOR,
+           GEOS_CAPI_VERSION_MINOR, GEOS_CAPI_VERSION_PATCH);
+
   /* export the GEOS versions as python tuple and string */
   PyModule_AddObject(m, "geos_version",
                      PyTuple_Pack(3, PyLong_FromLong((long)GEOS_VERSION_MAJOR),
@@ -78,9 +88,9 @@ PyMODINIT_FUNC PyInit_lib(void) {
                                   PyLong_FromLong((long)GEOS_CAPI_VERSION_MINOR),
                                   PyLong_FromLong((long)GEOS_CAPI_VERSION_PATCH)));
 
-  PyModule_AddObject(m, "geos_version_string", PyUnicode_FromString(GEOS_VERSION));
+  PyModule_AddObject(m, "geos_version_string", PyUnicode_FromString(geos_version_buffer));
   PyModule_AddObject(m, "geos_capi_version_string",
-                     PyUnicode_FromString(GEOS_CAPI_VERSION));
+                     PyUnicode_FromString(geos_capi_version_buffer));
 
   if (init_ufuncs(m, d) < 0) {
     return NULL;

--- a/src/lib.c
+++ b/src/lib.c
@@ -68,16 +68,6 @@ PyMODINIT_FUNC PyInit_lib(void) {
 #define GEOS_VERSION_PATCH_STR QUOTE(GEOS_VERSION_PATCH)
   int geos_version_patch_int = GEOS_VERSION_PATCH_STR[0] - '0';
 
-  char geos_version_buffer[16];
-  char geos_capi_version_buffer[32];
-
-  snprintf(geos_version_buffer, 16, "%i.%i.%i", GEOS_VERSION_MAJOR, GEOS_VERSION_MINOR,
-           geos_version_patch_int);
-
-  snprintf(geos_capi_version_buffer, 32, "%i.%i.%i-CAPI-%i.%i.%i", GEOS_VERSION_MAJOR,
-           GEOS_VERSION_MINOR, geos_version_patch_int, GEOS_CAPI_VERSION_MAJOR,
-           GEOS_CAPI_VERSION_MINOR, GEOS_CAPI_VERSION_PATCH);
-
   /* export the GEOS versions as python tuple and string */
   PyModule_AddObject(m, "geos_version",
                      PyTuple_Pack(3, PyLong_FromLong((long)GEOS_VERSION_MAJOR),
@@ -88,9 +78,9 @@ PyMODINIT_FUNC PyInit_lib(void) {
                                   PyLong_FromLong((long)GEOS_CAPI_VERSION_MINOR),
                                   PyLong_FromLong((long)GEOS_CAPI_VERSION_PATCH)));
 
-  PyModule_AddObject(m, "geos_version_string", PyUnicode_FromString(geos_version_buffer));
+  PyModule_AddObject(m, "geos_version_string", PyUnicode_FromString(GEOS_VERSION));
   PyModule_AddObject(m, "geos_capi_version_string",
-                     PyUnicode_FromString(geos_capi_version_buffer));
+                     PyUnicode_FromString(GEOS_CAPI_VERSION));
 
   if (init_ufuncs(m, d) < 0) {
     return NULL;


### PR DESCRIPTION
We are getting version test failures on GEOS master or latest on the `3.9.1` branch because the version string includes modifiers like `dev`.

This PR is one way to resolve that within C, by building up the string from the integer parts.  I'm not sure I like this option; it has the risk of being a tautology (i.e., version string is no longer a validity check against the tuple of version parts).

Do we want the version string to reflect the original string from GEOS with these modifiers?  This seems like it might be useful from a troubleshooting perspective.  In which case, we just need to modify the tests so that they ignore these modifiers, but we allow the versions to be a bit different: (3,9,1) => `3.9.1dev`