### PR TITLE
TST: Really allow s390x to fail on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
 branches:
   only:
   - master
-  - allow_s390x_ci_fail2
 
 before_install:
   - sudo apt-get --yes install libgeos-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
-arch:
-  - ppc64le
-  - s390x
-  - arm64
 os: linux
 dist: focal
 language: python
 python: "3.8"
 
-allow_failures:
-  - arch: s390x
+matrix:
+  include:
+    - arch: ppc64le
+    - arch: s390x
+    - arch: arm64
+  allow_failures:
+    - arch: s390x
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ language: python
 python: "3.8"
 
 allow_failures:
-  - s390x
+  - arch: s390x
 
 branches:
   only:
   - master
+  - allow_s390x_ci_fail2
 
 before_install:
   - sudo apt-get --yes install libgeos-dev


### PR DESCRIPTION
See results here: https://travis-ci.com/github/pygeos/pygeos/builds/220415212

We needed to use the `matrix` directly in order to mark one of the runs for failure.