### PR TITLE
to_shapely and from_shapely updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Version 0.10 (unreleased)
 * Updated ``box`` ufunc to use internal C function for creating polygon
   (about 2x faster) and added ``ccw`` parameter to create polygon in
   counterclockwise (default) or clockwise direction (#308).
+* Added ``to_shapely`` and improved performance of ``from_shapely`` in the case
+  GEOS versions are different (#312).
 
 **API Changes**
 
@@ -53,6 +55,7 @@ People with a "+" by their names contributed a patch for the first time.
 * Brendan Ward
 * Casper van der Wel
 * Joris Van den Bossche
+* 0phoff +
 
 
 Version 0.9 (2021-01-23)

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -9,18 +9,39 @@ from . import geos_capi_version_string
 
 
 ShapelyGeometry = None
-shapely_compatible = None
 shapely_lgeos = None
 shapely_geom_factory = None
 shapely_wkb_loads = None
+shapely_compatible = None
 _shapely_checked = False
 
 def check_shapely_version():
+    """
+    This function will try to import shapely and extracts some necessary classes and functions from the package.
+    It also looks if Shapely and PyGEOS use the same GEOS version, as this means the conversion can be faster.
+
+    This function sets a few global variables:
+
+    - ShapelyGeometry: 
+        shapely.geometry.base.BaseGeometry
+    - shapely_lgeos: 
+        shapely.geos.lgeos
+    - shapely_geom_factory: 
+        shapely.geometry.base.geom_factory
+    - shapely_wkb_loads: 
+        shapely.wkb.loads
+    - shapely_compatible: 
+        ``None`` if shapely is not installed, 
+        ``True`` if shapely and PyGEOS use the same GEOS version, 
+        ``False`` otherwise
+    - _shapely_checked: 
+        Mostly internal variable to mark that we already tried to import shapely
+    """
     global ShapelyGeometry
-    global shapely_compatible
     global shapely_lgeos
     global shapely_geom_factory
     global shapely_wkb_loads
+    global shapely_compatible
     global _shapely_checked
 
     if not _shapely_checked:

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -30,21 +30,21 @@ def check_shapely_version():
 
     This function sets a few global variables:
 
-    - ShapelyGeometry: 
+    - ShapelyGeometry:
         shapely.geometry.base.BaseGeometry
-    - ShapelyPreparedGeometry: 
+    - ShapelyPreparedGeometry:
         shapely.prepared.PreparedGeometry
-    - shapely_lgeos: 
+    - shapely_lgeos:
         shapely.geos.lgeos
-    - shapely_geom_factory: 
+    - shapely_geom_factory:
         shapely.geometry.base.geom_factory
-    - shapely_wkb_loads: 
+    - shapely_wkb_loads:
         shapely.wkb.loads
-    - shapely_compatible: 
-        ``None`` if shapely is not installed, 
-        ``True`` if shapely and PyGEOS use the same GEOS version, 
+    - shapely_compatible:
+        ``None`` if shapely is not installed,
+        ``True`` if shapely and PyGEOS use the same GEOS version,
         ``False`` otherwise
-    - _shapely_checked: 
+    - _shapely_checked:
         Mostly internal variable to mark that we already tried to import shapely
     """
     global ShapelyGeometry
@@ -159,12 +159,7 @@ def to_wkt(
 
 
 def to_wkb(
-    geometry,
-    hex=False,
-    output_dimension=3,
-    byte_order=-1,
-    include_srid=False,
-    **kwargs
+    geometry, hex=False, output_dimension=3, byte_order=-1, include_srid=False, **kwargs
 ):
     r"""
     Converts to the Well-Known Binary (WKB) representation of a Geometry.
@@ -225,7 +220,7 @@ def to_wkb(
 def to_shapely(geometry):
     """
     Converts PyGEOS geometries to Shapely.
-    
+
     Parameters
     ----------
     geometry : shapely Geometry object or array_like
@@ -257,12 +252,7 @@ def to_shapely(geometry):
         ]
     else:
         geometry = to_wkb(geometry)
-        geometry = [
-            None
-            if g is None
-            else shapely_wkb_loads(g)
-            for g in geometry
-        ]
+        geometry = [None if g is None else shapely_wkb_loads(g) for g in geometry]
 
     if unpack:
         return geometry[0]
@@ -378,7 +368,9 @@ def from_shapely(geometry, **kwargs):
 
         return lib.from_shapely(arr, **kwargs)
     else:
-        unpack = geometry is None or isinstance(geometry, (ShapelyGeometry, ShapelyPreparedGeometry))
+        unpack = geometry is None or isinstance(
+            geometry, (ShapelyGeometry, ShapelyPreparedGeometry)
+        )
         if unpack:
             geometry = (geometry,)
 
@@ -390,7 +382,9 @@ def from_shapely(geometry, **kwargs):
             if g is None:
                 arr.append(None)
             elif g.is_empty and g.geom_type == "Point":
-                arr.append(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf8\x7f\x00\x00\x00\x00\x00\x00\xf8\x7f')
+                arr.append(
+                    b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf8\x7f\x00\x00\x00\x00\x00\x00\xf8\x7f"
+                )
             else:
                 arr.append(g.wkb)
 

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -372,6 +372,18 @@ def test_from_shapely(geom):
     assert geom._ptr != actual._ptr
 
 
+@pytest.mark.parametrize("geom", all_types)
+@mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
+@mock.patch("pygeos.io.shapely_compatible", True)
+@mock.patch("pygeos.io._shapely_checked", True)
+def test_from_shapely_prepared(geom):
+    actual = pygeos.from_shapely(ShapelyPreparedMock(geom))
+    assert isinstance(actual, pygeos.Geometry)
+    assert pygeos.equals(geom, actual)
+    assert geom._ptr != actual._ptr
+
+
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
 @mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", True)

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -55,6 +55,11 @@ class ShapelyGeometryMock:
         return pygeos.is_empty(self.g)
 
 
+class ShapelyPreparedMock:
+    def __init__(self, g):
+        self.context = ShapelyGeometryMock(g)
+
+
 def shapely_wkb_loads_mock(wkb):
     geom = pygeos.from_wkb(wkb)
     return ShapelyGeometryMock(geom)
@@ -357,6 +362,7 @@ def test_to_wkb_point_empty_srid():
 
 @pytest.mark.parametrize("geom", all_types)
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", True)
 @mock.patch("pygeos.io._shapely_checked", True)
 def test_from_shapely(geom):
@@ -367,6 +373,7 @@ def test_from_shapely(geom):
 
 
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", True)
 @mock.patch("pygeos.io._shapely_checked", True)
 def test_from_shapely_arr():
@@ -375,6 +382,7 @@ def test_from_shapely_arr():
 
 
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", True)
 @mock.patch("pygeos.io._shapely_checked", True)
 def test_from_shapely_none():
@@ -384,6 +392,7 @@ def test_from_shapely_none():
 
 @pytest.mark.parametrize("geom", [1, 2.3, "x", ShapelyGeometryMock(None)])
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", True)
 @mock.patch("pygeos.io._shapely_checked", True)
 def test_from_shapely_error(geom):
@@ -393,6 +402,7 @@ def test_from_shapely_error(geom):
 
 @pytest.mark.parametrize("geom", all_types)
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", False)
 @mock.patch("pygeos.io._shapely_checked", True)
 def test_from_shapely_incompatible(geom):
@@ -402,7 +412,20 @@ def test_from_shapely_incompatible(geom):
     assert geom._ptr != actual._ptr
 
 
+@pytest.mark.parametrize("geom", all_types)
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
+@mock.patch("pygeos.io.shapely_compatible", False)
+@mock.patch("pygeos.io._shapely_checked", True)
+def test_from_shapely_incompatible_prepared(geom):
+    actual = pygeos.from_shapely(ShapelyPreparedMock(geom))
+    assert isinstance(actual, pygeos.Geometry)
+    assert pygeos.equals(geom, actual)
+    assert geom._ptr != actual._ptr
+
+
+@mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", False)
 @mock.patch("pygeos.io._shapely_checked", True)
 def test_from_shapely_incompatible_none():
@@ -411,6 +434,7 @@ def test_from_shapely_incompatible_none():
 
 
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)
+@mock.patch("pygeos.io.ShapelyPreparedGeometry", ShapelyPreparedMock)
 @mock.patch("pygeos.io.shapely_compatible", False)
 @mock.patch("pygeos.io._shapely_checked", True)
 def test_from_shapely_incompatible_array():

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -42,15 +42,15 @@ class ShapelyGeometryMock:
     def geom_type(self):
         idx = pygeos.get_type_id(self.g)
         return [
-            'None',
-            'Point',
-            'LineString',
-            'LinearRing',
-            'Polygon',
-            'MultiPoint',
-            'MultiLineString',
-            'MultiPolygon',
-            'GeometryCollection',
+            "None",
+            "Point",
+            "LineString",
+            "LinearRing",
+            "Polygon",
+            "MultiPoint",
+            "MultiLineString",
+            "MultiPolygon",
+            "GeometryCollection",
         ][idx]
 
     @property

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2355,6 +2355,10 @@ static void from_shapely_func(char** args, npy_intp* dimensions, npy_intp* steps
       /* None in the input propagates to the output */
       ret_ptr = NULL;
     } else {
+      /* Check if we have a prepared geometry */
+      if (PyObject_HasAttrString(in1, "context")) {
+        in1 = PyObject_GetAttrString(in1, "context");
+      }
       /* Get the __geom__ attribute */
       attr = PyObject_GetAttrString(in1, "__geom__");
       if (attr == NULL) {


### PR DESCRIPTION
I noticed issue #54 was pushed to a next milestone and thus decided to put some work into it.
This PR adds a `to_shapely()` function and improves the `from_shapely()` function to also work when the GEOS versions of both library do not match, by going through the WKB format (similarly to how geopandas handles things).

This implementation is implemented purely in python, as I do not know how we should create shapely objects from C.
I still believe it is worth adding, as this fills a "gap" in the current pygeos pipeline, and we can still optimize it without affecting the public API, later down the road...

Remarks / TODO:
- [ ] Unit Test `to_shapely()` when GEOS versions are the same. This would mean mocking `shapely.geos.lgeos.GEOSGeom_clone()` and `shapely.geometry.base.geom_factory()`. I am not completely sure if it is worth it / necessary, as we would effectively be mocking 90% of the functionality...
- [X] ~Contrary to geopandas, these implementations do not work with the `__geo_interface__`. I don't have any experience with this interface and don't really know what to expect here, so I currently cannot work on this.~
  Let's keep the to_* and from_* functions simple.
- [X] ~Instead of using `shapely.geos.lgeos.GEOSGeom_clone()`, we could probably use the `get_geos_handle` and `GEOSGeom_clone_r` from _pygeos/\_geos.pxd_. This would mean either rewriting this function in cython or exposing this functionality in python (get_geos_handle should be quite trivial with cpdef, not sure about the geos functions). Again,  I am not completely sure if it is worth it / necessary.~
  Not implementing this for now. If anyone wants to try to get an even faster conversion, feel free...
- [X] ~Add `ignore_shapely2_warnings`, similarly to [GeoPandas](https://github.com/geopandas/geopandas/blob/master/geopandas/_compat.py#L140). I have not done this yet, as I do not use Shapely V2 and did not immediately see a need for this. Let me know if this is necessary and I can add it.~
  I do not think this is necessary, as Shapely V2 will contain PyGEOS, hence making this library unnecessary.
- [x] Add `to_shapely()` to documentation.

---

__Performance Note:__

At first, I implemented things more like geopandas, by having a single python loop and performing the necessary transformations in  that loop:
- pygeos -> wkb -> shapely
- shapely -> wkb -> pygeos

However, after performing some tests, I found out it is faster to perform the "pygeos -> wkb" / "wkb -> pygeos" seperately and run it on the entire array at once. Obviously, having the same GEOS version is still much faster!
The test also shows that `from_shapely()` is quite a bit faster when you have the same GEOS version, compared to `to_shapely()`. My guess is that this is because most of the compute happens in C, whilst `to_shapely()` is built with python.
You can find my test-code and charts below.

```python
# Note: I only tested with boxes, so maybe the results can be slightly different when having different geometries

# pygeos -> shapely
times = []
nums = []
for i in range(0, 5001, 50):
    if i == 0:
        box = None
    else:
        box = pygeos.box(0,0,range(i),range(i))
        
    result = %timeit -o pygeos.to_shapely(box)
    nums.append(i if i != 0 else 1)
    times.append(result.best)

# shapely -> pygeos
times = []
nums = []
for i in range(0, 5001, 50):
    if i == 0:
        box = None
    else:
        box = np.array([shapely.geometry.box(0,0,j,j) for j in range(i)], dtype='object')
        
    result = %timeit -o pygeos.from_shapely(box)
    nums.append(i if i != 0 else 1)
    times.append(result.best)
```

![image](https://user-images.githubusercontent.com/11853089/110501175-3425bd80-80fa-11eb-835b-8c1d66b2a495.png)
![image](https://user-images.githubusercontent.com/11853089/110501197-38ea7180-80fa-11eb-9604-2554afdce1e6.png)
