### PR TITLE
Add flake8 linter and format repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [push, pull_request]
 
 jobs:
-  flake8:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - '*.py'
+  pull_request:
+    paths:
+      - '*.py'
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install flake8
+        run: pip install flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,12 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install flake8
-        run: pip install flake8
+      - name: Install flake8 and isort
+        run: pip install flake8 isort
+
+      - name: Run flake8
+        run: flake8 pygeos
+        
+      - name: Run isort
+        run: isort pygeos --check-only
+  

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,15 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install flake8 and isort
-        run: pip install flake8 isort
+      - name: Install flake8, isort and black
+        run: pip install flake8 isort black
 
       - name: Run flake8
         run: flake8 pygeos
-        
+
+      - name: Run black
+        run: black pygeos --check
+
       - name: Run isort
         run: isort pygeos --check-only --extend-skip __init__.py
   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,5 @@ jobs:
         run: flake8 pygeos
         
       - name: Run isort
-        run: isort pygeos --check-only
+        run: isort pygeos --check-only --extend-skip __init__.py
   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,6 @@
 name: Lint
 
-on:
-  push:
-    paths:
-      - '*.py'
-  pull_request:
-    paths:
-      - '*.py'
+on: [push, pull_request]
 
 jobs:
   flake8:

--- a/pygeos/__init__.py
+++ b/pygeos/__init__.py
@@ -1,20 +1,23 @@
-from .lib import GEOSException  # NOQA
-from .lib import Geometry  # NOQA
-from .lib import geos_version, geos_version_string  # NOQA
-from .lib import geos_capi_version, geos_capi_version_string  # NOQA
-from .decorators import UnsupportedGEOSOperation  # NOQA
-from .geometry import *
-from .creation import *
-from .constructive import *
-from .predicates import *
-from .measurement import *
-from .set_operations import *
-from .linear import *
-from .coordinates import *
-from .strtree import *
-from .io import *
+from ._version import get_versions  # NOQA
+from .lib import geos_capi_version  # NOQA
+from .lib import geos_capi_version_string  # NOQA
+from .lib import geos_version  # NOQA
+from .lib import geos_version_string  # NOQA
 
-from ._version import get_versions
+
+from .constructive import *  # NOQA
+from .coordinates import *  # NOQA
+from .creation import *  # NOQA
+from .decorators import UnsupportedGEOSOperation  # NOQA
+from .geometry import *  # NOQA
+from .io import *  # NOQA
+from .lib import Geometry  # NOQA
+from .lib import GEOSException  # NOQA
+from .linear import *  # NOQA
+from .measurement import *  # NOQA
+from .predicates import *  # NOQA
+from .set_operations import *  # NOQA
+from .strtree import *  # NOQA
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/pygeos/__init__.py
+++ b/pygeos/__init__.py
@@ -1,23 +1,20 @@
-from ._version import get_versions  # NOQA
-from .lib import geos_capi_version  # NOQA
-from .lib import geos_capi_version_string  # NOQA
-from .lib import geos_version  # NOQA
-from .lib import geos_version_string  # NOQA
-
-
-from .constructive import *  # NOQA
-from .coordinates import *  # NOQA
-from .creation import *  # NOQA
+from .lib import GEOSException  # NOQA
+from .lib import Geometry  # NOQA
+from .lib import geos_version, geos_version_string  # NOQA
+from .lib import geos_capi_version, geos_capi_version_string  # NOQA
 from .decorators import UnsupportedGEOSOperation  # NOQA
 from .geometry import *  # NOQA
-from .io import *  # NOQA
-from .lib import Geometry  # NOQA
-from .lib import GEOSException  # NOQA
-from .linear import *  # NOQA
-from .measurement import *  # NOQA
+from .creation import *  # NOQA
+from .constructive import *  # NOQA
 from .predicates import *  # NOQA
+from .measurement import *  # NOQA
 from .set_operations import *  # NOQA
+from .linear import *  # NOQA
+from .coordinates import *  # NOQA
 from .strtree import *  # NOQA
+from .io import *  # NOQA
+
+from ._version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -1,36 +1,38 @@
 # distutils: define_macros=GEOS_USE_ONLY_R_API
 
-from cpython cimport PyObject
 cimport cython
+from cpython cimport PyObject
 from cython cimport view
 
 import numpy as np
+
 cimport numpy as np
+
 import pygeos
 
 from pygeos._geos cimport (
-    GEOSGeometry,
-    GEOSCoordSequence,
     GEOSContextHandle_t,
-    GEOSGeom_clone_r,
-    GEOSGetGeometryN_r,
-    get_geos_handle,
-    GEOSGeom_destroy_r,
-    GEOSGeom_createCollection_r,
-    GEOSGeomTypeId_r,
     GEOSCoordSeq_create_r,
     GEOSCoordSeq_destroy_r,
     GEOSCoordSeq_setX_r,
     GEOSCoordSeq_setY_r,
     GEOSCoordSeq_setZ_r,
-    GEOSGeom_createPoint_r,
+    GEOSCoordSequence,
+    GEOSGeom_clone_r,
+    GEOSGeom_createCollection_r,
+    GEOSGeom_createLinearRing_r,
     GEOSGeom_createLineString_r,
-    GEOSGeom_createLinearRing_r
+    GEOSGeom_createPoint_r,
+    GEOSGeom_destroy_r,
+    GEOSGeometry,
+    GEOSGeomTypeId_r,
+    GEOSGetGeometryN_r,
+    get_geos_handle,
 )
 from pygeos._pygeos_api cimport (
     import_pygeos_c_api,
     PyGEOS_CreateGeometry,
-    PyGEOS_GetGEOSGeometry
+    PyGEOS_GetGEOSGeometry,
 )
 
 # initialize PyGEOS C API

--- a/pygeos/_geos.pyx
+++ b/pygeos/_geos.pyx
@@ -1,8 +1,10 @@
 # distutils: define_macros=GEOS_USE_ONLY_R_API
 #from pygeos import GEOSException
 from libc.stdio cimport snprintf
-from libc.stdlib cimport malloc, free
+from libc.stdlib cimport free, malloc
+
 import warnings
+
 from pygeos import GEOSException
 
 

