### PR TITLE
TST: ubuntu-16.04 about to reach EOL; upgrade to ubuntu-latest

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -5,8 +5,7 @@ on: [push, pull_request]
 jobs:
   TestLinux:
     name: Python ${{ matrix.python }} (GEOS ${{ matrix.geos }}, numpy ${{ matrix.numpy || 'latest' }})
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
According to the [Ubuntu release schedule](https://wiki.ubuntu.com/Releases), Ubuntu Xenial 16.04 is to reach it's end of standard support in a few days. Upgrading to [`ubuntu-latest`](https://github.com/actions/virtual-environments), which is currently an alias to Ubuntu Focal 20.04.

Note that `ubuntu-latest` is consistently used for `test-conda.yml` and `lint.yml` workflows.