### PR TITLE
ENH: Add shortest_line (nearest_points) ufunc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Version 0.10 (unreleased)
 * Addition of a ``segmentize`` function for GEOS >= 3.10 (#299)
 * Addition of ``oriented_envelope`` and ``minimum_rotated_rectangle`` functions (#314)
 * Addition of ``minimum_bounding_circle`` and ``minimum_bounding_radius`` functions for GEOS >= 3.8 (#315)
+* Addition of a ``shortest_line`` ("nearest points") function (#334)
 
 **Bug fixes**
 

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -4,7 +4,13 @@ from . import Geometry  # NOQA
 from . import lib
 from .decorators import multithreading_enabled
 
-__all__ = ["line_interpolate_point", "line_locate_point", "line_merge", "shared_paths"]
+__all__ = [
+    "line_interpolate_point",
+    "line_locate_point",
+    "line_merge",
+    "shared_paths",
+    "shortest_line",
+]
 
 
 @multithreading_enabled
@@ -140,3 +146,25 @@ def shared_paths(a, b, **kwargs):
     <pygeos.Geometry GEOMETRYCOLLECTION (MULTILINESTRING EMPTY, MULTILINESTRING ...>
     """
     return lib.shared_paths(a, b, **kwargs)
+
+
+def shortest_line(a, b, **kwargs):
+    """
+    Returns the shortest line between geom1 and geom2.
+
+    Parameters
+    ----------
+    a : Geometry or array_like
+    b : Geometry or array_like
+    **kwargs
+        For other keyword-only arguments, see the
+        `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+
+    Examples
+    --------
+    >>> geom1 = Geometry("LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)")
+    >>> geom2 = Geometry("LINESTRING (0 3, 3 0, 5 3)")
+    >>> shortest_line(geom1, geom2)
+    <pygeos.Geometry LINESTRING (1 1, 1.5 1.5)>
+    """
+    return lib.nearest_points(a, b, **kwargs)

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -148,15 +148,16 @@ def shared_paths(a, b, **kwargs):
     return lib.shared_paths(a, b, **kwargs)
 
 
+@multithreading_enabled
 def shortest_line(a, b, **kwargs):
     """
-    Returns the shortest line between geom1 and geom2.
+    Returns the shortest line between two geometries.
 
     The resulting line consists of two points, representing the nearest
-    points between the geometry pair. The line always starts in geom1 and
-    ends in geom2. The endpoints of the line will not necessarily be existing
-    vertices of geom1 and geom2, but can be any point along a line segment
-    (if the input geometries are lines or polygons).
+    points between the geometry pair. The line always starts in the first
+    geometry `a` and ends in he second geometry `b`. The endpoints of the
+    line will not necessarily be existing vertices of the input geometries
+    `a` and `b`, but can also be a point along a line segment.
 
     Parameters
     ----------
@@ -165,6 +166,10 @@ def shortest_line(a, b, **kwargs):
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+
+    See also
+    --------
+    prepare : improve performance by preparing ``a`` (the first argument) (for GEOS>=3.9)
 
     Examples
     --------

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -152,6 +152,12 @@ def shortest_line(a, b, **kwargs):
     """
     Returns the shortest line between geom1 and geom2.
 
+    The resulting line consists of two points, representing the nearest
+    points between the geometry pair. The line always starts in geom1 and
+    ends in geom2. The endpoints of the line will not necessarily be existing
+    vertices of geom1 and geom2, but can be any point along a line segment
+    (if the input geometries are lines or polygons).
+
     Parameters
     ----------
     a : Geometry or array_like

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -178,4 +178,4 @@ def shortest_line(a, b, **kwargs):
     >>> shortest_line(geom1, geom2)
     <pygeos.Geometry LINESTRING (1 1, 1.5 1.5)>
     """
-    return lib.nearest_points(a, b, **kwargs)
+    return lib.shortest_line(a, b, **kwargs)

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -165,9 +165,9 @@ def test_shortest_line():
 
 
 def test_shortest_line_none():
-    # assert pygeos.shortest_line(line_string, None) is None
+    assert pygeos.shortest_line(line_string, None) is None
     assert pygeos.shortest_line(None, line_string) is None
-    # assert pygeos.shortest_line(None, None) is None
+    assert pygeos.shortest_line(None, None) is None
 
 
 def test_shortest_line_empty():

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -156,21 +156,36 @@ def test_shared_paths_non_linestring():
         pygeos.shared_paths(g1, g2)
 
 
-def test_shortest_line():
+def _prepare_input(geometry, prepare):
+    """Prepare without modifying inplace"""
+    if prepare:
+        geometry = pygeos.apply(geometry, lambda x: x)  # makes a copy
+        pygeos.prepare(geometry)
+        return geometry
+    else:
+        return geometry
+
+
+@pytest.mark.parametrize("prepare", [True, False])
+def test_shortest_line(prepare):
     g1 = pygeos.linestrings([(0, 0), (1, 0), (1, 1)])
     g2 = pygeos.linestrings([(0, 3), (3, 0)])
-    actual = pygeos.shortest_line(g1, g2)
+    actual = pygeos.shortest_line(_prepare_input(g1, prepare), g2)
     expected = pygeos.linestrings([(1, 1), (1.5, 1.5)])
     assert pygeos.equals(actual, expected)
 
 
-def test_shortest_line_none():
-    assert pygeos.shortest_line(line_string, None) is None
+@pytest.mark.parametrize("prepare", [True, False])
+def test_shortest_line_none(prepare):
+    assert pygeos.shortest_line(_prepare_input(line_string, prepare), None) is None
     assert pygeos.shortest_line(None, line_string) is None
     assert pygeos.shortest_line(None, None) is None
 
 
-def test_shortest_line_empty():
-    assert pygeos.shortest_line(line_string, empty_line_string) is None
-    assert pygeos.shortest_line(empty_line_string, line_string) is None
-    assert pygeos.shortest_line(empty_line_string, empty_line_string) is None
+@pytest.mark.parametrize("prepare", [True, False])
+def test_shortest_line_empty(prepare):
+    g1 = _prepare_input(line_string, prepare)
+    assert pygeos.shortest_line(g1, empty_line_string) is None
+    g1_empty = _prepare_input(empty_line_string, prepare)
+    assert pygeos.shortest_line(g1_empty, line_string) is None
+    assert pygeos.shortest_line(g1_empty, empty_line_string) is None

--- a/pygeos/test/test_linear.py
+++ b/pygeos/test/test_linear.py
@@ -154,3 +154,23 @@ def test_shared_paths_non_linestring():
     g2 = pygeos.points(0, 1)
     with pytest.raises(pygeos.GEOSException):
         pygeos.shared_paths(g1, g2)
+
+
+def test_shortest_line():
+    g1 = pygeos.linestrings([(0, 0), (1, 0), (1, 1)])
+    g2 = pygeos.linestrings([(0, 3), (3, 0)])
+    actual = pygeos.shortest_line(g1, g2)
+    expected = pygeos.linestrings([(1, 1), (1.5, 1.5)])
+    assert pygeos.equals(actual, expected)
+
+
+def test_shortest_line_none():
+    # assert pygeos.shortest_line(line_string, None) is None
+    assert pygeos.shortest_line(None, line_string) is None
+    # assert pygeos.shortest_line(None, None) is None
+
+
+def test_shortest_line_empty():
+    assert pygeos.shortest_line(line_string, empty_line_string) is None
+    assert pygeos.shortest_line(empty_line_string, line_string) is None
+    assert pygeos.shortest_line(empty_line_string, empty_line_string) is None

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1945,8 +1945,8 @@ finish:
 }
 static PyUFuncGenericFunction polygonize_full_funcs[1] = {&polygonize_full_func};
 
-static char nearest_points_dtypes[3] = {NPY_OBJECT, NPY_OBJECT, NPY_OBJECT};
-static void nearest_points_func(char** args, npy_intp* dimensions, npy_intp* steps,
+static char shortest_line_dtypes[3] = {NPY_OBJECT, NPY_OBJECT, NPY_OBJECT};
+static void shortest_line_func(char** args, npy_intp* dimensions, npy_intp* steps,
                                 void* data) {
   GEOSGeometry* in1 = NULL;
   GEOSGeometry* in2 = NULL;
@@ -2015,7 +2015,7 @@ static void nearest_points_func(char** args, npy_intp* dimensions, npy_intp* ste
   }
   free(geom_arr);
 }
-static PyUFuncGenericFunction nearest_points_funcs[1] = {&nearest_points_func};
+static PyUFuncGenericFunction shortest_line_funcs[1] = {&shortest_line_func};
 
 #if GEOS_SINCE_3_6_0
 static char set_precision_dtypes[4] = {NPY_OBJECT, NPY_DOUBLE, NPY_BOOL, NPY_OBJECT};
@@ -3152,7 +3152,7 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_CUSTOM(relate_pattern, 3);
   DEFINE_GENERALIZED(polygonize, 1, "(d)->()");
   DEFINE_GENERALIZED_NOUT4(polygonize_full, 1, "(d)->(),(),(),()");
-  DEFINE_CUSTOM(nearest_points, 2);
+  DEFINE_CUSTOM(shortest_line, 2);
 
   DEFINE_GENERALIZED(points, 1, "(d)->()");
   DEFINE_GENERALIZED(linestrings, 1, "(i, d)->()");

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1942,6 +1942,70 @@ finish:
 }
 static PyUFuncGenericFunction polygonize_full_funcs[1] = {&polygonize_full_func};
 
+static char nearest_points_dtypes[3] = {NPY_OBJECT, NPY_OBJECT, NPY_OBJECT};
+static void nearest_points_func(char** args, npy_intp* dimensions, npy_intp* steps,
+                                void* data) {
+  GEOSGeometry* in1 = NULL;
+  GEOSGeometry* in2 = NULL;
+  GEOSGeometry** geom_arr;
+  GEOSCoordSequence* coord_seq = NULL;
+
+  CHECK_NO_INPLACE_OUTPUT(2);
+
+  // allocate a temporary array to store output GEOSGeometry objects
+  geom_arr = malloc(sizeof(void*) * dimensions[0]);
+  CHECK_ALLOC(geom_arr);
+
+  GEOS_INIT_THREADS;
+
+  BINARY_LOOP {
+    /* get the geometries: return on error */
+    if (!get_geom(*(GeometryObject**)ip1, &in1)) {
+      errstate = PGERR_NOT_A_GEOMETRY;
+      destroy_geom_arr(ctx, geom_arr, i - 1);
+      break;
+    }
+    if (!get_geom(*(GeometryObject**)ip2, &in2)) {
+      errstate = PGERR_NOT_A_GEOMETRY;
+      destroy_geom_arr(ctx, geom_arr, i - 1);
+      break;
+    }
+
+    if ((in1 == NULL) | (in2 == NULL)) {
+      // in case of a missing value: return NULL (None)
+      geom_arr[i] = NULL;
+    } else if (GEOSisEmpty_r(ctx, in1) | GEOSisEmpty_r(ctx, in2)) {
+      // GEOSNearestPoints_r would otherwise return a NULL not distinguishable
+      // from an actual error
+      geom_arr[i] = NULL;
+    } else {
+      coord_seq = GEOSNearestPoints_r(ctx, in1, in2);
+      if (coord_seq == NULL) {
+        errstate = PGERR_GEOS_EXCEPTION;
+        destroy_geom_arr(ctx, geom_arr, i - 1);
+        break;
+      }
+      geom_arr[i] = GEOSGeom_createLineString_r(ctx, coord_seq);
+      // Note: coordinate sequence is owned by linestring; if linestring fails to construct,
+      // it will automatically clean up the coordinate sequence
+      if (geom_arr[i] == NULL) {
+        errstate = PGERR_GEOS_EXCEPTION;
+        destroy_geom_arr(ctx, geom_arr, i - 1);
+        break;
+      }
+    }
+  }
+
+  GEOS_FINISH_THREADS;
+
+  // fill the numpy array with PyObjects while holding the GIL
+  if (errstate == PGERR_SUCCESS) {
+    geom_arr_to_npy(geom_arr, args[2], steps[2], dimensions[0]);
+  }
+  free(geom_arr);
+}
+static PyUFuncGenericFunction nearest_points_funcs[1] = {&nearest_points_func};
+
 #if GEOS_SINCE_3_6_0
 static char set_precision_dtypes[4] = {NPY_OBJECT, NPY_DOUBLE, NPY_BOOL, NPY_OBJECT};
 static void set_precision_func(char** args, npy_intp* dimensions, npy_intp* steps,
@@ -3072,6 +3136,7 @@ int init_ufuncs(PyObject* m, PyObject* d) {
   DEFINE_CUSTOM(relate_pattern, 3);
   DEFINE_GENERALIZED(polygonize, 1, "(d)->()");
   DEFINE_GENERALIZED_NOUT4(polygonize_full, 1, "(d)->(),(),(),()");
+  DEFINE_CUSTOM(nearest_points, 2);
 
   DEFINE_GENERALIZED(points, 1, "(d)->()");
   DEFINE_GENERALIZED(linestrings, 1, "(i, d)->()");

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1975,7 +1975,7 @@ static void nearest_points_func(char** args, npy_intp* dimensions, npy_intp* ste
       break;
     }
 
-    if ((in1 == NULL) | (in2 == NULL) | GEOSisEmpty_r(ctx, in1) |
+    if ((in1 == NULL) || (in2 == NULL) || GEOSisEmpty_r(ctx, in1) ||
         GEOSisEmpty_r(ctx, in2)) {
       // in case of a missing value or empty geometry: return NULL (None)
       // GEOSNearestPoints_r returns NULL for empty geometries


### PR DESCRIPTION
This is initial work to expose the `GEOSNearestPoints_r` function. There are however some design questions to decide on.

- The GEOS function returns a lenght-2 `CoordSequence`, so we need to wrap/unwrap that in some way for the actual return value
- Shapely exposes it as [`shapely.ops.nearest_points`](https://shapely.readthedocs.io/en/stable/manual.html#nearest-points) which returns a tuple of 2 Point geometries.
- The R spatial packages (`sf`) have a [`st_nearest_points`](https://r-spatial.github.io/sf/reference/st_nearest_points.html) to expose this, which returns this as a two-point LineString. 
- PostGIS doesn't expose this GEOS function, but they do have a [`ST_ShortestLine`](https://postgis.net/docs/ST_ShortestLine.html) with similar functionality, also returning a line of two points. 

In general, I think returning the two-point LineString geometries for the ufunc would make sense. You can then still easily get the first or second point using `get_points` (to mimic the current shapely return value), but having a single return value makes it easier to implement and use, I think.

If we decide to return LineStrings (and not arrays of points), I think the name "shortest_line" actually makes more sense as "nearest_points". It would be consistent in naming with PostGIS, but since they have their own custom implementation (it's not exposing `GEOSNearestPoints`), I am not sure it behaves exactly the same as "nearest_points", though. On the other hand "shortest_line" would be inconsistent with R `sf`. 
If we we go with "shortest_line" for the ufunc, we can still easily have a "nearest_points" in python,as a small wrapper around the ufunc, which directly returns the tuple/array of points, to be consistent with Shapely.


---

Given those open discussion points, I didn't yet add the python wrapper or tests, but so the actual ufunc already works:

```
In [12]: pygeos.lib.nearest_points(pygeos.box(0, 0, 1, 1), pygeos.box(2, 2, 3, 3))
Out[12]: <pygeos.Geometry LINESTRING (1 1, 2 2)>
```