### PR TITLE
Release the GIL in shared_paths (missing decorator)

### DIFF
--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -113,6 +113,7 @@ def line_merge(line, **kwargs):
     return lib.line_merge(line, **kwargs)
 
 
+@multithreading_enabled
 def shared_paths(a, b, **kwargs):
     """Returns the shared paths between geom1 and geom2.
 


### PR DESCRIPTION
This closes #155 (along with #326 which releases the GIL for geometry-creating functions)