### PR TITLE
Raise warning and return None on invalid WKB/WKT instead of raising exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Version 0.10 (unreleased)
 * Enable bulk construction of collections with different number of geometries
   by optionally taking an index arrays in the constructors ``multipoints``,
   ``multilinestrings``, ``multipolygons``, and ``geometrycollections`` (#290).
-* Released GIL for ``points``, ``linestrings``, ``linearrings``, and 
+* Released GIL for ``points``, ``linestrings``, ``linearrings``, and
   ``polygons`` (without holes) (#310).
 * Added the option to return the geometry index in ``get_coordinates`` (#318).
 * Updated ``box`` ufunc to use internal C function for creating polygon
@@ -27,8 +27,8 @@ Version 0.10 (unreleased)
   This will be removed in a future release.
 * ``points``, ``linestrings``, ``linearrings``, and ``polygons`` now return a ``GEOSException``
   instead of a ``ValueError`` for invalid input (#310).
-* ``from_wkb`` will return invalid WKB geometries as ``None`` and raise a warning
-  instead of raising an exception.
+* Addition of ``ignore_invalid`` parameter to ``from_wkb`` to return invalid WKB
+  geometries as ``None`` and raise a warning instead of raising an exception.
 
 **Added GEOS functions**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,8 +27,9 @@ Version 0.10 (unreleased)
   This will be removed in a future release.
 * ``points``, ``linestrings``, ``linearrings``, and ``polygons`` now return a ``GEOSException``
   instead of a ``ValueError`` for invalid input (#310).
-* Addition of ``ignore_invalid`` parameter to ``from_wkb`` to return invalid WKB
-  geometries as ``None`` and raise a warning instead of raising an exception.
+* Addition of ``ignore_invalid`` parameter to ``from_wkb`` and ``from_wkt`` to
+  return invalid WKB geometries as ``None`` and raise a warning instead of an
+  exception.
 
 **Added GEOS functions**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,9 +27,8 @@ Version 0.10 (unreleased)
   This will be removed in a future release.
 * ``points``, ``linestrings``, ``linearrings``, and ``polygons`` now return a ``GEOSException``
   instead of a ``ValueError`` for invalid input (#310).
-* Addition of ``ignore_invalid`` parameter to ``from_wkb`` and ``from_wkt`` to
-  return invalid WKB geometries as ``None`` and raise a warning instead of an
-  exception.
+* Addition of ``on_invalid`` parameter to ``from_wkb`` and ``from_wkt`` to
+  optionally return invalid WKB geometries as ``None``.
 
 **Added GEOS functions**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Version 0.10 (unreleased)
 
 * Addition of ``nearest`` and ``nearest_all`` functions to ``STRtree`` for
   GEOS >= 3.6 to find the nearest neighbors (#272).
-* Released GIL for ``points``, ``linestrings``, ``linearrings``, and 
+* Released GIL for ``points``, ``linestrings``, ``linearrings``, and
   ``polygons`` (without holes) (#310).
 * Updated ``box`` ufunc to use internal C function for creating polygon
   (about 2x faster) and added ``ccw`` parameter to create polygon in
@@ -24,6 +24,8 @@ Version 0.10 (unreleased)
   This will be removed in a future release.
 * ``points``, ``linestrings``, ``linearrings``, and ``polygons`` now return a ``GEOSException``
   instead of a ``ValueError`` for invalid input (#310).
+* ``from_wkb`` will return invalid WKB geometries as ``None`` and raise a warning
+  instead of raising an exception.
 
 **Added GEOS functions**
 
@@ -34,7 +36,7 @@ Version 0.10 (unreleased)
 **Bug fixes**
 
 * Fixed portability issue for ARM architecture (#293)
-* Fixed segfault in ``linearrings`` and ``box`` when constructing a geometry with nan 
+* Fixed segfault in ``linearrings`` and ``box`` when constructing a geometry with nan
   coordinates (#310).
 
 **Acknowledgments**

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -181,31 +181,36 @@ def from_wkt(geometry, **kwargs):
     return lib.from_wkt(geometry, **kwargs)
 
 
-def from_wkb(geometry, **kwargs):
+def from_wkb(geometry, ignore_invalid=False, **kwargs):
     r"""
     Creates geometries from the Well-Known Binary (WKB) representation.
 
     The Well-Known Binary format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
 
-    Invalid geometries will be returned as None and will raise a warning.
-    These can be filtered out using pygeos.is_geometry.
 
     Parameters
     ----------
     geometry : str or array_like
         The WKB byte object(s) to convert.
+    ignore_invalid : bool (default: False)
+        If True, each invalid WKB geometry will be returned as None and a
+        warning will be raised.
 
     Examples
     --------
     >>> from_wkb(b'\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\xf0?')
     <pygeos.Geometry POINT (1 1)>
     """
+
+    if not np.isscalar(ignore_invalid):
+        raise TypeError("ignore_invalid only accepts scalar values")
+
     # ensure the input has object dtype, to avoid numpy inferring it as a
     # fixed-length string dtype (which removes trailing null bytes upon access
     # of array elements)
     geometry = np.asarray(geometry, dtype=object)
-    return lib.from_wkb(geometry, **kwargs)
+    return lib.from_wkb(geometry, ignore_invalid, **kwargs)
 
 
 def from_shapely(geometry, **kwargs):

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -188,6 +188,9 @@ def from_wkb(geometry, **kwargs):
     The Well-Known Binary format is defined in the `OGC Simple Features
     Specification for SQL <https://www.opengeospatial.org/standards/sfs>`__.
 
+    Invalid geometries will be returned as None and will raise a warning.
+    These can be filtered out using pygeos.is_geometry.
+
     Parameters
     ----------
     geometry : str or array_like

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -161,7 +161,7 @@ def to_wkb(
     )
 
 
-def from_wkt(geometry, **kwargs):
+def from_wkt(geometry, ignore_invalid=False, **kwargs):
     """
     Creates geometries from the Well-Known Text (WKT) representation.
 
@@ -172,13 +172,19 @@ def from_wkt(geometry, **kwargs):
     ----------
     geometry : str or array_like
         The WKT string(s) to convert.
+    ignore_invalid : bool (default: False)
+        If True, each invalid WKT geometry will be returned as None and a
+        warning will be raised.
 
     Examples
     --------
     >>> from_wkt('POINT (0 0)')
     <pygeos.Geometry POINT (0 0)>
     """
-    return lib.from_wkt(geometry, **kwargs)
+    if not np.isscalar(ignore_invalid):
+        raise TypeError("ignore_invalid only accepts scalar values")
+
+    return lib.from_wkt(geometry, ignore_invalid, **kwargs)
 
 
 def from_wkb(geometry, ignore_invalid=False, **kwargs):

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -181,11 +181,11 @@ def from_wkt(geometry, on_invalid="raise", **kwargs):
     ----------
     geometry : str or array_like
         The WKT string(s) to convert.
-    on_invalid : str, one of {"raise", "warn", "ignore"} (default: "raise")
-        raise: an exception will be raised if WKT input geometries are invalid.
-        warn: a warning will be raised and invalid WKT geometries will be
-        returned as `None`.
-        ignore: invalid WKT geometries will be returned as `None` without a warning.
+    on_invalid : {"raise", "warn", "ignore"} (default: "raise")
+        - raise: an exception will be raised if WKT input geometries are invalid.
+        - warn: a warning will be raised and invalid WKT geometries will be
+          returned as `None`.
+        - ignore: invalid WKT geometries will be returned as `None` without a warning.
 
     Examples
     --------
@@ -212,11 +212,11 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     ----------
     geometry : str or array_like
         The WKB byte object(s) to convert.
-    on_invalid : str, one of {"raise", "warn", "ignore"} (default: "raise")
-        raise: an exception will be raised if WKB input geometries are invalid.
-        warn: a warning will be raised and invalid WKB geometries will be
-        returned as `None`.
-        ignore: invalid WKB geometries will be returned as `None` without a warning.
+    on_invalid : {"raise", "warn", "ignore"} (default: "raise")
+        - raise: an exception will be raised if WKB input geometries are invalid.
+        - warn: a warning will be raised and invalid WKB geometries will be
+          returned as `None`.
+        - ignore: invalid WKB geometries will be returned as `None` without a warning.
 
     Examples
     --------

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -181,7 +181,7 @@ def from_wkt(geometry, on_invalid="raise", **kwargs):
     ----------
     geometry : str or array_like
         The WKT string(s) to convert.
-    on_invalid : {"raise", "warn", "ignore"} (default: "raise")
+    on_invalid : {"raise", "warn", "ignore"}
         - raise: an exception will be raised if WKT input geometries are invalid.
         - warn: a warning will be raised and invalid WKT geometries will be
           returned as `None`.
@@ -212,7 +212,7 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     ----------
     geometry : str or array_like
         The WKB byte object(s) to convert.
-    on_invalid : {"raise", "warn", "ignore"} (default: "raise")
+    on_invalid : {"raise", "warn", "ignore"}
         - raise: an exception will be raised if WKB input geometries are invalid.
         - warn: a warning will be raised and invalid WKB geometries will be
           returned as `None`.

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -5,11 +5,20 @@ import numpy as np
 from . import Geometry  # noqa
 from . import lib
 from . import geos_capi_version_string
+from .enum import ParamEnum
+
+
+# Allowed options for handling WKB/WKT decoding errors
+# Note: cannot use standard constructor since "raise" is a keyword
+DecodingErrorOptions = ParamEnum(
+    "DecodingErrorOptions", {"ignore": 0, "warn": 1, "raise": 2}
+)
 
 
 shapely_geos_version = None
 ShapelyGeometry = None
 _shapely_checked = False
+
 
 def check_shapely_version():
     global shapely_geos_version
@@ -161,7 +170,7 @@ def to_wkb(
     )
 
 
-def from_wkt(geometry, ignore_invalid=False, **kwargs):
+def from_wkt(geometry, on_invalid="raise", **kwargs):
     """
     Creates geometries from the Well-Known Text (WKT) representation.
 
@@ -172,22 +181,26 @@ def from_wkt(geometry, ignore_invalid=False, **kwargs):
     ----------
     geometry : str or array_like
         The WKT string(s) to convert.
-    ignore_invalid : bool (default: False)
-        If True, each invalid WKT geometry will be returned as None and a
-        warning will be raised.
+    on_invalid : str, one of {"raise", "warn", "ignore"} (default: "raise")
+        raise: an exception will be raised if WKT input geometries are invalid.
+        warn: a warning will be raised and invalid WKT geometries will be
+        returned as `None`.
+        ignore: invalid WKT geometries will be returned as `None` without a warning.
 
     Examples
     --------
     >>> from_wkt('POINT (0 0)')
     <pygeos.Geometry POINT (0 0)>
     """
-    if not np.isscalar(ignore_invalid):
-        raise TypeError("ignore_invalid only accepts scalar values")
+    if not np.isscalar(on_invalid):
+        raise TypeError("on_invalid only accepts scalar values")
 
-    return lib.from_wkt(geometry, ignore_invalid, **kwargs)
+    invalid_handler = np.uint8(DecodingErrorOptions.get_value(on_invalid))
+
+    return lib.from_wkt(geometry, invalid_handler, **kwargs)
 
 
-def from_wkb(geometry, ignore_invalid=False, **kwargs):
+def from_wkb(geometry, on_invalid="raise", **kwargs):
     r"""
     Creates geometries from the Well-Known Binary (WKB) representation.
 
@@ -199,9 +212,11 @@ def from_wkb(geometry, ignore_invalid=False, **kwargs):
     ----------
     geometry : str or array_like
         The WKB byte object(s) to convert.
-    ignore_invalid : bool (default: False)
-        If True, each invalid WKB geometry will be returned as None and a
-        warning will be raised.
+    on_invalid : str, one of {"raise", "warn", "ignore"} (default: "raise")
+        raise: an exception will be raised if WKB input geometries are invalid.
+        warn: a warning will be raised and invalid WKB geometries will be
+        returned as `None`.
+        ignore: invalid WKB geometries will be returned as `None` without a warning.
 
     Examples
     --------
@@ -209,14 +224,16 @@ def from_wkb(geometry, ignore_invalid=False, **kwargs):
     <pygeos.Geometry POINT (1 1)>
     """
 
-    if not np.isscalar(ignore_invalid):
-        raise TypeError("ignore_invalid only accepts scalar values")
+    if not np.isscalar(on_invalid):
+        raise TypeError("on_invalid only accepts scalar values")
+
+    invalid_handler = np.uint8(DecodingErrorOptions.get_value(on_invalid))
 
     # ensure the input has object dtype, to avoid numpy inferring it as a
     # fixed-length string dtype (which removes trailing null bytes upon access
     # of array elements)
     geometry = np.asarray(geometry, dtype=object)
-    return lib.from_wkb(geometry, ignore_invalid, **kwargs)
+    return lib.from_wkb(geometry, invalid_handler, **kwargs)
 
 
 def from_shapely(geometry, **kwargs):

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -50,11 +50,21 @@ def test_from_wkt_exceptions():
     with pytest.raises(TypeError, match="Expected bytes, got int"):
         pygeos.from_wkt(1)
 
-    with pytest.raises(pygeos.GEOSException):
+    with pytest.raises(
+        pygeos.GEOSException, match="Expected word but encountered end of stream"
+    ):
         pygeos.from_wkt("")
 
-    with pytest.raises(pygeos.GEOSException):
+    with pytest.raises(pygeos.GEOSException, match="Unknown type: 'NOT'"):
         pygeos.from_wkt("NOT A WKT STRING")
+
+
+def test_from_wkt_ignore_invalid():
+    with pytest.warns(Warning, match="Invalid WKT"):
+        pygeos.from_wkt("", ignore_invalid=True)
+
+    with pytest.warns(Warning, match="Invalid WKT"):
+        pygeos.from_wkt("NOT A WKT STRING", ignore_invalid=True)
 
 
 @pytest.mark.parametrize("geom", all_types)
@@ -105,11 +115,15 @@ def test_from_wkb_exceptions():
         assert result is None
 
     # invalid ring in WKB
-    with pytest.raises(pygeos.GEOSException, match="Invalid number of points in LinearRing found 3 - must be 0 or >= 4"):
+    with pytest.raises(
+        pygeos.GEOSException,
+        match="Invalid number of points in LinearRing found 3 - must be 0 or >= 4",
+    ):
         result = pygeos.from_wkb(
             b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A"
         )
         assert result is None
+
 
 def test_from_wkb_ignore_invalid():
     # invalid WKB
@@ -121,9 +135,10 @@ def test_from_wkb_ignore_invalid():
     with pytest.warns(Warning, match="Invalid WKB"):
         result = pygeos.from_wkb(
             b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A",
-            ignore_invalid=True
+            ignore_invalid=True,
         )
         assert result is None
+
 
 @pytest.mark.parametrize("geom", all_types)
 @pytest.mark.parametrize("use_hex", [False, True])

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -59,12 +59,25 @@ def test_from_wkt_exceptions():
         pygeos.from_wkt("NOT A WKT STRING")
 
 
-def test_from_wkt_ignore_invalid():
+def test_from_wkt_warn_on_invalid():
     with pytest.warns(Warning, match="Invalid WKT"):
-        pygeos.from_wkt("", ignore_invalid=True)
+        pygeos.from_wkt("", on_invalid="warn")
 
     with pytest.warns(Warning, match="Invalid WKT"):
-        pygeos.from_wkt("NOT A WKT STRING", ignore_invalid=True)
+        pygeos.from_wkt("NOT A WKT STRING", on_invalid="warn")
+
+
+def test_from_wkb_ignore_on_invalid():
+    with pytest.warns(None):
+        pygeos.from_wkt("", on_invalid="ignore")
+
+    with pytest.warns(None):
+        pygeos.from_wkt("NOT A WKT STRING", on_invalid="ignore")
+
+
+def test_from_wkt_on_invalid_unsupported_option():
+    with pytest.raises(ValueError, match="not a valid option"):
+        pygeos.from_wkt(b"\x01\x01\x00\x00\x00\x00", on_invalid="unsupported_option")
 
 
 @pytest.mark.parametrize("geom", all_types)
@@ -125,19 +138,41 @@ def test_from_wkb_exceptions():
         assert result is None
 
 
-def test_from_wkb_ignore_invalid():
+def test_from_wkb_warn_on_invalid():
     # invalid WKB
     with pytest.warns(Warning, match="Invalid WKB"):
-        result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", ignore_invalid=True)
+        result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="warn")
         assert result is None
 
     # invalid ring in WKB
     with pytest.warns(Warning, match="Invalid WKB"):
         result = pygeos.from_wkb(
             b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A",
-            ignore_invalid=True,
+            on_invalid="warn"
         )
         assert result is None
+
+
+def test_from_wkb_ignore_on_invalid():
+    # invalid WKB
+    with pytest.warns(None) as w:
+        result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="ignore")
+        assert result is None
+        assert len(w) == 0  # no warning
+
+    # invalid ring in WKB
+    with pytest.warns(None) as w:
+        result = pygeos.from_wkb(
+            b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A",
+            on_invalid="ignore",
+        )
+        assert result is None
+        assert len(w) == 0  # no warning
+
+
+def test_from_wkb_on_invalid_unsupported_option():
+    with pytest.raises(ValueError, match="not a valid option"):
+        pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="unsupported_option")
 
 
 @pytest.mark.parametrize("geom", all_types)

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -100,17 +100,30 @@ def test_from_wkb_exceptions():
         pygeos.from_wkb(1)
 
     # invalid WKB
-    with pytest.warns(Warning, match="Unexpected EOF parsing WKB"):
+    with pytest.raises(pygeos.GEOSException, match="Unexpected EOF parsing WKB"):
         result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00")
         assert result is None
 
     # invalid ring in WKB
-    with pytest.warns(Warning, match="Invalid number of points in LinearRing found 3 - must be 0 or >= 4"):
+    with pytest.raises(pygeos.GEOSException, match="Invalid number of points in LinearRing found 3 - must be 0 or >= 4"):
         result = pygeos.from_wkb(
             b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A"
         )
         assert result is None
 
+def test_from_wkb_ignore_invalid():
+    # invalid WKB
+    with pytest.warns(Warning, match="Invalid WKB"):
+        result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", ignore_invalid=True)
+        assert result is None
+
+    # invalid ring in WKB
+    with pytest.warns(Warning, match="Invalid WKB"):
+        result = pygeos.from_wkb(
+            b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A",
+            ignore_invalid=True
+        )
+        assert result is None
 
 @pytest.mark.parametrize("geom", all_types)
 @pytest.mark.parametrize("use_hex", [False, True])
@@ -334,7 +347,7 @@ def test_to_wkb_point_empty_srid():
     wkb = pygeos.to_wkb(expected, include_srid=True)
     actual = pygeos.from_wkb(wkb)
     assert pygeos.get_srid(actual) == 4236
-    
+
 
 @pytest.mark.parametrize("geom", all_types)
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -99,8 +99,17 @@ def test_from_wkb_exceptions():
     with pytest.raises(TypeError, match="Expected bytes, got int"):
         pygeos.from_wkb(1)
 
-    with pytest.raises(pygeos.GEOSException):
-        pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00")
+    # invalid WKB
+    with pytest.warns(Warning, match="Unexpected EOF parsing WKB"):
+        result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00")
+        assert result is None
+
+    # invalid ring in WKB
+    with pytest.warns(Warning, match="Invalid number of points in LinearRing found 3 - must be 0 or >= 4"):
+        result = pygeos.from_wkb(
+            b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A"
+        )
+        assert result is None
 
 
 @pytest.mark.parametrize("geom", all_types)

--- a/src/geos.h
+++ b/src/geos.h
@@ -52,7 +52,8 @@ enum {
   PGERR_GEOMETRY_TYPE,
   PGERR_MULTIPOINT_WITH_POINT_EMPTY,
   PGERR_EMPTY_GEOMETRY,
-  PGWARN_INVALID_WKB  // raise the GEOS WKB error as a warning instead of exception
+  PGWARN_INVALID_WKB,  // raise the GEOS WKB error as a warning instead of exception
+  PGWARN_INVALID_WKT   // raise the GEOS WKB error as a warning instead of exception
 };
 
 // Define how the states are handled by CPython
@@ -89,6 +90,10 @@ enum {
     case PGWARN_INVALID_WKB:                                                             \
       PyErr_WarnFormat(PyExc_Warning, 0,                                                 \
                        "Invalid WKB: geometry is returned as None. %s", last_error);     \
+      break;                                                                             \
+    case PGWARN_INVALID_WKT:                                                             \
+      PyErr_WarnFormat(PyExc_Warning, 0,                                                 \
+                       "Invalid WKT: geometry is returned as None. %s", last_error);     \
       break;                                                                             \
     default:                                                                             \
       PyErr_Format(PyExc_RuntimeError,                                                   \

--- a/src/geos.h
+++ b/src/geos.h
@@ -52,7 +52,7 @@ enum {
   PGERR_GEOMETRY_TYPE,
   PGERR_MULTIPOINT_WITH_POINT_EMPTY,
   PGERR_EMPTY_GEOMETRY,
-  PGWARN_GEOS_EXCEPTION  // raise the GEOS error as a warning instead of exception
+  PGWARN_INVALID_WKB  // raise the GEOS WKB error as a warning instead of exception
 };
 
 // Define how the states are handled by CPython
@@ -86,8 +86,9 @@ enum {
     case PGERR_EMPTY_GEOMETRY:                                                           \
       PyErr_SetString(PyExc_ValueError, "One of the Geometry inputs is empty.");         \
       break;                                                                             \
-    case PGWARN_GEOS_EXCEPTION:                                                          \
-      PyErr_WarnEx(PyExc_Warning, last_error, 0);                                        \
+    case PGWARN_INVALID_WKB:                                                             \
+      PyErr_WarnFormat(PyExc_Warning, 0,                                                 \
+                       "Invalid WKB: geometry is returned as None. %s", last_error);     \
       break;                                                                             \
     default:                                                                             \
       PyErr_Format(PyExc_RuntimeError,                                                   \

--- a/src/geos.h
+++ b/src/geos.h
@@ -51,7 +51,8 @@ enum {
   PGERR_NO_MALLOC,
   PGERR_GEOMETRY_TYPE,
   PGERR_MULTIPOINT_WITH_POINT_EMPTY,
-  PGERR_EMPTY_GEOMETRY
+  PGERR_EMPTY_GEOMETRY,
+  PGWARN_GEOS_EXCEPTION  // raise the GEOS error as a warning instead of exception
 };
 
 // Define how the states are handled by CPython
@@ -84,6 +85,9 @@ enum {
       break;                                                                             \
     case PGERR_EMPTY_GEOMETRY:                                                           \
       PyErr_SetString(PyExc_ValueError, "One of the Geometry inputs is empty.");         \
+      break;                                                                             \
+    case PGWARN_GEOS_EXCEPTION:                                                          \
+      PyErr_WarnEx(PyExc_Warning, last_error, 0);                                        \
       break;                                                                             \
     default:                                                                             \
       PyErr_Format(PyExc_RuntimeError,                                                   \

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2362,8 +2362,8 @@ static void from_wkb_func(char** args, npy_intp* dimensions, npy_intp* steps,
         ret_ptr = GEOSWKBReader_read_r(ctx, reader, wkb, size);
       }
       if (ret_ptr == NULL) {
-        errstate = PGERR_GEOS_EXCEPTION;
-        goto finish;
+        // the output geometry will be set to None
+        errstate = PGWARN_GEOS_EXCEPTION;
       }
     }
     OUTPUT_Y;


### PR DESCRIPTION
Resolves #320

For reasons stated in #320, it is problematic to raise exceptions when deserializing invalid geometries from formats such as WKB.  This provides a way to gracefully read those in, raise a warning, and allow the user to filter them out instead of failing hard.

This adds a new enum value `PGWARN_GEOS_EXCEPTION` which is used to raise the GEOS exception as a warning instead of an exception.