--- a/pygeos/_pygeos_api.pxd
+++ b/pygeos/_pygeos_api.pxd
@@ -13,10 +13,10 @@ this capability.
 Segfaults will occur if the C API is not imported properly.
 """
 
-from cpython.ref cimport PyObject
 cimport numpy as np
+from cpython.ref cimport PyObject
 
-from pygeos._geos cimport GEOSGeometry, GEOSContextHandle_t
+from pygeos._geos cimport GEOSContextHandle_t, GEOSGeometry
 
 
 cdef extern from "c_api.h":

--- a/pygeos/_version.py
+++ b/pygeos/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -58,17 +57,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,10 +76,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -116,16 +119,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -181,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +199,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -198,19 +207,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -225,8 +241,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -234,10 +249,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -260,17 +284,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -279,10 +302,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -293,13 +318,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -330,8 +355,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -445,11 +469,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -469,9 +495,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 def get_versions():
@@ -485,8 +515,7 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
-                                          verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
     except NotThisMethod:
         pass
 
@@ -495,13 +524,16 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split('/'):
+        for i in cfg.versionfile_source.split("/"):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
-                "dirty": None,
-                "error": "unable to find root of source tree",
-                "date": None}
+        return {
+            "version": "0+unknown",
+            "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to find root of source tree",
+            "date": None,
+        }
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -515,6 +547,10 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to compute version", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }

--- a/pygeos/_version.py
+++ b/pygeos/_version.py
@@ -1,3 +1,4 @@
+
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -57,18 +58,17 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
-
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
-
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
+                env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -76,13 +76,10 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen(
-                [c] + args,
-                cwd=cwd,
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=(subprocess.PIPE if hide_stderr else None),
-            )
+            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
+                                 stdout=subprocess.PIPE,
+                                 stderr=(subprocess.PIPE if hide_stderr
+                                         else None))
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -119,22 +116,16 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {
-                "version": dirname[len(parentdir_prefix) :],
-                "full-revisionid": None,
-                "dirty": False,
-                "error": None,
-                "date": None,
-            }
+            return {"version": dirname[len(parentdir_prefix):],
+                    "full-revisionid": None,
+                    "dirty": False, "error": None, "date": None}
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print(
-            "Tried directories %s but none started with prefix %s"
-            % (str(rootdirs), parentdir_prefix)
-        )
+        print("Tried directories %s but none started with prefix %s" %
+              (str(rootdirs), parentdir_prefix))
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -190,7 +181,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -199,7 +190,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r"\d", r)])
+        tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -207,26 +198,19 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix) :]
+            r = ref[len(tag_prefix):]
             if verbose:
                 print("picking %s" % r)
-            return {
-                "version": r,
-                "full-revisionid": keywords["full"].strip(),
-                "dirty": False,
-                "error": None,
-                "date": date,
-            }
+            return {"version": r,
+                    "full-revisionid": keywords["full"].strip(),
+                    "dirty": False, "error": None,
+                    "date": date}
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {
-        "version": "0+unknown",
-        "full-revisionid": keywords["full"].strip(),
-        "dirty": False,
-        "error": "no suitable tags",
-        "date": None,
-    }
+    return {"version": "0+unknown",
+            "full-revisionid": keywords["full"].strip(),
+            "dirty": False, "error": "no suitable tags", "date": None}
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -241,7 +225,8 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
+                          hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -249,19 +234,10 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(
-        GITS,
-        [
-            "describe",
-            "--tags",
-            "--dirty",
-            "--always",
-            "--long",
-            "--match",
-            "%s*" % tag_prefix,
-        ],
-        cwd=root,
-    )
+    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
+                                          "--always", "--long",
+                                          "--match", "%s*" % tag_prefix],
+                                   cwd=root)
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -284,16 +260,17 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[: git_describe.rindex("-dirty")]
+        git_describe = git_describe[:git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
+        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
+            pieces["error"] = ("unable to parse git-describe output: '%s'"
+                               % describe_out)
             return pieces
 
         # tag
@@ -302,12 +279,10 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
-                full_tag,
-                tag_prefix,
-            )
+            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
+                               % (full_tag, tag_prefix))
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
+        pieces["closest-tag"] = full_tag[len(tag_prefix):]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -318,13 +293,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
+                                    cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
-        0
-    ].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
+                       cwd=root)[0].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -355,7 +330,8 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
+                                          pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -469,13 +445,11 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {
-            "version": "unknown",
-            "full-revisionid": pieces.get("long"),
-            "dirty": None,
-            "error": pieces["error"],
-            "date": None,
-        }
+        return {"version": "unknown",
+                "full-revisionid": pieces.get("long"),
+                "dirty": None,
+                "error": pieces["error"],
+                "date": None}
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -495,13 +469,9 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {
-        "version": rendered,
-        "full-revisionid": pieces["long"],
-        "dirty": pieces["dirty"],
-        "error": None,
-        "date": pieces.get("date"),
-    }
+    return {"version": rendered, "full-revisionid": pieces["long"],
+            "dirty": pieces["dirty"], "error": None,
+            "date": pieces.get("date")}
 
 
 def get_versions():
@@ -515,7 +485,8 @@ def get_versions():
     verbose = cfg.verbose
 
     try:
-        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix, verbose)
+        return git_versions_from_keywords(get_keywords(), cfg.tag_prefix,
+                                          verbose)
     except NotThisMethod:
         pass
 
@@ -524,16 +495,13 @@ def get_versions():
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in cfg.versionfile_source.split("/"):
+        for i in cfg.versionfile_source.split('/'):
             root = os.path.dirname(root)
     except NameError:
-        return {
-            "version": "0+unknown",
-            "full-revisionid": None,
-            "dirty": None,
-            "error": "unable to find root of source tree",
-            "date": None,
-        }
+        return {"version": "0+unknown", "full-revisionid": None,
+                "dirty": None,
+                "error": "unable to find root of source tree",
+                "date": None}
 
     try:
         pieces = git_pieces_from_vcs(cfg.tag_prefix, root, verbose)
@@ -547,10 +515,6 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {
-        "version": "0+unknown",
-        "full-revisionid": None,
-        "dirty": None,
-        "error": "unable to compute version",
-        "date": None,
-    }
+    return {"version": "0+unknown", "full-revisionid": None,
+            "dirty": None,
+            "error": "unable to compute version", "date": None}

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -1,12 +1,9 @@
-from . import lib
-from .decorators import multithreading_enabled
-from .decorators import requires_geos
-from .enum import ParamEnum
-
 import numpy as np
 
-
 from . import Geometry  # NOQA
+from . import lib
+from .decorators import multithreading_enabled, requires_geos
+from .enum import ParamEnum
 
 __all__ = [
     "BufferCapStyles",

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -1,9 +1,12 @@
-import numpy as np
-from . import Geometry  # NOQA
 from . import lib
-from .decorators import requires_geos, multithreading_enabled
+from .decorators import multithreading_enabled
+from .decorators import requires_geos
 from .enum import ParamEnum
 
+import numpy as np
+
+
+from . import Geometry  # NOQA
 
 __all__ = [
     "BufferCapStyles",

--- a/pygeos/coordinates.py
+++ b/pygeos/coordinates.py
@@ -1,5 +1,7 @@
-from . import lib, Geometry
+from . import lib
+
 import numpy as np
+
 
 __all__ = ["apply", "count_coordinates", "get_coordinates", "set_coordinates"]
 
@@ -165,15 +167,13 @@ def set_coordinates(geometry, coordinates):
     """
     geometry_arr = np.asarray(geometry, dtype=np.object_)
     coordinates = np.atleast_2d(np.asarray(coordinates)).astype(np.float64)
-    n_coords = lib.count_coordinates(geometry_arr)
     if coordinates.ndim != 2:
         raise ValueError(
             "The coordinate array should have dimension of 2 "
             "(has {})".format(coordinates.ndim)
         )
-    if (coordinates.shape[0] != lib.count_coordinates(geometry_arr)) or (
-        coordinates.shape[1] not in {2, 3}
-    ):
+    n_coords = lib.count_coordinates(geometry_arr)
+    if (coordinates.shape[0] != n_coords) or (coordinates.shape[1] not in {2, 3}):
         raise ValueError(
             "The coordinate array has an invalid shape {}".format(coordinates.shape)
         )

--- a/pygeos/coordinates.py
+++ b/pygeos/coordinates.py
@@ -1,7 +1,7 @@
-from . import lib
-from . import Geometry  # NOQA
 import numpy as np
 
+from . import Geometry  # NOQA
+from . import lib
 
 __all__ = ["apply", "count_coordinates", "get_coordinates", "set_coordinates"]
 

--- a/pygeos/coordinates.py
+++ b/pygeos/coordinates.py
@@ -1,5 +1,5 @@
 from . import lib
-
+from . import Geometry  # NOQA
 import numpy as np
 
 

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -1,12 +1,8 @@
-from . import Geometry
-from . import GeometryType
-from . import lib
-from ._geometry import collections_1d
-from ._geometry import simple_geometries_1d
-from .decorators import multithreading_enabled
-
 import numpy as np
 
