### PR TITLE
Merge polygons_1d into collections_1d + finish implementation for rls 0.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Version 0.10 (unreleased)
 * Addition of ``nearest`` and ``nearest_all`` functions to ``STRtree`` for
   GEOS >= 3.6 to find the nearest neighbors (#272).
 * Enable bulk construction of geometries with different number of coordinates
-  by optionally taking index arrays in all creation functions (#230, #322, #326).
+  by optionally taking index arrays in all creation functions (#230, #322, #326, #346).
 * Released the GIL in all geometry creation functions (#310, #326).
 * Added the option to return the geometry index in ``get_coordinates`` (#318).
 * Updated ``box`` ufunc to use internal C function for creating polygon

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Version 0.10 (unreleased)
   optionally return invalid WKB geometries as ``None``.
 * Removed the (internal) function ``lib.polygons_without_holes`` and renamed
   ``lib.polygons_with_holes`` to ``lib.polygons`` (#326).
+* ``polygons`` will now return an empty polygon for `None` inputs (#346).
+
 
 **Added GEOS functions**
 

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -331,7 +331,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
                 coll = GEOSGeom_createPolygon_r(
                     geos_handle,
                     <GEOSGeometry*> temp_geoms_view[0],
-                    <GEOSGeometry**> &temp_geoms_view[1 if coll_size > 1 else 0],
+                    NULL if coll_size <= 1 else <GEOSGeometry**> &temp_geoms_view[1],
                     coll_size - 1
                 )
             else:

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -217,6 +217,15 @@ cdef _deallocate_arr(void* handle, np.intp_t[:] arr, Py_ssize_t last_geom_i):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def collections_1d(object geometries, object indices, int geometry_type = 7):
+    """Converts geometries + indices to collections
+
+    Allowed geometry type conversions are:
+    - linearrings to polygons
+    - points to multipoints
+    - linestrings/linearrings to multilinestrings
+    - polygons to multipolygons
+    - any to geometrycollections
+    """
     cdef Py_ssize_t geom_idx_1 = 0
     cdef Py_ssize_t coll_idx = 0
     cdef unsigned int coll_size = 0
@@ -227,7 +236,9 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
     cdef int expected_type_alt = -1
     cdef int curr_type = -1
 
-    if geometry_type == 4:  # MULTIPOINT
+    if geometry_type == 3:  # POLYGON
+        expected_type = 2
+    elif geometry_type == 4:  # MULTIPOINT
         expected_type = 0
     elif geometry_type == 5:  # MULTILINESTRING
         expected_type = 1
@@ -310,157 +321,31 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
                 temp_geoms_view[coll_size] = <np.intp_t>geom
                 coll_size += 1
 
+            if coll_size == 0:
+                raise TypeError(
+                    f"One of the geometries has no valid input geometries."
+                )
+
             # create the collection
-            coll = GEOSGeom_createCollection_r(
-                geos_handle,
-                geometry_type, 
-                <GEOSGeometry**> &temp_geoms_view[0],
-                coll_size
-            )
+            if geometry_type == 3:  # POLYGON
+                coll = GEOSGeom_createPolygon_r(
+                    geos_handle,
+                    <GEOSGeometry*> temp_geoms_view[0],
+                    <GEOSGeometry**> &temp_geoms_view[1 if coll_size > 1 else 0],
+                    coll_size - 1
+                )
+            else:
+                coll = GEOSGeom_createCollection_r(
+                    geos_handle,
+                    geometry_type, 
+                    <GEOSGeometry**> &temp_geoms_view[0],
+                    coll_size
+                )
             if coll == NULL:
                 return  # GEOSException is raised by get_geos_handle
 
             result_view[coll_idx] = PyGEOS_CreateGeometry(coll, geos_handle)
 
             geom_idx_1 += collection_size[coll_idx]
-
-    return result
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def polygons_1d(object shells, object holes, object indices):
-    cdef Py_ssize_t hole_idx_1 = 0
-    cdef Py_ssize_t poly_idx = 0
-    cdef unsigned int n_holes = 0
-    cdef int geom_type = 0
-    cdef Py_ssize_t poly_hole_idx = 0
-    cdef GEOSGeometry *shell = NULL
-    cdef GEOSGeometry *hole = NULL
-    cdef GEOSGeometry *poly = NULL
-
-    # Cast input arrays and define memoryviews for later usage
-    shells = np.asarray(shells, dtype=object)
-    if shells.ndim != 1:
-        raise TypeError("shells is not a one-dimensional array.")
-
-    # Cast input arrays and define memoryviews for later usage
-    holes = np.asarray(holes, dtype=object)
-    if holes.ndim != 1:
-        raise TypeError("holes is not a one-dimensional array.")
-
-    indices = np.asarray(indices, dtype=np.int32)
-    if indices.ndim != 1:
-        raise TypeError("indices is not a one-dimensional array.")
-
-    if holes.shape[0] != indices.shape[0]:
-        raise ValueError("holes and indices do not have equal size.")
-
-    if shells.shape[0] == 0:
-        # return immediately if there are no geometries to return
-        return np.empty(shape=(0, ), dtype=object)
-
-    if (indices >= shells.shape[0]).any():
-        raise ValueError("Some indices are of bounds of the shells array.")  
-
-    if np.any(indices[1:] < indices[:indices.shape[0] - 1]):
-        raise ValueError("The indices should be sorted.")  
-
-    cdef Py_ssize_t n_poly = shells.shape[0]
-    cdef object[:] shells_view = shells
-    cdef object[:] holes_view = holes
-    cdef int[:] indices_view = indices
-
-    # get the holes count per polygon (this raises on negative indices)
-    cdef int[:] hole_count = np.bincount(indices, minlength=n_poly).astype(np.int32)
-
-    # A temporary array for the holes that will be given to CreatePolygon
-    # Its size equals max(hole_count) to accomodate the largest polygon.
-    temp_holes = np.empty(shape=(np.max(hole_count), ), dtype=np.intp)
-    cdef np.intp_t[:] temp_holes_view = temp_holes
-
-    # The final target array
-    result = np.empty(shape=(n_poly, ), dtype=object)
-    cdef object[:] result_view = result
-
-    with get_geos_handle() as geos_handle:
-        for poly_idx in range(n_poly):
-            n_holes = 0
-
-            # get the shell
-            if PyGEOS_GetGEOSGeometry(<PyObject *>shells_view[poly_idx], &shell) == 0:
-                raise TypeError(
-                    "One of the arguments is of incorrect type. Please provide only Geometry objects."
-                )
-
-            # return None for missing shells (ignore possibly present holes)
-            if shell == NULL:
-                result_view[poly_idx] = PyGEOS_CreateGeometry(NULL, geos_handle)
-                hole_idx_1 += hole_count[poly_idx]
-                continue
-
-            geom_type = GEOSGeomTypeId_r(geos_handle, shell)
-            if geom_type == -1:
-                return  # GEOSException is raised by get_geos_handle
-            elif geom_type != 2:
-                raise TypeError(
-                    f"One of the shells has unexpected geometry type {geom_type}."
-                )
-
-            # fill the temporary array with holes belonging to this polygon
-            for poly_hole_idx in range(hole_count[poly_idx]):
-                if PyGEOS_GetGEOSGeometry(<PyObject *>holes_view[hole_idx_1 + poly_hole_idx], &hole) == 0:
-                    _deallocate_arr(geos_handle, temp_holes_view, n_holes)
-                    raise TypeError(
-                        "One of the arguments is of incorrect type. Please provide only Geometry objects."
-                    )
-
-                # ignore missing holes
-                if hole == NULL:
-                    continue
-
-                # check the type
-                geom_type = GEOSGeomTypeId_r(geos_handle, hole)
-                if geom_type == -1:
-                    _deallocate_arr(geos_handle, temp_holes_view, n_holes)
-                    return  # GEOSException is raised by get_geos_handle
-                elif geom_type != 2:
-                    _deallocate_arr(geos_handle, temp_holes_view, n_holes)
-                    raise TypeError(
-                        f"One of the holes has unexpected geometry type {geom_type}."
-                    )
-
-                # assign to the temporary geometry array  
-                hole = GEOSGeom_clone_r(geos_handle, hole)
-                if hole == NULL:
-                    _deallocate_arr(geos_handle, temp_holes_view, n_holes)
-                    return  # GEOSException is raised by get_geos_handle                 
-                temp_holes_view[n_holes] = <np.intp_t>hole
-                n_holes += 1
-
-            # clone the shell as the polygon will take ownership
-            shell = GEOSGeom_clone_r(geos_handle, shell)
-            if shell == NULL:
-                _deallocate_arr(geos_handle, temp_holes_view, n_holes)
-                return  # GEOSException is raised by get_geos_handle
-
-            # create the polygon
-            poly = GEOSGeom_createPolygon_r(
-                geos_handle,
-                shell, 
-                <GEOSGeometry**> &temp_holes_view[0],
-                n_holes
-            )
-            if poly == NULL:
-                # GEOSGeom_createPolygon_r should take ownership of the input geometries,
-                # but it doesn't in case of an exception. We prefer a memory leak here over
-                # a possible segfault in the future. The pre-emptive type check already covers
-                # all known cases that GEOSGeom_createPolygon_r errors, so this should never
-                # happen anyway. https://trac.osgeo.org/geos/ticket/1111.
-                return  # GEOSException is raised by get_geos_handle
-
-            result_view[poly_idx] = PyGEOS_CreateGeometry(poly, geos_handle)
-
-            hole_idx_1 += hole_count[poly_idx]
 
     return result

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -106,7 +106,7 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type):
 
             # for now, raise if there are no coordinates (decision on this in GH345)
             if geom_size == 0:
-                raise TypeError(
+                raise ValueError(
                     f"One of the geometries has no valid input coordinates."
                 )
 
@@ -320,7 +320,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
 
             # for now, raise if there are no geometries (decision on this in GH345)
             if coll_size == 0:
-                raise TypeError(
+                raise ValueError(
                     f"One of the geometries has no valid input geometries."
                 )
 

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -104,10 +104,11 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type):
         for geom_idx in range(n_geoms):
             geom_size = coord_counts[geom_idx]
 
-            # insert None if there are no coordinates
+            # for now, raise if there are no coordinates (decision on this in GH345)
             if geom_size == 0:
-                result_view[geom_idx] = PyGEOS_CreateGeometry(NULL, geos_handle)
-                continue
+                raise TypeError(
+                    f"One of the geometries has no valid input coordinates."
+                )
 
             # check if we need to close a linearring
             if geometry_type == 2:
@@ -317,6 +318,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
                 temp_geoms_view[coll_size] = <np.intp_t>geom
                 coll_size += 1
 
+            # for now, raise if there are no geometries (decision on this in GH345)
             if coll_size == 0:
                 raise TypeError(
                     f"One of the geometries has no valid input geometries."

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -69,7 +69,7 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type):
     if coordinates.ndim != 2:
         raise TypeError("coordinates is not a two-dimensional array.")
 
-    indices = np.asarray(indices, dtype=np.intp)
+    indices = np.asarray(indices, dtype=np.intp)  # intp is what bincount takes
     if indices.ndim != 1:
         raise TypeError("indices is not a one-dimensional array.")
 
@@ -91,7 +91,6 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type):
         raise ValueError("The indices must be sorted.")  
 
     cdef double[:, :] coord_view = coordinates
-    cdef np.intp_t[:] index_view = indices
 
     # get the geometry count per collection (this raises on negative indices)
     cdef unsigned int[:] coord_counts = np.bincount(indices).astype(np.uint32)
@@ -255,7 +254,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
     if geometries.ndim != 1:
         raise TypeError("geometries is not a one-dimensional array.")
 
-    indices = np.asarray(indices, dtype=np.int32)
+    indices = np.asarray(indices, dtype=np.intp)  # intp is what bincount takes
     if indices.ndim != 1:
         raise TypeError("indices is not a one-dimensional array.")
 
@@ -268,9 +267,6 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
 
     if np.any(indices[1:] < indices[:indices.shape[0] - 1]):
         raise ValueError("The indices should be sorted.")  
-
-    cdef object[:] geometries_view = geometries
-    cdef int[:] indices_view = indices
 
     # get the geometry count per collection (this raises on negative indices)
     cdef int[:] collection_size = np.bincount(indices).astype(np.int32)
@@ -291,7 +287,7 @@ def collections_1d(object geometries, object indices, int geometry_type = 7):
 
             # fill the temporary array with geometries belonging to this collection
             for coll_geom_idx in range(collection_size[coll_idx]):
-                if PyGEOS_GetGEOSGeometry(<PyObject *>geometries_view[geom_idx_1 + coll_geom_idx], &geom) == 0:
+                if PyGEOS_GetGEOSGeometry(<PyObject *>geometries[geom_idx_1 + coll_geom_idx], &geom) == 0:
                     _deallocate_arr(geos_handle, temp_geoms_view, coll_size)
                     raise TypeError(
                         "One of the arguments is of incorrect type. Please provide only Geometry objects."

--- a/pygeos/_geos.pxd
+++ b/pygeos/_geos.pxd
@@ -29,6 +29,7 @@ cdef extern from "geos_c.h":
     GEOSGeometry* GEOSGeom_createPoint_r(GEOSContextHandle_t handle, GEOSCoordSequence* s) nogil
     GEOSGeometry* GEOSGeom_createLineString_r(GEOSContextHandle_t handle, GEOSCoordSequence* s) nogil
     GEOSGeometry* GEOSGeom_createLinearRing_r(GEOSContextHandle_t handle, GEOSCoordSequence* s) nogil
+    GEOSGeometry* GEOSGeom_createEmptyPolygon_r(GEOSContextHandle_t handle) nogil
     GEOSGeometry* GEOSGeom_createPolygon_r(GEOSContextHandle_t handle, GEOSGeometry* shell, GEOSGeometry** holes, unsigned int nholes) nogil
     GEOSGeometry* GEOSGeom_createCollection_r(GEOSContextHandle_t handle, int type, GEOSGeometry** geoms, unsigned int ngeoms) nogil
     void GEOSGeom_destroy_r(GEOSContextHandle_t handle, GEOSGeometry* g) nogil

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -46,12 +46,19 @@ def points(coords, y=None, z=None, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
-        indices should be 1D with shape (N,). Missing indices will result
-        in a ValueError.
+        indices should be an array of shape (N,) with integers in increasing
+        order. Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
         Ignored if ``indices`` is provided.
+
+    Examples
+    --------
+    >>> points([[0, 1], [4, 5]]).tolist()
+    [<pygeos.Geometry POINT (0 1)>, <pygeos.Geometry POINT (4 5)>]
+    >>> points([0, 1, 2])
+    <pygeos.Geometry POINT Z (0 1 2)>
     """
     coords = _xyz_to_coords(coords, y, z)
     if indices is None:
@@ -77,12 +84,19 @@ def linestrings(coords, y=None, z=None, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
-        indices should be 1D with shape (N,). Missing indices will result
-        in a ValueError.
+        indices should be an array of shape (N,) with integers in increasing
+        order. Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
         Ignored if ``indices`` is provided.
+
+    Examples
+    --------
+    >>> linestrings([[[0, 1], [4, 5]], [[2, 3], [5, 6]]]).tolist()
+    [<pygeos.Geometry LINESTRING (0 1, 4 5)>, <pygeos.Geometry LINESTRING (2 3, 5 6)>]
+    >>> linestrings([[0, 1], [4, 5], [2, 3], [5, 6], [7, 8]], indices=[0, 0, 1, 1, 1]).tolist()
+    [<pygeos.Geometry LINESTRING (0 1, 4 5)>, <pygeos.Geometry LINESTRING (2 3, 5 6, 7 8)>]
     """
     coords = _xyz_to_coords(coords, y, z)
     if indices is None:
@@ -110,12 +124,23 @@ def linearrings(coords, y=None, z=None, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
-        indices should be 1D with shape (N,). Missing indices will result
-        in a ValueError.
+        indices should be an array of shape (N,) with integers in increasing
+        order. Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
         Ignored if ``indices`` is provided.
+
+    See also
+    --------
+    linestrings
+
+    Examples
+    --------
+    >>> linearrings([[0, 0], [0, 1], [1, 1], [0, 0]])
+    <pygeos.Geometry LINEARRING (0 0, 0 1, 1 1, 0 0)>
+    >>> linearrings([[0, 0], [0, 1], [1, 1]])
+    <pygeos.Geometry LINEARRING (0 0, 0 1, 1 1, 0 0)>
     """
     coords = _xyz_to_coords(coords, y, z)
     if indices is None:
@@ -127,26 +152,69 @@ def linearrings(coords, y=None, z=None, indices=None, **kwargs):
 @multithreading_enabled
 def polygons(geometries, holes=None, indices=None, **kwargs):
     """Create an array of polygons.
+    and the holes; the first geometry for each index is the outer shell and all subsequent geometries in that index are the holes...
+        Parameters
+        ----------
+        geometries : array_like
+            An array of linearrings or coordinates (see linearrings).
+            Unless ``indices`` are given (see description below), this
+            include the outer shells only. The ``holes`` argument should be used
+            to create polygons with holes.
+        holes : array_like or None
+            An array of lists of linearrings that constitute holes for each shell.
+            Not to be used in combination with ``indices``.
+        indices : array_like or None
+            Indices into the target array where input geometries belong. If
+            provided, the holes are expected to be present inside ``geometries``;
+            the first geometry for each index is the outer shell
+            and all subsequent geometries in that index are the holes.
+            Both geometries and indices should be 1D and have matching sizes.
+            Indices should be in increasing order. Missing indices will result
+            in a ValueError.
+        **kwargs
+            For other keyword-only arguments, see the
+            `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+            Ignored if ``indices`` is provided.
 
-    Parameters
-    ----------
-    geometries : array_like
-        An array of linearrings or coordinates (see linearrings).
-        If ``indices`` are given, the geometries include both the outer shell
-        and the holes. If not, the geometries only include the shells and the
-        ``holes`` argument should be used to create polygons with holes.
-    holes : array_like or None
-        An array of lists of linearrings that constitute holes for each shell.
-        Not to be used in combination with ``indices``.
-    indices : array_like or None
-        Indices into the target array where input geometries belong. If
-        provided, the holes are expected to be present inside ``geometries``.
-        Both geometries and indices should be 1D and have matching sizes.
-        Missing indices will result in a ValueError.
-    **kwargs
-        For other keyword-only arguments, see the
-        `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
-        Ignored if ``indices`` is provided.
+        Examples
+        --------
+        Polygons are constructed from rings:
+
+        >>> ring_1 = linearrings([[0, 0], [0, 10], [10, 10], [10, 0]])
+        >>> ring_2 = linearrings([[2, 6], [2, 7], [3, 7], [3, 6]])
+        >>> polygons([ring_1, ring_2])[0]
+        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+        >>> polygons([ring_1, ring_2])[1]
+        <pygeos.Geometry POLYGON ((2 6, 2 7, 3 7, 3 6, 2 6))>
+
+        Or from coordinates directly:
+
+        >>> polygons([[0, 0], [0, 10], [10, 10], [10, 0]])
+        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+
+        Adding holes can be done using the `holes` keyword argument:
+
+        >>> polygons(ring_1, holes=[ring_2])
+        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
+
+        Or using the `indices` argument:
+
+        >>> polygons([ring_1, ring_2], indices=[0, 1])[0]
+        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+        >>> polygons([ring_1, ring_2], indices=[0, 1])[1]
+        <pygeos.Geometry POLYGON ((2 6, 2 7, 3 7, 3 6, 2 6))>
+        >>> polygons([ring_1, ring_2], indices=[0, 0])[0]
+        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
+
+        Missing input values (`None`) are ignored and may result in an
+        empty polygon:
+
+        >>> polygons(None)
+        <pygeos.Geometry POLYGON EMPTY>
+        >>> polygons(ring_1, holes=[None])
+        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+        >>> polygons([ring_1, None], indices=[0, 0])[0]
+        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
     """
     geometries = np.asarray(geometries)
     if not isinstance(geometries, Geometry) and np.issubdtype(
@@ -213,11 +281,44 @@ def multipoints(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes. Missing indices will result in a ValueError.
+        sizes. Indices should be in increasing order. Missing indices will result
+        in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
         Ignored if ``indices`` is provided.
+
+    Examples
+    --------
+    Multipoints are constructed from points:
+
+    >>> point_1 = points([1, 1])
+    >>> point_2 = points([2, 2])
+    >>> multipoints([point_1, point_2])
+    <pygeos.Geometry MULTIPOINT (1 1, 2 2)>
+    >>> multipoints([[point_1, point_2], [point_2, None]]).tolist()
+    [<pygeos.Geometry MULTIPOINT (1 1, 2 2)>, <pygeos.Geometry MULTIPOINT (2 2)>]
+
+    Or from coordinates directly:
+
+    >>> multipoints([[0, 0], [2, 2], [3, 3]])
+    <pygeos.Geometry MULTIPOINT (0 0, 2 2, 3 3)>
+
+    Multiple multipoints of different sizes can be constructed efficiently using the
+    `indices` keyword argument:
+
+    >>> multipoints([point_1, point_2, point_2], indices=[0, 0, 1]).tolist()
+    [<pygeos.Geometry MULTIPOINT (1 1, 2 2)>, <pygeos.Geometry MULTIPOINT (2 2)>]
+
+    Missing input values (`None`) are ignored and may result in an
+    empty multipoint:
+
+    >>> multipoints([None])
+    <pygeos.Geometry MULTIPOINT EMPTY>
+    >>> multipoints([point_1, None], indices=[0, 0]).tolist()
+    [<pygeos.Geometry MULTIPOINT (1 1)>]
+    >>> multipoints([point_1, None], indices=[0, 1]).tolist()
+    [<pygeos.Geometry MULTIPOINT (1 1)>, <pygeos.Geometry MULTIPOINT EMPTY>]
     """
     typ = GeometryType.MULTIPOINT
     geometries = np.asarray(geometries)
@@ -242,11 +343,16 @@ def multilinestrings(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes. Missing indices will result in a ValueError.
+        sizes. Indices should be in increasing order. Missing indices will result
+        in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
         Ignored if ``indices`` is provided.
+
+    See also
+    --------
+    multipoints
     """
     typ = GeometryType.MULTILINESTRING
     geometries = np.asarray(geometries)
@@ -272,11 +378,16 @@ def multipolygons(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes. Missing indices will result in a ValueError.
+        sizes. Indices should be in increasing order. Missing indices will result
+        in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
         Ignored if ``indices`` is provided.
+
+    See also
+    --------
+    multipoints
     """
     typ = GeometryType.MULTIPOLYGON
     geometries = np.asarray(geometries)
@@ -301,11 +412,16 @@ def geometrycollections(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes. Missing indices will result in a ValueError.
+        sizes. Indices should be in increasing order. Missing indices will result
+        in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
         Ignored if ``indices`` is provided.
+
+    See also
+    --------
+    multipoints
     """
     typ = GeometryType.GEOMETRYCOLLECTION
     if indices is None:

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -142,8 +142,7 @@ def polygons(geometries, holes=None, indices=None, **kwargs):
         Indices into the target array where input geometries belong. If
         provided, the holes are expected to be present inside ``geometries``.
         Both geometries and indices should be 1D and have matching sizes.
-        Output geometries with no input geometries specified (no index or only
-        None inputs) will result in a ValueError.
+        Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -214,9 +213,7 @@ def multipoints(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes.
-        Output geometries with no input geometries specified (no index or only
-        None inputs) will result in a ValueError.
+        sizes. Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -245,9 +242,7 @@ def multilinestrings(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes.
-        Output geometries with no input geometries specified (no index or only
-        None inputs) will result in a ValueError.
+        sizes. Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -277,9 +272,7 @@ def multipolygons(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes.
-        Output geometries with no input geometries specified (no index or only
-        None inputs) will result in a ValueError.
+        sizes. Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -308,9 +301,7 @@ def geometrycollections(geometries, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
-        sizes.
-        Output geometries with no input geometries specified (no index or only
-        None inputs) will result in a ValueError.
+        sizes. Missing indices will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -148,7 +148,9 @@ def polygons(geometries, holes=None, indices=None, **kwargs):
         Ignored if ``indices`` is provided.
     """
     geometries = np.asarray(geometries)
-    if not isinstance(geometries, Geometry) and np.issubdtype(geometries.dtype, np.number):
+    if not isinstance(geometries, Geometry) and np.issubdtype(
+        geometries.dtype, np.number
+    ):
         geometries = linearrings(geometries)
 
     if indices is not None:

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -155,7 +155,7 @@ def polygons(geometries, holes=None, indices=None, **kwargs):
 
     if indices is not None:
         if holes is not None:
-            raise TypeError("Indices provided with a holes array.")
+            raise TypeError("Cannot specify separate holes array when using indices.")
         return collections_1d(geometries, indices, GeometryType.POLYGON)
 
     if holes is None:

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -46,8 +46,8 @@ def points(coords, y=None, z=None, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
-        indices should be 1D with shape (N,). Missing indices will give None
-        values in the output array.
+        indices should be 1D with shape (N,). Missing indices will result
+        in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -77,8 +77,8 @@ def linestrings(coords, y=None, z=None, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
-        indices should be 1D with shape (N,). Missing indices will give None
-        values in the output array.
+        indices should be 1D with shape (N,). Missing indices will result
+        in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -110,8 +110,8 @@ def linearrings(coords, y=None, z=None, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
-        indices should be 1D with shape (N,). Missing indices will give None
-        values in the output array.
+        indices should be 1D with shape (N,). Missing indices will result
+        in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -141,7 +141,9 @@ def polygons(geometries, holes=None, indices=None, **kwargs):
     indices : array_like or None
         Indices into the target array where input geometries belong. If
         provided, the holes are expected to be present inside ``geometries``.
-        Both geometries and indices should be 1D and have matching  sizes.
+        Both geometries and indices should be 1D and have matching sizes.
+        Output geometries with no input geometries specified (no index or only
+        None inputs) will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -213,6 +215,8 @@ def multipoints(geometries, indices=None, **kwargs):
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes.
+        Output geometries with no input geometries specified (no index or only
+        None inputs) will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -242,6 +246,8 @@ def multilinestrings(geometries, indices=None, **kwargs):
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes.
+        Output geometries with no input geometries specified (no index or only
+        None inputs) will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -272,6 +278,8 @@ def multipolygons(geometries, indices=None, **kwargs):
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes.
+        Output geometries with no input geometries specified (no index or only
+        None inputs) will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -301,6 +309,8 @@ def geometrycollections(geometries, indices=None, **kwargs):
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes.
+        Output geometries with no input geometries specified (no index or only
+        None inputs) will result in a ValueError.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.

--- a/pygeos/test/test_creation.py
+++ b/pygeos/test/test_creation.py
@@ -4,6 +4,7 @@ import pytest
 import pygeos
 
 from .common import (
+    empty_polygon,
     geometry_collection,
     line_string,
     linear_ring,
@@ -146,8 +147,8 @@ def test_polygon_from_linearring():
 
 
 def test_polygons_none():
-    assert pygeos.polygons(None) is None
-    assert pygeos.polygons(None, holes=[linear_ring]) is None
+    assert pygeos.equals(pygeos.polygons(None), empty_polygon)
+    assert pygeos.equals(pygeos.polygons(None, holes=[linear_ring]), empty_polygon)
 
 
 def test_polygons():

--- a/pygeos/test/test_creation_indices.py
+++ b/pygeos/test/test_creation_indices.py
@@ -128,6 +128,7 @@ def test_linearrings_invalid(coordinates):
 hole_1 = pygeos.linearrings([(0.2, 0.2), (0.2, 0.4), (0.4, 0.4)])
 hole_2 = pygeos.linearrings([(0.6, 0.6), (0.6, 0.8), (0.8, 0.8)])
 poly = pygeos.polygons(linear_ring)
+poly_empty = pygeos.Geometry("POLYGON EMPTY")
 poly_hole_1 = pygeos.polygons(linear_ring, holes=[hole_1])
 poly_hole_2 = pygeos.polygons(linear_ring, holes=[hole_2])
 poly_hole_1_2 = pygeos.polygons(linear_ring, holes=[hole_1, hole_2])
@@ -137,6 +138,8 @@ poly_hole_1_2 = pygeos.polygons(linear_ring, holes=[hole_1, hole_2])
     "rings,indices,expected",
     [
         ([linear_ring, linear_ring], [0, 1], [poly, poly]),
+        ([None, linear_ring], [0, 1], [poly_empty, poly]),
+        ([None, linear_ring, None, None], [0, 0, 1, 1], [poly, poly_empty]),
         ([linear_ring, hole_1, linear_ring], [0, 0, 1], [poly_hole_1, poly]),
         ([linear_ring, linear_ring, hole_1], [0, 1, 1], [poly, poly_hole_1]),
         ([None, linear_ring, linear_ring, hole_1], [0, 0, 1, 1], [poly, poly_hole_1]),
@@ -205,6 +208,8 @@ def test_invalid_indices_collections(func, indices):
         ([point, line_string], [0, 0], [geom_coll([point, line_string])]),
         ([point, line_string], [0, 1], [geom_coll([point]), geom_coll([line_string])]),
         ([point, None], [0, 0], [geom_coll([point])]),
+        ([point, None], [0, 1], [geom_coll([point]), geom_coll([])]),
+        ([None, point, None, None], [0, 0, 1, 1], [geom_coll([point]), geom_coll([])]),
         ([point, None, line_string], [0, 0, 0], [geom_coll([point, line_string])]),
     ],
 )
@@ -219,13 +224,6 @@ def test_geometrycollections_no_index_raises():
     with pytest.raises(ValueError):
         pygeos.geometrycollections(
             np.array([point, line_string], dtype=object), indices=[0, 2]
-        )
-
-
-def test_geometrycollections_missing_input_raises():
-    with pytest.raises(ValueError):
-        pygeos.geometrycollections(
-            np.array([point, None, line_string], dtype=object), indices=[0, 1, 2]
         )
 
 

--- a/pygeos/test/test_creation_indices.py
+++ b/pygeos/test/test_creation_indices.py
@@ -63,9 +63,17 @@ def test_points_invalid():
 def test_points():
     actual = pygeos.points(
         np.array([[2, 3], [2, 3]], dtype=float),
-        indices=np.array([0, 2], dtype=np.intp),
+        indices=np.array([0, 1], dtype=np.intp),
     )
-    assert_geometries_equal(actual, [point, None, point])
+    assert_geometries_equal(actual, [point, point])
+
+
+def test_points_no_index_raises():
+    with pytest.raises(TypeError):
+        pygeos.points(
+            np.array([[2, 3], [2, 3]], dtype=float),
+            indices=np.array([0, 2], dtype=np.intp),
+        )
 
 
 @pytest.mark.parametrize(
@@ -73,7 +81,6 @@ def test_points():
     [
         ([[1, 1], [2, 2]], [0, 0], [lstrs([[1, 1], [2, 2]])]),
         ([[1, 1, 1], [2, 2, 2]], [0, 0], [lstrs([[1, 1, 1], [2, 2, 2]])]),
-        ([[1, 1], [2, 2]], [1, 1], [None, lstrs([[1, 1], [2, 2]])]),
         (
             [[1, 1], [2, 2], [2, 2], [3, 3]],
             [0, 0, 1, 1],
@@ -206,6 +213,20 @@ def test_geometrycollections(geometries, indices, expected):
         np.array(geometries, dtype=object), indices=indices
     )
     assert_geometries_equal(actual, expected)
+
+
+def test_geometrycollections_no_index_raises():
+    with pytest.raises(TypeError):
+        pygeos.geometrycollections(
+            np.array([point, line_string], dtype=object), indices=[0, 2]
+        )
+
+
+def test_geometrycollections_missing_input_raises():
+    with pytest.raises(TypeError):
+        pygeos.geometrycollections(
+            np.array([point, None, line_string], dtype=object), indices=[0, 1, 2]
+        )
 
 
 def test_multipoints():

--- a/pygeos/test/test_creation_indices.py
+++ b/pygeos/test/test_creation_indices.py
@@ -38,7 +38,7 @@ def test_invalid_coordinates(func, coordinates):
     ],
 )
 @pytest.mark.parametrize(
-    "geometries", [np.array([1, 2], dtype=np.int32), None, np.array([[point]]), "hello"]
+    "geometries", [np.array([1, 2], dtype=np.intp), None, np.array([[point]]), "hello"]
 )
 def test_invalid_geometries(func, geometries):
     with pytest.raises((TypeError, ValueError)):
@@ -61,7 +61,10 @@ def test_points_invalid():
 
 
 def test_points():
-    actual = pygeos.points([[2, 3], [2, 3]], indices=[0, 2])
+    actual = pygeos.points(
+        np.array([[2, 3], [2, 3]], dtype=float),
+        indices=np.array([0, 2], dtype=np.intp),
+    )
     assert_geometries_equal(actual, [point, None, point])
 
 
@@ -79,7 +82,9 @@ def test_points():
     ],
 )
 def test_linestrings(coordinates, indices, expected):
-    actual = pygeos.linestrings(coordinates, indices=indices)
+    actual = pygeos.linestrings(
+        np.array(coordinates, dtype=float), indices=np.array(indices, dtype=np.intp)
+    )
     assert_geometries_equal(actual, expected)
 
 
@@ -93,7 +98,10 @@ def test_linestrings_invalid():
     "coordinates", [([[1, 1], [2, 1], [2, 2], [1, 1]]), ([[1, 1], [2, 1], [2, 2]])]
 )
 def test_linearrings(coordinates):
-    actual = pygeos.linearrings(coordinates, indices=len(coordinates) * [0])
+    actual = pygeos.linearrings(
+        np.array(coordinates, dtype=np.float64),
+        indices=np.zeros(len(coordinates), dtype=np.intp),
+    )
     assert_geometries_equal(actual, pygeos.linearrings(coordinates))
 
 
@@ -162,7 +170,9 @@ poly_hole_1_2 = pygeos.polygons(linear_ring, holes=[hole_1, hole_2])
     ],
 )
 def test_polygons(rings, indices, expected):
-    actual = pygeos.polygons(rings, indices=indices)
+    actual = pygeos.polygons(
+        np.array(rings, dtype=object), indices=np.array(indices, dtype=np.intp)
+    )
     assert_geometries_equal(actual, expected)
 
 
@@ -192,27 +202,37 @@ def test_invalid_indices_collections(func, indices):
     ],
 )
 def test_geometrycollections(geometries, indices, expected):
-    actual = pygeos.geometrycollections(geometries, indices=indices)
+    actual = pygeos.geometrycollections(
+        np.array(geometries, dtype=object), indices=indices
+    )
     assert_geometries_equal(actual, expected)
 
 
 def test_multipoints():
-    actual = pygeos.multipoints([point], indices=[0])
+    actual = pygeos.multipoints(
+        np.array([point], dtype=object), indices=np.zeros(1, dtype=np.intp)
+    )
     assert_geometries_equal(actual, pygeos.multipoints([point]))
 
 
 def test_multilinestrings():
-    actual = pygeos.multilinestrings([line_string], indices=[0])
+    actual = pygeos.multilinestrings(
+        np.array([line_string], dtype=object), indices=np.zeros(1, dtype=np.intp)
+    )
     assert_geometries_equal(actual, pygeos.multilinestrings([line_string]))
 
 
 def test_multilinearrings():
-    actual = pygeos.multilinestrings([linear_ring], indices=[0])
+    actual = pygeos.multilinestrings(
+        np.array([linear_ring], dtype=object), indices=np.zeros(1, dtype=np.intp)
+    )
     assert_geometries_equal(actual, pygeos.multilinestrings([linear_ring]))
 
 
 def test_multipolygons():
-    actual = pygeos.multipolygons([polygon], indices=[0])
+    actual = pygeos.multipolygons(
+        np.array([polygon], dtype=object), indices=np.zeros(1, dtype=np.intp)
+    )
     assert_geometries_equal(actual, pygeos.multipolygons([polygon]))
 
 

--- a/pygeos/test/test_creation_indices.py
+++ b/pygeos/test/test_creation_indices.py
@@ -69,7 +69,7 @@ def test_points():
 
 
 def test_points_no_index_raises():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         pygeos.points(
             np.array([[2, 3], [2, 3]], dtype=float),
             indices=np.array([0, 2], dtype=np.intp),
@@ -216,14 +216,14 @@ def test_geometrycollections(geometries, indices, expected):
 
 
 def test_geometrycollections_no_index_raises():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         pygeos.geometrycollections(
             np.array([point, line_string], dtype=object), indices=[0, 2]
         )
 
 
 def test_geometrycollections_missing_input_raises():
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         pygeos.geometrycollections(
             np.array([point, None, line_string], dtype=object), indices=[0, 1, 2]
         )

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2199,8 +2199,13 @@ static void polygons_func(char** args, npy_intp* dimensions, npy_intp* steps,
       break;
     }
     if (shell == NULL) {
-      // set None if shell is None (ignoring holes)
-      geom_arr[i] = NULL;
+      // output empty polygon if shell is None (ignoring holes)
+      geom_arr[i] = GEOSGeom_createEmptyPolygon_r(ctx);
+      if (geom_arr[i] == NULL) {
+        errstate = PGERR_GEOS_EXCEPTION;
+        destroy_geom_arr(ctx, geom_arr, i - 1);
+        break;
+      };
       continue;
     }
     geom_type = GEOSGeomTypeId_r(ctx, shell);


### PR DESCRIPTION
Follow up from #326 .

Now `polygons` only takes 1 array of rings if used in combination with `indices`.

Also now the collection constructor raise errors if there are any indices missing (see #345). It was easier to implement the Polygons in that way. 