### PR TITLE
TST: Allow s390 CI fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ dist: focal
 language: python
 python: "3.8"
 
+allow_failures:
+  - s390x
+
 branches:
   only:
   - master


### PR DESCRIPTION
This allows the `s390x` arch to fail in Travis-CI, since it is failing due to errors at the GEOS level.