### PR TITLE
NaN equality tests for GEOS 3.10

### DIFF
--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -32,6 +32,9 @@ def _wrap_construct_ufunc(func, coords, y=None, z=None):
 def points(coords, y=None, z=None):
     """Create an array of points.
 
+    Note that GEOS >=3.10 automatically converts POINT (nan nan) to
+    POINT EMPTY.
+
     Parameters
     ----------
     coords : array_like

--- a/pygeos/test/common.py
+++ b/pygeos/test/common.py
@@ -33,7 +33,7 @@ empty_point = pygeos.Geometry("POINT EMPTY")
 empty_line_string = pygeos.Geometry("LINESTRING EMPTY")
 empty_polygon = pygeos.Geometry("POLYGON EMPTY")
 empty = pygeos.Geometry("GEOMETRYCOLLECTION EMPTY")
-point_nan = pygeos.points(np.nan, np.nan)
+line_string_nan = pygeos.linestrings([(np.nan, np.nan), (np.nan, np.nan)])
 
 all_types = (
     point,

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -41,6 +41,11 @@ def test_points_invalid_ndim():
         pygeos.points([0, 1, 2, 3])
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
+def test_points_nan_becomes_empty():
+    assert str(pygeos.points(np.nan, np.nan)) == "POINT EMPTY"
+
+
 def test_linestrings_from_coords():
     actual = pygeos.linestrings([[[0, 0], [1, 1]], [[0, 0], [2, 2]]])
     assert str(actual[0]) == "LINESTRING (0 0, 1 1)"

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -4,7 +4,7 @@ import pygeos
 import pytest
 
 from .common import point
-from .common import point_nan
+from .common import line_string_nan
 from .common import empty_point
 from .common import line_string
 from .common import empty_line_string
@@ -231,24 +231,24 @@ def test_set_unique(geom):
 
 
 def test_eq_nan():
-    assert point_nan != point_nan
+    assert line_string_nan != line_string_nan
 
 
 def test_neq_nan():
-    assert not (point_nan == point_nan)
+    assert not (line_string_nan == line_string_nan)
 
 
 def test_set_nan():
     # As NaN != NaN, you can have multiple "NaN" points in a set
     # set([float("nan"), float("nan")]) also returns a set with 2 elements
-    a = set(pygeos.points([[np.nan, np.nan]] * 10))
+    a = set(pygeos.linestrings([[[np.nan, np.nan], [np.nan, np.nan]]] * 10))
     assert len(a) == 10  # different objects: NaN != NaN
 
 
 def test_set_nan_same_objects():
     # You can't put identical objects in a set.
     # x = float("nan"); set([x, x]) also retuns a set with 1 element
-    a = set([point_nan] * 10)
+    a = set([line_string_nan] * 10)
     assert len(a) == 1
 
 
@@ -411,7 +411,7 @@ def test_set_precision_z():
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision_nan():
-    assert np.all(np.isnan(pygeos.get_coordinates(pygeos.set_precision(point_nan, 1))))
+    assert np.all(np.isnan(pygeos.get_coordinates(pygeos.set_precision(line_string_nan, 1))))
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")

--- a/src/geos.c
+++ b/src/geos.c
@@ -15,18 +15,12 @@ int init_geos(PyObject* m) {
   return 0;
 }
 
-/* Returns 1 if geometry is an empty point, 0 otherwise, 2 on error.
- */
-char is_point_empty(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
-  int geom_type;
-
-  geom_type = GEOSGeomTypeId_r(ctx, geom);
-  if (geom_type == GEOS_POINT) {
-    return GEOSisEmpty_r(ctx, geom);
-  } else if (geom_type == -1) {
-    return 2;  // GEOS exception
-  } else {
-    return 0;  // No empty point
+void destroy_geom_arr(void* context, GEOSGeometry** array, int length) {
+  int i;
+  for (i = 0; i < length; i++) {
+    if (array[i] != NULL) {
+      GEOSGeom_destroy_r(context, array[i]);
+    }
   }
 }
 
@@ -53,6 +47,25 @@ char multipoint_has_point_empty(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
     }
   }
   return 0;
+}
+
+// POINT EMPTY is converted to POINT (nan nan)
+// by GEOS >= 3.10.0. Before that, we do it ourselves here.
+#if !GEOS_SINCE_3_10_0
+
+/* Returns 1 if geometry is an empty point, 0 otherwise, 2 on error.
+ */
+char is_point_empty(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
+  int geom_type;
+
+  geom_type = GEOSGeomTypeId_r(ctx, geom);
+  if (geom_type == GEOS_POINT) {
+    return GEOSisEmpty_r(ctx, geom);
+  } else if (geom_type == -1) {
+    return 2;  // GEOS exception
+  } else {
+    return 0;  // No empty point
+  }
 }
 
 /* Returns 1 if a geometrycollection has an empty point, 0 otherwise, 2 on error.
@@ -131,15 +144,6 @@ GEOSGeometry* point_empty_to_nan(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
   }
   GEOSSetSRID_r(ctx, result, GEOSGetSRID_r(ctx, geom));
   return result;
-}
-
-void destroy_geom_arr(void* context, GEOSGeometry** array, int length) {
-  int i;
-  for (i = 0; i < length; i++) {
-    if (array[i] != NULL) {
-      GEOSGeom_destroy_r(context, array[i]);
-    }
-  }
 }
 
 /* Creates a new multipoint, replacing empty points with POINT (nan, nan[, nan)]
@@ -250,6 +254,8 @@ GEOSGeometry* point_empty_to_nan_all_geoms(GEOSContextHandle_t ctx, GEOSGeometry
   return result;
 }
 
+#endif  // !GEOS_SINCE_3_10_0
+
 /* Checks whether the geometry is a multipoint with an empty point in it
  *
  * According to https://github.com/libgeos/geos/issues/305, this check is not
@@ -284,13 +290,13 @@ char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
 
 /* GEOSInterpolate_r and GEOSInterpolateNormalized_r segfault on empty
  * geometries and also on collections with the first geometry empty.
- * 
+ *
  * This function returns:
  * - PGERR_GEOMETRY_TYPE on non-linear geometries
  * - PGERR_EMPTY_GEOMETRY on empty linear geometries
  * - PGERR_EXCEPTIONS on GEOS exceptions
  * - PGERR_SUCCESS on a non-empty and linear geometry
- * 
+ *
  * Note that GEOS 3.8 fixed this situation for empty LINESTRING/LINEARRING,
  * but it still segfaults on other empty geometries.
  */

--- a/src/geos.h
+++ b/src/geos.h
@@ -131,9 +131,11 @@ extern PyObject* geos_exception[1];
 extern void geos_error_handler(const char* message, void* userdata);
 extern void geos_notice_handler(const char* message, void* userdata);
 extern void destroy_geom_arr(void* context, GEOSGeometry** array, int length);
+#if !GEOS_SINCE_3_10_0
 extern char has_point_empty(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 extern GEOSGeometry* point_empty_to_nan_all_geoms(GEOSContextHandle_t ctx,
                                                   GEOSGeometry* geom);
+#endif  // !GEOS_SINCE_3_10_0
 extern char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 extern char geos_interpolate_checker(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -126,7 +126,8 @@ static PyObject* GeometryObject_ToWKB(GeometryObject* obj) {
 
   GEOS_INIT;
 
-  // WKB Does not allow empty points.
+#if !GEOS_SINCE_3_10_0
+  // WKB Does not allow empty points in GEOS < 3.10.
   // We check for that and patch the POINT EMPTY if necessary
   has_empty = has_point_empty(ctx, obj->ptr);
   if (has_empty == 2) {
@@ -138,6 +139,9 @@ static PyObject* GeometryObject_ToWKB(GeometryObject* obj) {
   } else {
     geom = obj->ptr;
   }
+#else
+  geom = obj->ptr;
+#endif  // !GEOS_SINCE_3_10_0
 
   /* Create the WKB writer */
   writer = GEOSWKBWriter_create_r(ctx);


### PR DESCRIPTION
See #233 for a discussion. For GEOS 3.9 and before, we were able to construct a POINT (nan nan). In GEOS master, this is not possible anymore and it transforms to a POINT EMPTY. This caused some of our tests to fail.

These tests just use a point because it is the simplest geometry. Now I updated the tests so that they use linestrings and everything passes on my machine.