### PR TITLE
Raise ValueError on nonscalar max_distance parameter for STRtree::nearest_all

### DIFF
--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -284,8 +284,12 @@ class STRtree:
         if geometry.ndim == 0:
             geometry = np.expand_dims(geometry, 0)
 
-        if max_distance is not None and max_distance <= 0:
-            raise ValueError("max_distance must be greater than 0")
+        if max_distance is not None:
+            if not np.isscalar(max_distance):
+                raise ValueError("max_distance parameter only accepts scalar values")
+
+            if max_distance <= 0:
+                raise ValueError("max_distance must be greater than 0")
 
         # a distance of 0 means no max_distance is used
         max_distance = max_distance or 0

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -1473,11 +1473,20 @@ def test_nearest_all_max_distance(tree, geometry, max_distance, expected):
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,max_distance",
-    [(pygeos.points(0.5, 0.5), 0), (pygeos.points(0.5, 0.5), -1)],
+    [
+        (pygeos.points(0.5, 0.5), 0),
+        (pygeos.points(0.5, 0.5), -1),
+    ],
 )
 def test_nearest_all_invalid_max_distance(tree, geometry, max_distance):
     with pytest.raises(ValueError, match="max_distance must be greater than 0"):
         tree.nearest_all(geometry, max_distance=max_distance)
+
+
+@pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
+def test_nearest_all_nonscalar_max_distance(tree):
+    with pytest.raises(ValueError, match="parameter only accepts scalar values"):
+        tree.nearest_all(pygeos.points(0.5, 0.5), max_distance=[1])
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")


### PR DESCRIPTION
We expect `max_distance` to be scalars but didn't correctly validate that.  This adds a check and associated test.