+from . import Geometry, GeometryType, lib
+from ._geometry import collections_1d, simple_geometries_1d
+from .decorators import multithreading_enabled
 
 __all__ = [
     "points",

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -1,8 +1,12 @@
-import numpy as np
+from . import Geometry
+from . import GeometryType
 from . import lib
-from . import Geometry, GeometryType
+from ._geometry import collections_1d
+from ._geometry import simple_geometries_1d
 from .decorators import multithreading_enabled
-from ._geometry import collections_1d, simple_geometries_1d
+
+import numpy as np
+
 
 __all__ = [
     "points",

--- a/pygeos/decorators.py
+++ b/pygeos/decorators.py
@@ -1,7 +1,8 @@
-from . import lib
 from functools import wraps
 
 import numpy as np
+
+from . import lib
 
 
 class UnsupportedGEOSOperation(ImportError):

--- a/pygeos/decorators.py
+++ b/pygeos/decorators.py
@@ -1,7 +1,7 @@
-from contextlib import contextmanager
-from functools import wraps
-import numpy as np
 from . import lib
+from functools import wraps
+
+import numpy as np
 
 
 class UnsupportedGEOSOperation(ImportError):

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -1,13 +1,10 @@
-from . import _geometry
-from . import lib
-from .decorators import multithreading_enabled
-from .decorators import requires_geos
 from enum import IntEnum
 
 import numpy as np
 
-
 from . import Geometry  # NOQA
+from . import _geometry, lib
+from .decorators import multithreading_enabled, requires_geos
 
 __all__ = [
     "GeometryType",

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -1,11 +1,13 @@
+from . import _geometry
+from . import lib
+from .decorators import multithreading_enabled
+from .decorators import requires_geos
 from enum import IntEnum
+
 import numpy as np
 
-from . import Geometry  # NOQA
-from . import lib
-from . import _geometry
-from .decorators import multithreading_enabled, requires_geos
 
+from . import Geometry  # NOQA
 
 __all__ = [
     "GeometryType",

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,11 +1,9 @@
-from . import geos_capi_version_string
-from . import lib
 from collections.abc import Sized
 
 import numpy as np
 
-
 from . import Geometry  # noqa
+from . import geos_capi_version_string, lib
 
 shapely_geos_version = None
 ShapelyGeometry = None

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -36,7 +36,7 @@ def to_wkt(
     trim=True,
     output_dimension=3,
     old_3d=False,
-    **kwargs,
+    **kwargs
 ):
     """
     Converts to the Well-Known Text (WKT) representation of a Geometry.

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,15 +1,16 @@
+from . import geos_capi_version_string
+from . import lib
 from collections.abc import Sized
 
 import numpy as np
 
-from . import Geometry  # noqa
-from . import lib
-from . import geos_capi_version_string
 
+from . import Geometry  # noqa
 
 shapely_geos_version = None
 ShapelyGeometry = None
 _shapely_checked = False
+
 
 def check_shapely_version():
     global shapely_geos_version
@@ -18,8 +19,8 @@ def check_shapely_version():
 
     if not _shapely_checked:
         try:
-            from shapely.geos import geos_version_string as shapely_geos_version
             from shapely.geometry.base import BaseGeometry as ShapelyGeometry
+            from shapely.geos import geos_version_string as shapely_geos_version
         except ImportError:
             pass
 
@@ -35,7 +36,7 @@ def to_wkt(
     trim=True,
     output_dimension=3,
     old_3d=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Converts to the Well-Known Text (WKT) representation of a Geometry.

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -1,9 +1,8 @@
-from . import lib
-from .decorators import multithreading_enabled
 from warnings import warn
 
-
 from . import Geometry  # NOQA
+from . import lib
+from .decorators import multithreading_enabled
 
 __all__ = ["line_interpolate_point", "line_locate_point", "line_merge", "shared_paths"]
 

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -1,8 +1,9 @@
+from . import lib
+from .decorators import multithreading_enabled
 from warnings import warn
 
-from . import lib
+
 from . import Geometry  # NOQA
-from .decorators import multithreading_enabled
 
 __all__ = ["line_interpolate_point", "line_locate_point", "line_merge", "shared_paths"]
 

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -1,13 +1,21 @@
+from . import lib
+from .decorators import multithreading_enabled
+from .decorators import requires_geos
+
 import numpy as np
 
-from . import lib
-from . import Geometry  # NOQA
-from .decorators import requires_geos, multithreading_enabled
 
+from . import Geometry  # NOQA
 
 __all__ = [
-    "area", "distance", "bounds", "total_bounds", "length", "hausdorff_distance",
-    "frechet_distance", "minimum_clearance"
+    "area",
+    "distance",
+    "bounds",
+    "total_bounds",
+    "length",
+    "hausdorff_distance",
+    "frechet_distance",
+    "minimum_clearance",
 ]
 
 

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -1,11 +1,8 @@
-from . import lib
-from .decorators import multithreading_enabled
-from .decorators import requires_geos
-
 import numpy as np
 
-
 from . import Geometry  # NOQA
+from . import lib
+from .decorators import multithreading_enabled, requires_geos
 
 __all__ = [
     "area",

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -1,8 +1,11 @@
+from . import lib
+from .decorators import multithreading_enabled
+from .decorators import requires_geos
+
 import warnings
 
-from . import lib
+
 from . import Geometry  # NOQA
-from .decorators import multithreading_enabled, requires_geos
 
 __all__ = [
     "has_z",
@@ -136,6 +139,7 @@ def is_empty(geometry, **kwargs):
     """
     return lib.is_empty(geometry, **kwargs)
 
+
 @multithreading_enabled
 def is_geometry(geometry, **kwargs):
     """Returns True if the object is a geometry
@@ -161,6 +165,7 @@ def is_geometry(geometry, **kwargs):
     False
     """
     return lib.is_geometry(geometry, **kwargs)
+
 
 @multithreading_enabled
 def is_missing(geometry, **kwargs):

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -1,11 +1,8 @@
-from . import lib
-from .decorators import multithreading_enabled
-from .decorators import requires_geos
-
 import warnings
 
-
 from . import Geometry  # NOQA
+from . import lib
+from .decorators import multithreading_enabled, requires_geos
 
 __all__ = [
     "has_z",

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -1,7 +1,11 @@
-import numpy as np
-from . import lib, Geometry, GeometryType, box
-from .decorators import requires_geos, UnsupportedGEOSOperation
+from . import GeometryType
+from . import lib
 from .decorators import multithreading_enabled
+from .decorators import requires_geos
+from .decorators import UnsupportedGEOSOperation
+
+import numpy as np
+
 
 __all__ = [
     "difference",

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -1,4 +1,6 @@
 from . import GeometryType
+from . import Geometry  # NOQA
+from . import box  # NOQA
 from . import lib
 from .decorators import multithreading_enabled
 from .decorators import requires_geos

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -1,13 +1,9 @@
-from . import GeometryType
-from . import Geometry  # NOQA
-from . import box  # NOQA
-from . import lib
-from .decorators import multithreading_enabled
-from .decorators import requires_geos
-from .decorators import UnsupportedGEOSOperation
-
 import numpy as np
 
+from . import box  # NOQA
+from . import Geometry  # NOQA
+from . import GeometryType, lib
+from .decorators import multithreading_enabled, requires_geos, UnsupportedGEOSOperation
 
 __all__ = [
     "difference",

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -1,7 +1,9 @@
-import numpy as np
 from . import lib
 from .decorators import requires_geos
 from .enum import ParamEnum
+
+import numpy as np
+
 
 __all__ = ["STRtree"]
 

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -1,9 +1,8 @@
+import numpy as np
+
 from . import lib
 from .decorators import requires_geos
 from .enum import ParamEnum
-
-import numpy as np
-
 
 __all__ = ["STRtree"]
 

--- a/pygeos/test/common.py
+++ b/pygeos/test/common.py
@@ -1,9 +1,9 @@
+import sys
 from contextlib import contextmanager
 
 import numpy as np
-import pygeos
-import sys
 
+import pygeos
 
 point_polygon_testdata = (
     pygeos.points(np.arange(6), np.arange(6)),

--- a/pygeos/test/common.py
+++ b/pygeos/test/common.py
@@ -1,7 +1,9 @@
+from contextlib import contextmanager
+
 import numpy as np
 import pygeos
 import sys
-from contextlib import contextmanager
+
 
 point_polygon_testdata = (
     pygeos.points(np.arange(6), np.arange(6)),

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -1,19 +1,20 @@
-from .common import all_types
-from .common import empty
-from .common import empty_line_string
-from .common import empty_point
-from .common import empty_polygon
-from .common import line_string
-from .common import multi_point
-from .common import point
-from .common import point_z
-from pygeos import Geometry
-from pygeos import GEOSException
-
 import numpy as np
-import pygeos
 import pytest
 
+import pygeos
+from pygeos import Geometry, GEOSException
+
+from .common import (
+    all_types,
+    empty,
+    empty_line_string,
+    empty_point,
+    empty_polygon,
+    line_string,
+    multi_point,
+    point,
+    point_z,
+)
 
 CONSTRUCTIVE_NO_ARGS = (
     pygeos.boundary,

--- a/pygeos/test/test_constructive.py
+++ b/pygeos/test/test_constructive.py
@@ -1,21 +1,19 @@
-import pygeos
+from .common import all_types
+from .common import empty
+from .common import empty_line_string
+from .common import empty_point
+from .common import empty_polygon
+from .common import line_string
+from .common import multi_point
+from .common import point
+from .common import point_z
+from pygeos import Geometry
+from pygeos import GEOSException
+
 import numpy as np
+import pygeos
 import pytest
 
-from pygeos import Geometry, GEOSException
-
-from .common import (
-    point,
-    point_z,
-    line_string,
-    all_types,
-    empty,
-    empty_point,
-    empty_line_string,
-    empty_polygon,
-    geometry_collection,
-    multi_point,
-)
 
 CONSTRUCTIVE_NO_ARGS = (
     pygeos.boundary,
@@ -428,9 +426,7 @@ def test_polygonize_array():
         pygeos.Geometry("LINESTRING (0 0, 0 1)"),
         pygeos.Geometry("LINESTRING (0 1, 1 1)"),
     ]
-    expected = pygeos.Geometry(
-        "GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))"
-    )
+    expected = pygeos.Geometry("GEOMETRYCOLLECTION (POLYGON ((1 1, 0 0, 0 1, 1 1)))")
     result = pygeos.polygonize(np.array(lines))
     assert isinstance(result, pygeos.Geometry)
     assert result == expected
@@ -492,18 +488,12 @@ def test_segmentize_invalid_tolerance(geometry, tolerance):
 @pytest.mark.parametrize("geometry", all_types)
 def test_segmentize_tolerance_nan(geometry):
     actual = pygeos.segmentize(geometry, tolerance=np.nan)
-    assert actual == None
+    assert actual is None
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 @pytest.mark.parametrize(
-    "geometry",
-    [
-        empty,
-        empty_point,
-        empty_line_string,
-        empty_polygon,
-    ],
+    "geometry", [empty, empty_point, empty_line_string, empty_polygon]
 )
 def test_segmentize_empty(geometry):
     actual = pygeos.segmentize(geometry, tolerance=5)

--- a/pygeos/test/test_coordinates.py
+++ b/pygeos/test/test_coordinates.py
@@ -1,24 +1,29 @@
-import pytest
-import pygeos
-from pygeos import apply, count_coordinates, get_coordinates, set_coordinates
-import numpy as np
-from numpy.testing import assert_equal, assert_allclose
-
 from .common import empty
-from .common import point
 from .common import empty_point
-from .common import point_z
+from .common import geometry_collection
+from .common import geometry_collection_z
 from .common import line_string
 from .common import line_string_z
 from .common import linear_ring
-from .common import polygon
-from .common import polygon_z
-from .common import polygon_with_hole
-from .common import multi_point
 from .common import multi_line_string
+from .common import multi_point
 from .common import multi_polygon
-from .common import geometry_collection
-from .common import geometry_collection_z
+from .common import point
+from .common import point_z
+from .common import polygon
+from .common import polygon_with_hole
+from .common import polygon_z
+from numpy.testing import assert_allclose
+from numpy.testing import assert_equal
+from pygeos import apply
+from pygeos import count_coordinates
+from pygeos import get_coordinates
+from pygeos import set_coordinates
+
+import numpy as np
+import pygeos
+import pytest
+
 
 nested_2 = pygeos.geometrycollections([geometry_collection, point])
 nested_3 = pygeos.geometrycollections([nested_2, point])
@@ -77,7 +82,7 @@ def test_get_coords(geoms, x, y, include_z):
     if not include_z:
         expected = np.array([x, y], np.float64).T
     else:
-        expected = np.array([x, y, [np.nan]*len(x)], np.float64).T
+        expected = np.array([x, y, [np.nan] * len(x)], np.float64).T
     assert_equal(actual, expected)
 
 

--- a/pygeos/test/test_coordinates.py
+++ b/pygeos/test/test_coordinates.py
@@ -1,29 +1,27 @@
-from .common import empty
-from .common import empty_point
-from .common import geometry_collection
-from .common import geometry_collection_z
-from .common import line_string
-from .common import line_string_z
-from .common import linear_ring
-from .common import multi_line_string
-from .common import multi_point
-from .common import multi_polygon
-from .common import point
-from .common import point_z
-from .common import polygon
-from .common import polygon_with_hole
-from .common import polygon_z
-from numpy.testing import assert_allclose
-from numpy.testing import assert_equal
-from pygeos import apply
-from pygeos import count_coordinates
-from pygeos import get_coordinates
-from pygeos import set_coordinates
-
 import numpy as np
-import pygeos
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 
+import pygeos
+from pygeos import apply, count_coordinates, get_coordinates, set_coordinates
+
+from .common import (
+    empty,
+    empty_point,
+    geometry_collection,
+    geometry_collection_z,
+    line_string,
+    line_string_z,
+    linear_ring,
+    multi_line_string,
+    multi_point,
+    multi_polygon,
+    point,
+    point_z,
+    polygon,
+    polygon_with_hole,
+    polygon_z,
+)
 
 nested_2 = pygeos.geometrycollections([geometry_collection, point])
 nested_3 = pygeos.geometrycollections([nested_2, point])

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -1,15 +1,18 @@
-from .common import geometry_collection
-from .common import line_string
-from .common import linear_ring
-from .common import multi_line_string
-from .common import multi_point
-from .common import multi_polygon
-from .common import point
-from .common import polygon
-
 import numpy as np
-import pygeos
 import pytest
+
+import pygeos
+
+from .common import (
+    geometry_collection,
+    line_string,
+    linear_ring,
+    multi_line_string,
+    multi_point,
+    multi_polygon,
+    point,
+    polygon,
+)
 
 
 def box_tpl(x1, y1, x2, y2):

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -1,17 +1,15 @@
+from .common import geometry_collection
+from .common import line_string
+from .common import linear_ring
+from .common import multi_line_string
+from .common import multi_point
+from .common import multi_polygon
+from .common import point
+from .common import polygon
+
+import numpy as np
 import pygeos
 import pytest
-import numpy as np
-
-from .common import (
-    point,
-    line_string,
-    linear_ring,
-    polygon,
-    multi_point,
-    multi_line_string,
-    multi_polygon,
-    geometry_collection,
-)
 
 
 def box_tpl(x1, y1, x2, y2):
@@ -137,7 +135,7 @@ def test_linearrings_all_nan():
     coords = np.full((4, 2), np.nan)
     with pytest.raises(pygeos.GEOSException):
         pygeos.linearrings(coords)
-    
+
 
 def test_polygon_from_linearring():
     actual = pygeos.polygons(pygeos.linearrings(box_tpl(0, 0, 1, 1)))
@@ -395,9 +393,9 @@ def with_point_in_registry():
 
 
 def test_subclasses(with_point_in_registry):
-    for point in [Point("POINT (1 1)"), pygeos.points(1, 1)]:
-        assert isinstance(point, Point)
-        assert pygeos.get_type_id(point) == pygeos.GeometryType.POINT
+    for _point in [Point("POINT (1 1)"), pygeos.points(1, 1)]:
+        assert isinstance(_point, Point)
+        assert pygeos.get_type_id(_point) == pygeos.GeometryType.POINT
         assert point.x == 1
 
 

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -396,7 +396,7 @@ def test_subclasses(with_point_in_registry):
     for _point in [Point("POINT (1 1)"), pygeos.points(1, 1)]:
         assert isinstance(_point, Point)
         assert pygeos.get_type_id(_point) == pygeos.GeometryType.POINT
-        assert point.x == 1
+        assert _point.x == 1
 
 
 def test_prepare():

--- a/pygeos/test/test_creation_indices.py
+++ b/pygeos/test/test_creation_indices.py
@@ -1,14 +1,13 @@
+from .common import assert_geometries_equal
+from .common import line_string
+from .common import linear_ring
+from .common import point
+from .common import polygon
+
+import numpy as np
 import pygeos
 import pytest
-import numpy as np
-from .common import (
-    point,
-    line_string,
-    linear_ring,
-    polygon,
-    empty,
-    assert_geometries_equal,
-)
+
 
 pnts = pygeos.points
 lstrs = pygeos.linestrings

--- a/pygeos/test/test_creation_indices.py
+++ b/pygeos/test/test_creation_indices.py
@@ -1,13 +1,9 @@
-from .common import assert_geometries_equal
-from .common import line_string
-from .common import linear_ring
-from .common import point
-from .common import polygon
-
 import numpy as np
-import pygeos
 import pytest
 
+import pygeos
+
+from .common import assert_geometries_equal, line_string, linear_ring, point, polygon
 
 pnts = pygeos.points
 lstrs = pygeos.linestrings

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -1,24 +1,23 @@
-import sys
+from .common import all_types
+from .common import empty as empty_geometry_collection
+from .common import empty_line_string
+from .common import empty_point
+from .common import empty_polygon
+from .common import geometry_collection
+from .common import line_string
+from .common import line_string_nan
+from .common import linear_ring
+from .common import multi_line_string
+from .common import multi_point
+from .common import multi_polygon
+from .common import point
+from .common import point_z
+from .common import polygon
+from .common import polygon_with_hole
+
 import numpy as np
 import pygeos
 import pytest
-
-from .common import point
-from .common import line_string_nan
-from .common import empty_point
-from .common import line_string
-from .common import empty_line_string
-from .common import linear_ring
-from .common import polygon
-from .common import polygon_with_hole
-from .common import empty_polygon
-from .common import multi_point
-from .common import multi_line_string
-from .common import multi_polygon
-from .common import geometry_collection
-from .common import empty as empty_geometry_collection
-from .common import point_z
-from .common import all_types
 
 
 def test_get_num_points():
@@ -411,7 +410,9 @@ def test_set_precision_z():
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 def test_set_precision_nan():
-    assert np.all(np.isnan(pygeos.get_coordinates(pygeos.set_precision(line_string_nan, 1))))
+    assert np.all(
+        np.isnan(pygeos.get_coordinates(pygeos.set_precision(line_string_nan, 1)))
+    )
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -1,23 +1,26 @@
+import numpy as np
+import pytest
+
+import pygeos
+
 from .common import all_types
 from .common import empty as empty_geometry_collection
-from .common import empty_line_string
-from .common import empty_point
-from .common import empty_polygon
-from .common import geometry_collection
-from .common import line_string
-from .common import line_string_nan
-from .common import linear_ring
-from .common import multi_line_string
-from .common import multi_point
-from .common import multi_polygon
-from .common import point
-from .common import point_z
-from .common import polygon
-from .common import polygon_with_hole
-
-import numpy as np
-import pygeos
-import pytest
+from .common import (
+    empty_line_string,
+    empty_point,
+    empty_polygon,
+    geometry_collection,
+    line_string,
+    line_string_nan,
+    linear_ring,
+    multi_line_string,
+    multi_point,
+    multi_polygon,
+    point,
+    point_z,
+    polygon,
+    polygon_with_hole,
+)
 
 
 def test_get_num_points():

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -151,7 +151,7 @@ def test_from_wkb_warn_on_invalid_warn():
     with pytest.warns(Warning, match="Invalid WKB"):
         result = pygeos.from_wkb(
             b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A",
-            on_invalid="warn"
+            on_invalid="warn",
         )
         assert result is None
 

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -1,14 +1,13 @@
-from .common import all_types
-from .common import empty_point
-from .common import point
-from .common import point_z
+import pickle
+import struct
 from unittest import mock
 
 import numpy as np
-import pickle
-import pygeos
 import pytest
-import struct
+
+import pygeos
+
+from .common import all_types, empty_point, point, point_z
 
 # fmt: off
 POINT11_WKB = b"\x01\x01\x00\x00\x00" + struct.pack("<2d", 1.0, 1.0)

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -1,15 +1,17 @@
-import numpy as np
-import pygeos
-import pytest
-import pickle
-import struct
+from .common import all_types
+from .common import empty_point
+from .common import point
+from .common import point_z
 from unittest import mock
 
-from .common import all_types, point, empty_point, point_z
+import numpy as np
+import pickle
+import pygeos
+import pytest
+import struct
 
-
-POINT11_WKB = b'\x01\x01\x00\x00\x00' + struct.pack("<2d", 1., 1.)
-
+# fmt: off
+POINT11_WKB = b"\x01\x01\x00\x00\x00" + struct.pack("<2d", 1.0, 1.0)
 NAN = struct.pack("<d", float("nan"))
 POINT_NAN_WKB = b'\x01\x01\x00\x00\x00' + (NAN * 2)
 POINTZ_NAN_WKB = b'\x01\x01\x00\x00\x80' + (NAN * 3)
@@ -19,6 +21,8 @@ GEOMETRYCOLLECTION_NAN_WKB = b'\x01\x07\x00\x00\x00\x01\x00\x00\x00\x01\x01\x00\
 GEOMETRYCOLLECTIONZ_NAN_WKB = b'\x01\x07\x00\x00\x80\x01\x00\x00\x00\x01\x01\x00\x00\x80' + (NAN * 3)
 NESTED_COLLECTION_NAN_WKB = b'\x01\x07\x00\x00\x00\x01\x00\x00\x00\x01\x04\x00\x00\x00\x01\x00\x00\x00\x01\x01\x00\x00\x00' + (NAN * 2)
 NESTED_COLLECTIONZ_NAN_WKB = b'\x01\x07\x00\x00\x80\x01\x00\x00\x00\x01\x04\x00\x00\x80\x01\x00\x00\x00\x01\x01\x00\x00\x80' + (NAN * 3)
+# fmt: on
+
 
 class ShapelyGeometryMock:
     def __init__(self, g):
@@ -29,7 +33,7 @@ class ShapelyGeometryMock:
     def __array_interface__(self):
         # this should not be called
         # (starting with numpy 1.20 it is called, but not used)
-        return np.array([1., 2.]).__array_interface__
+        return np.array([1.0, 2.0]).__array_interface__
 
 
 def test_from_wkt():
@@ -113,7 +117,8 @@ def test_from_wkb_all_types(geom, use_hex, byte_order):
 
 
 @pytest.mark.parametrize(
-    "wkt", ("POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY", "GEOMETRYCOLLECTION EMPTY")
+    "wkt",
+    ("POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY", "GEOMETRYCOLLECTION EMPTY"),
 )
 def test_from_wkb_empty(wkt):
     wkb = pygeos.to_wkb(pygeos.Geometry(wkt))
@@ -265,54 +270,83 @@ def test_to_wkb_srid():
     assert np.frombuffer(result[5:9], "<u4").item() == 4326
 
 
-@pytest.mark.skipif(pygeos.geos_version >= (3, 8, 0), reason="Pre GEOS 3.8.0 has 3D empty points")
-@pytest.mark.parametrize("geom,dims,expected", [
-    (empty_point, 2, POINT_NAN_WKB),
-    (empty_point, 3, POINTZ_NAN_WKB),
-    (pygeos.multipoints([empty_point]), 2, MULTIPOINT_NAN_WKB),
-    (pygeos.multipoints([empty_point]), 3, MULTIPOINTZ_NAN_WKB),
-    (pygeos.geometrycollections([empty_point]), 2, GEOMETRYCOLLECTION_NAN_WKB),
-    (pygeos.geometrycollections([empty_point]), 3, GEOMETRYCOLLECTIONZ_NAN_WKB),
-    (pygeos.geometrycollections([pygeos.multipoints([empty_point])]), 2, NESTED_COLLECTION_NAN_WKB),
-    (pygeos.geometrycollections([pygeos.multipoints([empty_point])]), 3, NESTED_COLLECTIONZ_NAN_WKB),
-])
-def test_to_wkb_point_empty_pre_geos38(geom,dims,expected):
+@pytest.mark.skipif(
+    pygeos.geos_version >= (3, 8, 0), reason="Pre GEOS 3.8.0 has 3D empty points"
+)
+@pytest.mark.parametrize(
+    "geom,dims,expected",
+    [
+        (empty_point, 2, POINT_NAN_WKB),
+        (empty_point, 3, POINTZ_NAN_WKB),
+        (pygeos.multipoints([empty_point]), 2, MULTIPOINT_NAN_WKB),
+        (pygeos.multipoints([empty_point]), 3, MULTIPOINTZ_NAN_WKB),
+        (pygeos.geometrycollections([empty_point]), 2, GEOMETRYCOLLECTION_NAN_WKB),
+        (pygeos.geometrycollections([empty_point]), 3, GEOMETRYCOLLECTIONZ_NAN_WKB),
+        (
+            pygeos.geometrycollections([pygeos.multipoints([empty_point])]),
+            2,
+            NESTED_COLLECTION_NAN_WKB,
+        ),
+        (
+            pygeos.geometrycollections([pygeos.multipoints([empty_point])]),
+            3,
+            NESTED_COLLECTIONZ_NAN_WKB,
+        ),
+    ],
+)
+def test_to_wkb_point_empty_pre_geos38(geom, dims, expected):
     actual = pygeos.to_wkb(geom, output_dimension=dims, byte_order=1)
     # Use numpy.isnan; there are many byte representations for NaN
-    assert actual[:-dims * 8] == expected[:-dims * 8]
-    assert np.isnan(struct.unpack("<{}d".format(dims), actual[-dims * 8:])).all()
+    assert actual[: -dims * 8] == expected[: -dims * 8]
+    assert np.isnan(struct.unpack("<{}d".format(dims), actual[-dims * 8 :])).all()
 
 
-@pytest.mark.skipif(pygeos.geos_version < (3, 8, 0), reason="Post GEOS 3.8.0 has 2D empty points")
-@pytest.mark.parametrize("geom,dims,expected", [
-    (empty_point, 2, POINT_NAN_WKB),
-    (empty_point, 3, POINT_NAN_WKB),
-    (pygeos.multipoints([empty_point]), 2, MULTIPOINT_NAN_WKB),
-    (pygeos.multipoints([empty_point]), 3, MULTIPOINT_NAN_WKB),
-    (pygeos.geometrycollections([empty_point]), 2, GEOMETRYCOLLECTION_NAN_WKB),
-    (pygeos.geometrycollections([empty_point]), 3, GEOMETRYCOLLECTION_NAN_WKB),
-    (pygeos.geometrycollections([pygeos.multipoints([empty_point])]), 2, NESTED_COLLECTION_NAN_WKB),
-    (pygeos.geometrycollections([pygeos.multipoints([empty_point])]), 3, NESTED_COLLECTION_NAN_WKB),
-])
-def test_to_wkb_point_empty_post_geos38(geom,dims,expected):
+@pytest.mark.skipif(
+    pygeos.geos_version < (3, 8, 0), reason="Post GEOS 3.8.0 has 2D empty points"
+)
+@pytest.mark.parametrize(
+    "geom,dims,expected",
+    [
+        (empty_point, 2, POINT_NAN_WKB),
+        (empty_point, 3, POINT_NAN_WKB),
+        (pygeos.multipoints([empty_point]), 2, MULTIPOINT_NAN_WKB),
+        (pygeos.multipoints([empty_point]), 3, MULTIPOINT_NAN_WKB),
+        (pygeos.geometrycollections([empty_point]), 2, GEOMETRYCOLLECTION_NAN_WKB),
+        (pygeos.geometrycollections([empty_point]), 3, GEOMETRYCOLLECTION_NAN_WKB),
+        (
+            pygeos.geometrycollections([pygeos.multipoints([empty_point])]),
+            2,
+            NESTED_COLLECTION_NAN_WKB,
+        ),
+        (
+            pygeos.geometrycollections([pygeos.multipoints([empty_point])]),
+            3,
+            NESTED_COLLECTION_NAN_WKB,
+        ),
+    ],
+)
+def test_to_wkb_point_empty_post_geos38(geom, dims, expected):
     # Post GEOS 3.8: empty point is 2D
     actual = pygeos.to_wkb(geom, output_dimension=dims, byte_order=1)
     # Use numpy.isnan; there are many byte representations for NaN
-    assert actual[:-2 * 8] == expected[:-2 * 8]
-    assert np.isnan(struct.unpack("<2d", actual[-2 * 8:])).all()
+    assert actual[: -2 * 8] == expected[: -2 * 8]
+    assert np.isnan(struct.unpack("<2d", actual[-2 * 8 :])).all()
 
 
-@pytest.mark.parametrize("wkb,expected_type", [
-    (POINT_NAN_WKB, 0),
-    (POINTZ_NAN_WKB, 0),
-    (MULTIPOINT_NAN_WKB, 4),
-    (MULTIPOINTZ_NAN_WKB, 4),
-    (GEOMETRYCOLLECTION_NAN_WKB, 7),
-    (GEOMETRYCOLLECTIONZ_NAN_WKB, 7),
-    (NESTED_COLLECTION_NAN_WKB, 7),
-    (NESTED_COLLECTIONZ_NAN_WKB, 7),
-])
-def test_from_wkb_point_empty(wkb,expected_type):
+@pytest.mark.parametrize(
+    "wkb,expected_type",
+    [
+        (POINT_NAN_WKB, 0),
+        (POINTZ_NAN_WKB, 0),
+        (MULTIPOINT_NAN_WKB, 4),
+        (MULTIPOINTZ_NAN_WKB, 4),
+        (GEOMETRYCOLLECTION_NAN_WKB, 7),
+        (GEOMETRYCOLLECTIONZ_NAN_WKB, 7),
+        (NESTED_COLLECTION_NAN_WKB, 7),
+        (NESTED_COLLECTIONZ_NAN_WKB, 7),
+    ],
+)
+def test_from_wkb_point_empty(wkb, expected_type):
     geom = pygeos.from_wkb(wkb)
     # POINT (nan nan) transforms to an empty point
     # Note that the dimensionality (2D/3D) is GEOS-version dependent
@@ -325,7 +359,7 @@ def test_to_wkb_point_empty_srid():
     wkb = pygeos.to_wkb(expected, include_srid=True)
     actual = pygeos.from_wkb(wkb)
     assert pygeos.get_srid(actual) == 4236
-    
+
 
 @pytest.mark.parametrize("geom", all_types)
 @mock.patch("pygeos.io.ShapelyGeometry", ShapelyGeometryMock)

--- a/pygeos/test/test_io.py
+++ b/pygeos/test/test_io.py
@@ -141,7 +141,7 @@ def test_from_wkb_exceptions():
         assert result is None
 
 
-def test_from_wkb_warn_on_invalid():
+def test_from_wkb_warn_on_invalid_warn():
     # invalid WKB
     with pytest.warns(Warning, match="Invalid WKB"):
         result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="warn")
@@ -156,7 +156,7 @@ def test_from_wkb_warn_on_invalid():
         assert result is None
 
 
-def test_from_wkb_ignore_on_invalid():
+def test_from_wkb_ignore_on_invalid_ignore():
     # invalid WKB
     with pytest.warns(None) as w:
         result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="ignore")

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -1,16 +1,19 @@
-from .common import empty_line_string
-from .common import empty_point
-from .common import line_string
-from .common import linear_ring
-from .common import multi_line_string
-from .common import multi_point
-from .common import multi_polygon
-from .common import point
-from .common import polygon
-
 import numpy as np
-import pygeos
 import pytest
+
+import pygeos
+
+from .common import (
+    empty_line_string,
+    empty_point,
+    line_string,
+    linear_ring,
+    multi_line_string,
+    multi_point,
+    multi_polygon,
+    point,
+    polygon,
+)
 
 
 def test_line_interpolate_point_geom_array():

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -1,16 +1,16 @@
-import pygeos
-import numpy as np
-import pytest
-
-from .common import empty_point
 from .common import empty_line_string
-from .common import point
+from .common import empty_point
 from .common import line_string
-from .common import polygon
-from .common import multi_point
-from .common import multi_polygon
 from .common import linear_ring
 from .common import multi_line_string
+from .common import multi_point
+from .common import multi_polygon
+from .common import point
+from .common import polygon
+
+import numpy as np
+import pygeos
+import pytest
 
 
 def test_line_interpolate_point_geom_array():
@@ -110,8 +110,12 @@ def test_line_locate_point_none(normalized):
 
 @pytest.mark.parametrize("normalized", [False, True])
 def test_line_locate_point_empty(normalized):
-    assert np.isnan(pygeos.line_locate_point(line_string, empty_point, normalized=normalized))
-    assert np.isnan(pygeos.line_locate_point(empty_line_string, point, normalized=normalized))
+    assert np.isnan(
+        pygeos.line_locate_point(line_string, empty_point, normalized=normalized)
+    )
+    assert np.isnan(
+        pygeos.line_locate_point(empty_line_string, point, normalized=normalized)
+    )
 
 
 @pytest.mark.parametrize("normalized", [False, True])

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -1,19 +1,20 @@
-import pygeos
-import pytest
-import numpy as np
-from numpy.testing import assert_array_equal, assert_allclose
-
-from .common import point_polygon_testdata
-from .common import point
+from .common import empty
+from .common import geometry_collection
 from .common import line_string
 from .common import linear_ring
+from .common import multi_line_string
+from .common import multi_point
+from .common import multi_polygon
+from .common import point
+from .common import point_polygon_testdata
 from .common import polygon
 from .common import polygon_with_hole
-from .common import multi_point
-from .common import multi_line_string
-from .common import multi_polygon
-from .common import geometry_collection
-from .common import empty
+from numpy.testing import assert_allclose
+from numpy.testing import assert_array_equal
+
+import numpy as np
+import pygeos
+import pytest
 
 
 @pytest.mark.parametrize(
@@ -191,7 +192,7 @@ def test_hausdorff_distance_densify_empty():
         (
             pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]]),
             pygeos.linestrings([[0, 200], [200, 150], [0, 100], [200, 50], [0, 0]]),
-            200
+            200,
         ),
         # same geometries but different curve direction results in maximum
         # distance between vertices on the lines.
@@ -204,13 +205,13 @@ def test_hausdorff_distance_densify_empty():
         (
             pygeos.linestrings([[0, 0], [50, 200], [100, 0], [150, 200], [200, 0]]),
             pygeos.linestrings([[0, 0], [200, 50], [0, 100], [200, 150], [0, 200]]),
-            282.842712474619
+            282.842712474619,
         ),
         # example from GEOS tests
         (
             pygeos.linestrings([[0, 0], [100, 0]]),
             pygeos.linestrings([[0, 0], [50, 50], [100, 0]]),
-            70.7106781186548
+            70.7106781186548,
         ),
     ],
 )
@@ -228,8 +229,8 @@ def test_frechet_distance(geom1, geom2, expected):
             pygeos.linestrings([[0, 0], [100, 0]]),
             pygeos.linestrings([[0, 0], [50, 50], [100, 0]]),
             0.001,
-            50
-        ),
+            50,
+        )
     ],
 )
 def test_frechet_distance_densify(geom1, geom2, densify, expected):
