### PR TITLE
Add back pygeos.strtree.VALID_PREDICATES for now

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,9 @@ Version 0.10 (unreleased)
 
 * STRtree default leaf size is now 10 instead of 5, for somewhat better performance
   under normal conditions (#286)
-* Removes ``VALID_PREDICATES`` set from ``pygeos.strtree`` package; these can be constructed
+* Deprecated ``VALID_PREDICATES`` set from ``pygeos.strtree`` package; these can be constructed
   in downstream libraries using the ``pygeos.strtree.BinaryPredicate`` enum.
+  This will be removed in a future release.
 
 **Added GEOS functions**
 

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -20,7 +20,8 @@ class BinaryPredicate(ParamEnum):
     contains_properly = 9
 
 
- VALID_PREDICATES = {e.name for e in BinaryPredicate}
+# DEPRECATED: to be removed on a future release
+VALID_PREDICATES = {e.name for e in BinaryPredicate}
 
 
 class STRtree:

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -20,6 +20,9 @@ class BinaryPredicate(ParamEnum):
     contains_properly = 9
 
 
+ VALID_PREDICATES = {e.name for e in BinaryPredicate}
+
+
 class STRtree:
     """A query-only R-tree created using the Sort-Tile-Recursive (STR)
     algorithm.


### PR DESCRIPTION
See https://github.com/pygeos/pygeos/pull/263#issuecomment-790463108. Removing it broke geopandas. I think it's easy to keep it a bit longer in pygeos for now (and we can still revert this before doing the next release)