@@ -259,7 +260,7 @@ def test_frechet_densify_ndarray():
     actual = pygeos.frechet_distance(
         pygeos.linestrings([[0, 0], [100, 0]]),
         pygeos.linestrings([[0, 0], [50, 50], [100, 0]]),
-        densify=[0.1, 0.2, 1]
+        densify=[0.1, 0.2, 1],
     )
     expected = np.array([50, 50.99019514, 70.7106781186548])
     np.testing.assert_array_almost_equal(actual, expected)
@@ -272,17 +273,10 @@ def test_frechet_densify_nan():
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
-@pytest.mark.parametrize(
-    "densify",
-    [
-        0,
-        -1,
-        2,
-    ]
-)
+@pytest.mark.parametrize("densify", [0, -1, 2])
 def test_frechet_densify_invalid_values(densify):
     with pytest.raises(pygeos.GEOSException, match="Fraction is not in range"):
-        actual = pygeos.frechet_distance(line_string, line_string, densify=densify)
+        pygeos.frechet_distance(line_string, line_string, densify=densify)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")

--- a/pygeos/test/test_measurement.py
+++ b/pygeos/test/test_measurement.py
@@ -1,20 +1,22 @@
-from .common import empty
-from .common import geometry_collection
-from .common import line_string
-from .common import linear_ring
-from .common import multi_line_string
-from .common import multi_point
-from .common import multi_polygon
-from .common import point
-from .common import point_polygon_testdata
-from .common import polygon
-from .common import polygon_with_hole
-from numpy.testing import assert_allclose
-from numpy.testing import assert_array_equal
-
 import numpy as np
-import pygeos
 import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+import pygeos
+
+from .common import (
+    empty,
+    geometry_collection,
+    line_string,
+    linear_ring,
+    multi_line_string,
+    multi_point,
+    multi_polygon,
+    point,
+    point_polygon_testdata,
+    polygon,
+    polygon_with_hole,
+)
 
 
 @pytest.mark.parametrize(

--- a/pygeos/test/test_misc.py
+++ b/pygeos/test/test_misc.py
@@ -1,13 +1,13 @@
+import sys
 from itertools import chain
-from pygeos.decorators import multithreading_enabled
-from pygeos.decorators import requires_geos
 from string import ascii_lowercase
 from unittest import mock
 
 import numpy as np
-import pygeos
 import pytest
-import sys
+
+import pygeos
+from pygeos.decorators import multithreading_enabled, requires_geos
 
 
 @pytest.fixture

--- a/pygeos/test/test_misc.py
+++ b/pygeos/test/test_misc.py
@@ -1,13 +1,13 @@
-from string import ascii_lowercase
-
-import pygeos
-from pygeos.decorators import requires_geos, multithreading_enabled
-from unittest import mock
-import pytest
 from itertools import chain
-import sys
+from pygeos.decorators import multithreading_enabled
+from pygeos.decorators import requires_geos
+from string import ascii_lowercase
+from unittest import mock
 
 import numpy as np
+import pygeos
+import pytest
+import sys
 
 
 @pytest.fixture

--- a/pygeos/test/test_predicates.py
+++ b/pygeos/test/test_predicates.py
@@ -1,9 +1,14 @@
-import pytest
-import pygeos
+from .common import all_types
+from .common import empty
+from .common import geometry_collection
+from .common import point
+from .common import polygon
 from pygeos import Geometry
-import numpy as np
 
-from .common import point, all_types, line_string, polygon, geometry_collection, empty
+import numpy as np
+import pygeos
+import pytest
+
 
 UNARY_PREDICATES = (
     pygeos.is_empty,
@@ -15,7 +20,10 @@ UNARY_PREDICATES = (
     pygeos.is_geometry,
     pygeos.is_valid_input,
     pygeos.is_prepared,
-    pytest.param(pygeos.is_ccw, marks=pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")),
+    pytest.param(
+        pygeos.is_ccw,
+        marks=pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7"),
+    ),
 )
 
 BINARY_PREDICATES = (
@@ -114,12 +122,12 @@ def test_relate_none(g1, g2):
 
 
 def test_relate_pattern():
-    line_string = pygeos.linestrings([(0, 0), (1, 0), (1, 1)])
+    g = pygeos.linestrings([(0, 0), (1, 0), (1, 1)])
     polygon = pygeos.box(0, 0, 2, 2)
-    assert pygeos.relate(line_string, polygon) == "11F00F212"
-    assert pygeos.relate_pattern(line_string, polygon, "11F00F212")
-    assert pygeos.relate_pattern(line_string, polygon, "*********")
-    assert not pygeos.relate_pattern(line_string, polygon, "F********")
+    assert pygeos.relate(g, polygon) == "11F00F212"
+    assert pygeos.relate_pattern(g, polygon, "11F00F212")
+    assert pygeos.relate_pattern(g, polygon, "*********")
+    assert not pygeos.relate_pattern(g, polygon, "F********")
 
 
 def test_relate_pattern_empty():
@@ -147,22 +155,25 @@ def test_relate_pattern_non_string(pattern):
 
 def test_relate_pattern_non_scalar():
     with pytest.raises(ValueError, match="only supports scalar"):
-        pygeos.relate_pattern([point] *2, polygon, ["*********"] * 2)
+        pygeos.relate_pattern([point] * 2, polygon, ["*********"] * 2)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 7, 0), reason="GEOS < 3.7")
-@pytest.mark.parametrize("geom, expected", [
-    (Geometry("LINEARRING (0 0, 0 1, 1 1, 0 0)"), False),
-    (Geometry("LINEARRING (0 0, 1 1, 0 1, 0 0)"), True),
-    (Geometry("LINESTRING (0 0, 0 1, 1 1, 0 0)"), False),
-    (Geometry("LINESTRING (0 0, 1 1, 0 1, 0 0)"), True),
-    (Geometry("LINESTRING (0 0, 1 1, 0 1)"), False),
-    (Geometry("LINESTRING (0 0, 0 1, 1 1)"), False),
-    (point, False),
-    (polygon, False),
-    (geometry_collection, False),
-    (None, False),
-])
+@pytest.mark.parametrize(
+    "geom, expected",
+    [
+        (Geometry("LINEARRING (0 0, 0 1, 1 1, 0 0)"), False),
+        (Geometry("LINEARRING (0 0, 1 1, 0 1, 0 0)"), True),
+        (Geometry("LINESTRING (0 0, 0 1, 1 1, 0 0)"), False),
+        (Geometry("LINESTRING (0 0, 1 1, 0 1, 0 0)"), True),
+        (Geometry("LINESTRING (0 0, 1 1, 0 1)"), False),
+        (Geometry("LINESTRING (0 0, 0 1, 1 1)"), False),
+        (point, False),
+        (polygon, False),
+        (geometry_collection, False),
+        (None, False),
+    ],
+)
 def test_is_ccw(geom, expected):
     assert pygeos.is_ccw(geom) == expected
 

--- a/pygeos/test/test_predicates.py
+++ b/pygeos/test/test_predicates.py
@@ -1,14 +1,10 @@
-from .common import all_types
-from .common import empty
-from .common import geometry_collection
-from .common import point
-from .common import polygon
-from pygeos import Geometry
-
 import numpy as np
-import pygeos
 import pytest
 
+import pygeos
+from pygeos import Geometry
+
+from .common import all_types, empty, geometry_collection, point, polygon
 
 UNARY_PREDICATES = (
     pygeos.is_empty,

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -1,13 +1,17 @@
-import numpy as np
-import pytest
-import pygeos
+from .common import all_types
+from .common import multi_polygon
+from .common import point
+from .common import polygon
 from pygeos import Geometry
 from pygeos.decorators import UnsupportedGEOSOperation
 
-from .common import point, all_types, polygon, multi_polygon
+import numpy as np
+import pygeos
+import pytest
+
 
 # fixed-precision operations raise GEOS exceptions on mixed dimension geometry collections
-all_single_types = [g for g in all_types if not pygeos.get_type_id(g)==7]
+all_single_types = [g for g in all_types if not pygeos.get_type_id(g) == 7]
 
 SET_OPERATIONS = (
     pygeos.difference,
@@ -205,7 +209,6 @@ def test_set_operation_prec_reduce_axis(func, related_func):
     assert actual.shape == (3,)
 
 
-
 @pytest.mark.skipif(pygeos.geos_version < (3, 9, 0), reason="GEOS < 3.9")
 @pytest.mark.parametrize("none_position", range(3))
 @pytest.mark.parametrize("func, related_func", REDUCE_SET_OPERATIONS_PREC)
@@ -287,9 +290,9 @@ def test_coverage_union_overlapping_inputs():
 @pytest.mark.parametrize(
     "geom_1, geom_2",
     # All possible polygon, non_polygon combinations
-    [[polygon, non_polygon] for non_polygon in non_polygon_types] +
+    [[polygon, non_polygon] for non_polygon in non_polygon_types]
     # All possible non_polygon, non_polygon combinations
-    [
+    + [
         [non_polygon_1, non_polygon_2]
         for non_polygon_1 in non_polygon_types
         for non_polygon_2 in non_polygon_types
@@ -334,14 +337,14 @@ def test_coverage_union_non_polygon_inputs(geom_1, geom_2):
         (
             [pygeos.box(0.1, 0.1, 5, 5), pygeos.box(0, 0.2, 5.1, 10)],
             10,
-            pygeos.Geometry('POLYGON ((0 10, 10 10, 10 0, 0 0, 0 10))')
+            pygeos.Geometry("POLYGON ((0 10, 10 10, 10 0, 0 0, 0 10))"),
         ),
         # grid_size is so large that polygons collapse to empty
         (
             [pygeos.box(0.1, 0.1, 5, 5), pygeos.box(0, 0.2, 5.1, 10)],
             100,
-            pygeos.Geometry('POLYGON EMPTY')
-        )
+            pygeos.Geometry("POLYGON EMPTY"),
+        ),
     ],
 )
 def test_union_all_prec(geom, grid_size, expected):

--- a/pygeos/test/test_set_operations.py
+++ b/pygeos/test/test_set_operations.py
@@ -1,14 +1,11 @@
-from .common import all_types
-from .common import multi_polygon
-from .common import point
-from .common import polygon
+import numpy as np
+import pytest
+
+import pygeos
 from pygeos import Geometry
 from pygeos.decorators import UnsupportedGEOSOperation
 
-import numpy as np
-import pygeos
-import pytest
-
+from .common import all_types, multi_polygon, point, polygon
 
 # fixed-precision operations raise GEOS exceptions on mixed dimension geometry collections
 all_single_types = [g for g in all_types if not pygeos.get_type_id(g) == 7]

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -1,17 +1,20 @@
-from .common import assert_decreases_refcount
-from .common import assert_increases_refcount
-from .common import empty
-from .common import empty_line_string
-from .common import empty_point
-from .common import point
+import math
+
+import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
+
+import pygeos
 from pygeos import box
 
-import math
-import numpy as np
-import pygeos
-import pytest
-
+from .common import (
+    assert_decreases_refcount,
+    assert_increases_refcount,
+    empty,
+    empty_line_string,
+    empty_point,
+    point,
+)
 
 # the distance between 2 points spaced at whole numbers along a diagonal
 HALF_UNIT_DIAG = math.sqrt(2) / 2

--- a/pygeos/test/test_strtree.py
+++ b/pygeos/test/test_strtree.py
@@ -1,17 +1,16 @@
-import math
-import pygeos
-from pygeos import box
-import pytest
-import numpy as np
+from .common import assert_decreases_refcount
+from .common import assert_increases_refcount
+from .common import empty
+from .common import empty_line_string
+from .common import empty_point
+from .common import point
 from numpy.testing import assert_array_equal
-from .common import (
-    point,
-    empty,
-    empty_point,
-    empty_line_string,
-    assert_increases_refcount,
-    assert_decreases_refcount,
-)
+from pygeos import box
+
+import math
+import numpy as np
+import pygeos
+import pytest
 
 
 # the distance between 2 points spaced at whole numbers along a diagonal
@@ -1195,10 +1194,7 @@ def test_nearest_invalid_geom(tree, geometry):
 
 # TODO: add into regular results
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
-@pytest.mark.parametrize(
-    "geometry,expected",
-    [(None, [[], []]), ([None], [[], []])],
-)
+@pytest.mark.parametrize("geometry,expected", [(None, [[], []]), ([None], [[], []])])
 def test_nearest_none(tree, geometry, expected):
     assert_array_equal(tree.nearest_all(geometry), expected)
 
@@ -1382,18 +1378,7 @@ def test_nearest_all_empty_geom(tree, geometry, expected):
         # return nearest point in tree for each point in multipoint
         (pygeos.multipoints([[5, 5], [7, 7]]), [[0, 0], [5, 7]]),
         # 2 equidistant points per point in multipoint
-        (
-            pygeos.multipoints([[0.5, 0.5], [3.5, 3.5]]),
-            [
-                [
-                    0,
-                    0,
-                    0,
-                    0,
-                ],
-                [0, 1, 3, 4],
-            ],
-        ),
+        (pygeos.multipoints([[0.5, 0.5], [3.5, 3.5]]), [[0, 0, 0, 0], [0, 1, 3, 4]]),
     ],
 )
 def test_nearest_all_points(tree, geometry, expected):
@@ -1473,10 +1458,7 @@ def test_nearest_all_max_distance(tree, geometry, max_distance, expected):
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")
 @pytest.mark.parametrize(
     "geometry,max_distance",
-    [
-        (pygeos.points(0.5, 0.5), 0),
-        (pygeos.points(0.5, 0.5), -1),
-    ],
+    [(pygeos.points(0.5, 0.5), 0), (pygeos.points(0.5, 0.5), -1)],
 )
 def test_nearest_all_invalid_max_distance(tree, geometry, max_distance):
     with pytest.raises(ValueError, match="max_distance must be greater than 0"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ use_parentheses = true
 honor_noqa = true
 src_paths = ["pygeos"]
 supported_extensions = ["*.py"]
-extend_skip = ["pygeos/_version.py"]
+extend_skip = ["pygeos/_version.py", "pygeos/__init__.py"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ tag_prefix =
 [flake8]
 ignore = E203, E266, E501, W503, "pygeos/_version.py"
 
-[isort]
+[tool:isort]
 profile = black
 force_alphabetical_sort_within_sections = true
-extend_skip = ["pygeos/_version.py", "pygeos/__init__.py"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,14 +9,6 @@ tag_prefix =
 ignore = E203, E266, E501, W503, "pygeos/_version.py"
 
 [isort]
-atomic = true
-force_alphabetical_sort = true
-force_single_line = true
-include_trailing_comma = true
-lines_after_imports = 2
-multi_line_output = 3
-use_parentheses = true
-honor_noqa = true
-src_paths = ["pygeos"]
-supported_extensions = ["*.py"]
+profile = black
+force_alphabetical_sort_within_sections = true
 extend_skip = ["pygeos/_version.py", "pygeos/__init__.py"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ versionfile_build = pygeos/_version.py
 tag_prefix =
 
 [flake8]
-ignore = E203, E266, E501, W503, "pygeos/_version.py"
+ignore = E203, E266, E501, W503
 
 [tool:isort]
 profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,19 @@ style = pep440
 versionfile_source = pygeos/_version.py
 versionfile_build = pygeos/_version.py
 tag_prefix =
+
+[flake8]
+ignore = E203, E266, E501, W503, "pygeos/_version.py"
+
+[isort]
+atomic = true
+force_alphabetical_sort = true
+force_single_line = true
+include_trailing_comma = true
+lines_after_imports = 2
+multi_line_output = 3
+use_parentheses = true
+honor_noqa = true
+src_paths = ["pygeos"]
+supported_extensions = ["*.py"]
+extend_skip = ["pygeos/_version.py"]


### PR DESCRIPTION
I used the tools `black` and `isort` to format the repo. The `isort` required some settings to match `black`.

`flake8` captured one thing that will lead to a performance improvement in `set_coordinates` and `apply`.