### PR TITLE
Remove minimum_rotated_rectangle duplicate + fix docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,11 @@ html_css_files = [
 ]
 
 
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = False
+
+
 # set an environment variable for pygeos.decorators.requires_geos to see if we
 # are in a doc build
 import os

--- a/docs/constructive.rst
+++ b/docs/constructive.rst
@@ -3,7 +3,7 @@ Constructive operations
 
 .. automodule:: pygeos.constructive
    :members:
-   :exclude-members: BufferCapStyles, BufferJoinStyles
+   :exclude-members: BufferCapStyles, BufferJoinStyles, minimum_rotated_rectangle
    :special-members:
    :inherited-members:
    :show-inheritance:

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -104,23 +104,23 @@ def buffer(
     geometry : Geometry or array_like
     width : float or array_like
         Specifies the circle radius in the Minkowski sum (or difference).
-    quadsegs : int
+    quadsegs : int, default 8
         Specifies the number of linear segments in a quarter circle in the
         approximation of circular arcs.
-    cap_style : {'round', 'square', 'flat'}
+    cap_style : {'round', 'square', 'flat'}, default 'round'
         Specifies the shape of buffered line endings. 'round' results in
         circular line endings (see ``quadsegs``). Both 'square' and 'flat'
         result in rectangular line endings, only 'flat' will end at the
         original vertex, while 'square' involves adding the buffer width.
-    join_style : {'round', 'bevel', 'mitre'}
+    join_style : {'round', 'bevel', 'mitre'}, default 'round'
         Specifies the shape of buffered line midpoints. 'round' results in
         rounded shapes. 'bevel' results in a beveled edge that touches the
         original vertex. 'mitre' results in a single vertex that is beveled
         depending on the ``mitre_limit`` parameter.
-    mitre_limit : float
+    mitre_limit : float, default 5.0
         Crops of 'mitre'-style joins if the point is displaced from the
         buffered vertex by more than this limit.
-    single_sided : bool
+    single_sided : bool, default False
         Only buffer at one side of the geometry.
     **kwargs
         For other keyword-only arguments, see the
@@ -203,15 +203,15 @@ def offset_curve(
     distance : float or array_like
         Specifies the offset distance from the input geometry. Negative
         for right side offset, positive for left side offset.
-    quadsegs : int
+    quadsegs : int, default 8
         Specifies the number of linear segments in a quarter circle in the
         approximation of circular arcs.
-    join_style : {'round', 'bevel', 'mitre'}
+    join_style : {'round', 'bevel', 'mitre'}, default 'round'
         Specifies the shape of outside corners. 'round' results in
         rounded shapes. 'bevel' results in a beveled edge that touches the
         original vertex. 'mitre' results in a single vertex that is beveled
         depending on the ``mitre_limit`` parameter.
-    mitre_limit : float
+    mitre_limit : float, default 5.0
         Crops of 'mitre'-style joins if the point is displaced from the
         buffered vertex by more than this limit.
     **kwargs
@@ -353,9 +353,9 @@ def delaunay_triangles(geometry, tolerance=0.0, only_edges=False, **kwargs):
     Parameters
     ----------
     geometry : Geometry or array_like
-    tolerance : float or array_like
+    tolerance : float or array_like, default 0.0
         Snap input vertices together if their distance is less than this value.
-    only_edges : bool or array_like
+    only_edges : bool or array_like, default False
         If set to True, the triangulation will return a collection of
         linestrings instead of polygons.
     **kwargs
@@ -719,7 +719,7 @@ def simplify(geometry, tolerance, preserve_topology=False, **kwargs):
     tolerance : float or array_like
         The maximum allowed geometry displacement. The higher this value, the
         smaller the number of vertices in the resulting geometry.
-    preserve_topology : bool
+    preserve_topology : bool, default False
         If set to True, the operation will avoid creating invalid geometries.
     **kwargs
         For other keyword-only arguments, see the
@@ -790,12 +790,12 @@ def voronoi_polygons(
     Parameters
     ----------
     geometry : Geometry or array_like
-    tolerance : float or array_like
+    tolerance : float or array_like, default 0.0
         Snap input vertices together if their distance is less than this value.
-    extend_to : Geometry or array_like
+    extend_to : Geometry or array_like, optional
         If provided, the diagram will be extended to cover the envelope of this
         geometry (unless this envelope is smaller than the input geometry).
-    only_edges : bool or array_like
+    only_edges : bool or array_like, default False
         If set to True, the triangulation will return a collection of
         linestrings instead of polygons.
     **kwargs

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -484,7 +484,7 @@ def normalize(geometry, **kwargs):
 
     This method orders the coordinates, rings of a polygon and parts of
     multi geometries consistently. Typically useful for testing purposes
-    (for example in combination with `equals_exact`).
+    (for example in combination with ``equals_exact``).
 
     Parameters
     ----------
@@ -540,8 +540,8 @@ def polygonize(geometries, **kwargs):
     ignored.
 
     This function returns the polygons within a GeometryCollection.
-    Individual Polygons can be obtained using `get_geometry` to get
-    a single polygon or `get_parts` to get an array of polygons.
+    Individual Polygons can be obtained using ``get_geometry`` to get
+    a single polygon or ``get_parts`` to get an array of polygons.
     MultiPolygons can be constructed from the output using
     ``pygeos.multipolygons(pygeos.get_parts(pygeos.polygonize(geometries)))``.
 
@@ -588,7 +588,7 @@ def polygonize_full(geometries, **kwargs):
     provided as input; only the constituent lines and rings will be used to
     create the output polygons.
 
-    This function performs the same polygonization as `polygonize` but does
+    This function performs the same polygonization as ``polygonize`` but does
     not only return the polygonal result but all extra outputs as well. The
     return value consists of 4 elements:
 
@@ -598,8 +598,8 @@ def polygonize_full(geometries, **kwargs):
     * **invalid rings**: polygons formed but which are not valid
 
     This function returns the geometries within GeometryCollections.
-    Individual geometries can be obtained using `get_geometry` to get
-    a single geometry or `get_parts` to get an array of geometries.
+    Individual geometries can be obtained using ``get_geometry`` to get
+    a single geometry or ``get_parts`` to get an array of geometries.
 
     Parameters
     ----------

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -858,47 +858,7 @@ def oriented_envelope(geometry, **kwargs):
     return lib.oriented_envelope(geometry, **kwargs)
 
 
-@requires_geos("3.6.0")
-@multithreading_enabled
-def minimum_rotated_rectangle(geometry, **kwargs):
-    """
-    Computes the oriented envelope (minimum rotated rectangle)
-    that encloses an input geometry.
-
-    Unlike envelope this rectangle is not constrained to be parallel to the
-    coordinate axes. If the convex hull of the object is a degenerate (line
-    or point) this degenerate is returned.
-
-    An alias for ``oriented_envelope``.
-
-    Parameters
-    ----------
-    geometry : Geometry or array_like
-    **kwargs
-        For other keyword-only arguments, see the
-        `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
-
-    Examples
-    --------
-    >>> minimum_rotated_rectangle(Geometry("MULTIPOINT (0 0, 10 0, 10 10)"))
-    <pygeos.Geometry POLYGON ((0 0, 5 -5, 15 5, 10 10, 0 0))>
-    >>> minimum_rotated_rectangle(Geometry("LINESTRING (1 1, 5 1, 10 10)"))
-    <pygeos.Geometry POLYGON ((1 1, 3 -1, 12 8, 10 10, 1 1))>
-    >>> minimum_rotated_rectangle(Geometry("POLYGON ((1 1, 15 1, 5 10, 1 1))"))
-    <pygeos.Geometry POLYGON ((15 1, 15 10, 1 10, 1 1, 15 1))>
-    >>> minimum_rotated_rectangle(Geometry("LINESTRING (1 1, 10 1)"))
-    <pygeos.Geometry LINESTRING (1 1, 10 1)>
-    >>> minimum_rotated_rectangle(Geometry("POINT (2 2)"))
-    <pygeos.Geometry POINT (2 2)>
-    >>> minimum_rotated_rectangle(Geometry("GEOMETRYCOLLECTION EMPTY"))
-    <pygeos.Geometry POLYGON EMPTY>
-
-    See also
-    --------
-    oriented_envelope
-    """
-    return lib.oriented_envelope(geometry, **kwargs)
-
+minimum_rotated_rectangle = oriented_envelope
 
 @requires_geos("3.8.0")
 @multithreading_enabled

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -860,6 +860,7 @@ def oriented_envelope(geometry, **kwargs):
 
 minimum_rotated_rectangle = oriented_envelope
 
+
 @requires_geos("3.8.0")
 @multithreading_enabled
 def minimum_bounding_circle(geometry, **kwargs):

--- a/pygeos/coordinates.py
+++ b/pygeos/coordinates.py
@@ -21,7 +21,7 @@ def apply(geometry, transformation, include_z=False):
     transformation : function
         A function that transforms a (N, 2) or (N, 3) ndarray of float64 to
         another (N, 2) or (N, 3) ndarray of float64.
-    include_z : bool, default False
+    include_z : bool
         If True, include the third dimension in the coordinates array
         that is passed to the `transformation` function. If a
         geometry has no third dimension, the z-coordinates passed to the
@@ -100,10 +100,10 @@ def get_coordinates(geometry, include_z=False, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
-    include_z : bool, default False
+    include_z : bool
         If, True include the third dimension in the output. If a geometry
         has no third dimension, the z-coordinates will be NaN.
-    return_index : bool, default False
+    return_index : bool
         If True, also return the index of each returned geometry as a separate
         ndarray of integers. For multidimensional arrays, this indexes into the
         flattened array (in C contiguous order).

--- a/pygeos/coordinates.py
+++ b/pygeos/coordinates.py
@@ -21,7 +21,7 @@ def apply(geometry, transformation, include_z=False):
     transformation : function
         A function that transforms a (N, 2) or (N, 3) ndarray of float64 to
         another (N, 2) or (N, 3) ndarray of float64.
-    include_z : bool
+    include_z : bool, default False
         If True, include the third dimension in the coordinates array
         that is passed to the ``transformation`` function. If a
         geometry has no third dimension, the z-coordinates passed to the
@@ -100,10 +100,10 @@ def get_coordinates(geometry, include_z=False, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
-    include_z : bool
+    include_z : bool, default False
         If, True include the third dimension in the output. If a geometry
         has no third dimension, the z-coordinates will be NaN.
-    return_index : bool
+    return_index : bool, default False
         If True, also return the index of each returned geometry as a separate
         ndarray of integers. For multidimensional arrays, this indexes into the
         flattened array (in C contiguous order).

--- a/pygeos/coordinates.py
+++ b/pygeos/coordinates.py
@@ -23,7 +23,7 @@ def apply(geometry, transformation, include_z=False):
         another (N, 2) or (N, 3) ndarray of float64.
     include_z : bool
         If True, include the third dimension in the coordinates array
-        that is passed to the `transformation` function. If a
+        that is passed to the ``transformation`` function. If a
         geometry has no third dimension, the z-coordinates passed to the
         function will be NaN.
 
@@ -93,8 +93,8 @@ def get_coordinates(geometry, include_z=False, return_index=False):
     """Gets coordinates from a geometry array as an array of floats.
 
     The shape of the returned array is (N, 2), with N being the number of
-    coordinate pairs. With the default of `include_z=False`, three-dimensional
-    data is ignored. When specifying `include_z=True`, the shape of the
+    coordinate pairs. With the default of ``include_z=False``, three-dimensional
+    data is ignored. When specifying ``include_z=True``, the shape of the
     returned array is (N, 3).
 
     Parameters

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -152,69 +152,69 @@ def linearrings(coords, y=None, z=None, indices=None, **kwargs):
 @multithreading_enabled
 def polygons(geometries, holes=None, indices=None, **kwargs):
     """Create an array of polygons.
-    and the holes; the first geometry for each index is the outer shell and all subsequent geometries in that index are the holes...
-        Parameters
-        ----------
-        geometries : array_like
-            An array of linearrings or coordinates (see linearrings).
-            Unless ``indices`` are given (see description below), this
-            include the outer shells only. The ``holes`` argument should be used
-            to create polygons with holes.
-        holes : array_like or None
-            An array of lists of linearrings that constitute holes for each shell.
-            Not to be used in combination with ``indices``.
-        indices : array_like or None
-            Indices into the target array where input geometries belong. If
-            provided, the holes are expected to be present inside ``geometries``;
-            the first geometry for each index is the outer shell
-            and all subsequent geometries in that index are the holes.
-            Both geometries and indices should be 1D and have matching sizes.
-            Indices should be in increasing order. Missing indices will result
-            in a ValueError.
-        **kwargs
-            For other keyword-only arguments, see the
-            `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
-            Ignored if ``indices`` is provided.
 
-        Examples
-        --------
-        Polygons are constructed from rings:
+    Parameters
+    ----------
+    geometries : array_like
+        An array of linearrings or coordinates (see linearrings).
+        Unless ``indices`` are given (see description below), this
+        include the outer shells only. The ``holes`` argument should be used
+        to create polygons with holes.
+    holes : array_like or None
+        An array of lists of linearrings that constitute holes for each shell.
+        Not to be used in combination with ``indices``.
+    indices : array_like or None
+        Indices into the target array where input geometries belong. If
+        provided, the holes are expected to be present inside ``geometries``;
+        the first geometry for each index is the outer shell
+        and all subsequent geometries in that index are the holes.
+        Both geometries and indices should be 1D and have matching sizes.
+        Indices should be in increasing order. Missing indices will result
+        in a ValueError.
+    **kwargs
+        For other keyword-only arguments, see the
+        `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+        Ignored if ``indices`` is provided.
 
-        >>> ring_1 = linearrings([[0, 0], [0, 10], [10, 10], [10, 0]])
-        >>> ring_2 = linearrings([[2, 6], [2, 7], [3, 7], [3, 6]])
-        >>> polygons([ring_1, ring_2])[0]
-        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
-        >>> polygons([ring_1, ring_2])[1]
-        <pygeos.Geometry POLYGON ((2 6, 2 7, 3 7, 3 6, 2 6))>
+    Examples
+    --------
+    Polygons are constructed from rings:
 
-        Or from coordinates directly:
+    >>> ring_1 = linearrings([[0, 0], [0, 10], [10, 10], [10, 0]])
+    >>> ring_2 = linearrings([[2, 6], [2, 7], [3, 7], [3, 6]])
+    >>> polygons([ring_1, ring_2])[0]
+    <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+    >>> polygons([ring_1, ring_2])[1]
+    <pygeos.Geometry POLYGON ((2 6, 2 7, 3 7, 3 6, 2 6))>
 
-        >>> polygons([[0, 0], [0, 10], [10, 10], [10, 0]])
-        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+    Or from coordinates directly:
 
-        Adding holes can be done using the `holes` keyword argument:
+    >>> polygons([[0, 0], [0, 10], [10, 10], [10, 0]])
+    <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
 
-        >>> polygons(ring_1, holes=[ring_2])
-        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
+    Adding holes can be done using the `holes` keyword argument:
 
-        Or using the `indices` argument:
+    >>> polygons(ring_1, holes=[ring_2])
+    <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
 
-        >>> polygons([ring_1, ring_2], indices=[0, 1])[0]
-        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
-        >>> polygons([ring_1, ring_2], indices=[0, 1])[1]
-        <pygeos.Geometry POLYGON ((2 6, 2 7, 3 7, 3 6, 2 6))>
-        >>> polygons([ring_1, ring_2], indices=[0, 0])[0]
-        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
+    Or using the `indices` argument:
 
-        Missing input values (`None`) are ignored and may result in an
-        empty polygon:
+    >>> polygons([ring_1, ring_2], indices=[0, 1])[0]
+    <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+    >>> polygons([ring_1, ring_2], indices=[0, 1])[1]
+    <pygeos.Geometry POLYGON ((2 6, 2 7, 3 7, 3 6, 2 6))>
+    >>> polygons([ring_1, ring_2], indices=[0, 0])[0]
+    <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
 
-        >>> polygons(None)
-        <pygeos.Geometry POLYGON EMPTY>
-        >>> polygons(ring_1, holes=[None])
-        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
-        >>> polygons([ring_1, None], indices=[0, 0])[0]
-        <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+    Missing input values (`None`) are ignored and may result in an
+    empty polygon:
+
+    >>> polygons(None)
+    <pygeos.Geometry POLYGON EMPTY>
+    >>> polygons(ring_1, holes=[None])
+    <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
+    >>> polygons([ring_1, None], indices=[0, 0])[0]
+    <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
     """
     geometries = np.asarray(geometries)
     if not isinstance(geometries, Geometry) and np.issubdtype(
@@ -250,7 +250,7 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
     ymin : array_like
     xmax : array_like
     ymax : array_like
-    ccw : bool (default: True)
+    ccw : bool
         If True, box will be created in counterclockwise direction starting
         from bottom right coordinate (xmax, ymin).
         If False, box will be created in clockwise direction starting from

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -39,7 +39,7 @@ def points(coords, y=None, z=None, indices=None, **kwargs):
     Parameters
     ----------
     coords : array_like
-        An array of coordinate tuples (2- or 3-dimensional) or, if `y` is
+        An array of coordinate tuples (2- or 3-dimensional) or, if ``y`` is
         provided, an array of x coordinates.
     y : array_like
     z : array_like
@@ -77,7 +77,7 @@ def linestrings(coords, y=None, z=None, indices=None, **kwargs):
     Parameters
     ----------
     coords : array_like
-        An array of lists of coordinate tuples (2- or 3-dimensional) or, if `y`
+        An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
         is provided, an array of lists of x coordinates
     y : array_like
     z : array_like
@@ -117,7 +117,7 @@ def linearrings(coords, y=None, z=None, indices=None, **kwargs):
     Parameters
     ----------
     coords : array_like
-        An array of lists of coordinate tuples (2- or 3-dimensional) or, if `y`
+        An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
         is provided, an array of lists of x coordinates
     y : array_like
     z : array_like
@@ -192,12 +192,12 @@ def polygons(geometries, holes=None, indices=None, **kwargs):
     >>> polygons([[0, 0], [0, 10], [10, 10], [10, 0]])
     <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
 
-    Adding holes can be done using the `holes` keyword argument:
+    Adding holes can be done using the ``holes`` keyword argument:
 
     >>> polygons(ring_1, holes=[ring_2])
     <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
 
-    Or using the `indices` argument:
+    Or using the ``indices`` argument:
 
     >>> polygons([ring_1, ring_2], indices=[0, 1])[0]
     <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
@@ -206,7 +206,7 @@ def polygons(geometries, holes=None, indices=None, **kwargs):
     >>> polygons([ring_1, ring_2], indices=[0, 0])[0]
     <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0), (2 6, 2 7, 3 7, 3 6...>
 
-    Missing input values (`None`) are ignored and may result in an
+    Missing input values (``None``) are ignored and may result in an
     empty polygon:
 
     >>> polygons(None)
@@ -305,12 +305,12 @@ def multipoints(geometries, indices=None, **kwargs):
     <pygeos.Geometry MULTIPOINT (0 0, 2 2, 3 3)>
 
     Multiple multipoints of different sizes can be constructed efficiently using the
-    `indices` keyword argument:
+    ``indices`` keyword argument:
 
     >>> multipoints([point_1, point_2, point_2], indices=[0, 0, 1]).tolist()
     [<pygeos.Geometry MULTIPOINT (1 1, 2 2)>, <pygeos.Geometry MULTIPOINT (2 2)>]
 
-    Missing input values (`None`) are ignored and may result in an
+    Missing input values (``None``) are ignored and may result in an
     empty multipoint:
 
     >>> multipoints([None])

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -41,9 +41,9 @@ def points(coords, y=None, z=None, indices=None, **kwargs):
     coords : array_like
         An array of coordinate tuples (2- or 3-dimensional) or, if ``y`` is
         provided, an array of x coordinates.
-    y : array_like
-    z : array_like
-    indices : array_like or None
+    y : array_like, optional
+    z : array_like, optional
+    indices : array_like, optional
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
         indices should be an array of shape (N,) with integers in increasing
@@ -79,9 +79,9 @@ def linestrings(coords, y=None, z=None, indices=None, **kwargs):
     coords : array_like
         An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
         is provided, an array of lists of x coordinates
-    y : array_like
-    z : array_like
-    indices : array_like or None
+    y : array_like, optional
+    z : array_like, optional
+    indices : array_like, optional
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
         indices should be an array of shape (N,) with integers in increasing
@@ -119,9 +119,9 @@ def linearrings(coords, y=None, z=None, indices=None, **kwargs):
     coords : array_like
         An array of lists of coordinate tuples (2- or 3-dimensional) or, if ``y``
         is provided, an array of lists of x coordinates
-    y : array_like
-    z : array_like
-    indices : array_like or None
+    y : array_like, optional
+    z : array_like, optional
+    indices : array_like, optional
         Indices into the target array where input coordinates belong. If
         provided, the coords should be 2D with shape (N, 2) or (N, 3) and
         indices should be an array of shape (N,) with integers in increasing
@@ -160,10 +160,10 @@ def polygons(geometries, holes=None, indices=None, **kwargs):
         Unless ``indices`` are given (see description below), this
         include the outer shells only. The ``holes`` argument should be used
         to create polygons with holes.
-    holes : array_like or None
+    holes : array_like, optional
         An array of lists of linearrings that constitute holes for each shell.
         Not to be used in combination with ``indices``.
-    indices : array_like or None
+    indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, the holes are expected to be present inside ``geometries``;
         the first geometry for each index is the outer shell
@@ -250,7 +250,7 @@ def box(xmin, ymin, xmax, ymax, ccw=True, **kwargs):
     ymin : array_like
     xmax : array_like
     ymax : array_like
-    ccw : bool
+    ccw : bool, default True
         If True, box will be created in counterclockwise direction starting
         from bottom right coordinate (xmax, ymin).
         If False, box will be created in clockwise direction starting from
@@ -278,7 +278,7 @@ def multipoints(geometries, indices=None, **kwargs):
     ----------
     geometries : array_like
         An array of points or coordinates (see points).
-    indices : array_like or None
+    indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes. Indices should be in increasing order. Missing indices will result
@@ -340,7 +340,7 @@ def multilinestrings(geometries, indices=None, **kwargs):
     ----------
     geometries : array_like
         An array of linestrings or coordinates (see linestrings).
-    indices : array_like or None
+    indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes. Indices should be in increasing order. Missing indices will result
@@ -375,7 +375,7 @@ def multipolygons(geometries, indices=None, **kwargs):
     ----------
     geometries : array_like
         An array of polygons or coordinates (see polygons).
-    indices : array_like or None
+    indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes. Indices should be in increasing order. Missing indices will result
@@ -409,7 +409,7 @@ def geometrycollections(geometries, indices=None, **kwargs):
     ----------
     geometries : array_like
         An array of geometries
-    indices : array_like or None
+    indices : array_like, optional
         Indices into the target array where input geometries belong. If
         provided, both geometries and indices should be 1D and have matching
         sizes. Indices should be in increasing order. Missing indices will result

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -525,7 +525,7 @@ def get_parts(geometry, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
-    return_index : bool, optional
+    return_index : bool, default False
         If True, will return a tuple of ndarrays of (parts, indexes), where indexes
         are the indexes of the original geometries in the source array.
 
@@ -571,7 +571,7 @@ def get_rings(geometry, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
-    return_index : bool, optional
+    return_index : bool, default False
         If True, will return a tuple of ndarrays of (rings, indexes), where
         indexes are the indexes of the original geometries in the source array.
 
@@ -711,7 +711,7 @@ def set_precision(geometry, grid_size, preserve_topology=False, **kwargs):
         geometry if precision grid size was not previously set). If this
         value is more precise than input geometry, the input geometry will
         not be modified.
-    preserve_topology : bool, optional
+    preserve_topology : bool, default False
         If True, will attempt to preserve the topology of a geometry after
         rounding coordinates.
     **kwargs

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -525,7 +525,7 @@ def get_parts(geometry, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
-    return_index : bool, optional (default: False)
+    return_index : bool, optional
         If True, will return a tuple of ndarrays of (parts, indexes), where indexes
         are the indexes of the original geometries in the source array.
 
@@ -571,7 +571,7 @@ def get_rings(geometry, return_index=False):
     Parameters
     ----------
     geometry : Geometry or array_like
-    return_index : bool, optional (default: False)
+    return_index : bool, optional
         If True, will return a tuple of ndarrays of (rings, indexes), where
         indexes are the indexes of the original geometries in the source array.
 
@@ -711,7 +711,7 @@ def set_precision(geometry, grid_size, preserve_topology=False, **kwargs):
         geometry if precision grid size was not previously set). If this
         value is more precise than input geometry, the input geometry will
         not be modified.
-    preserve_topology : bool, optional (default: False)
+    preserve_topology : bool, optional
         If True, will attempt to preserve the topology of a geometry after
         rounding coordinates.
     **kwargs

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -102,16 +102,16 @@ def to_wkt(
     Parameters
     ----------
     geometry : Geometry or array_like
-    rounding_precision : int, default 6
+    rounding_precision : int
         The rounding precision when writing the WKT string. Set to a value of
         -1 to indicate the full precision.
-    trim : bool, default True
+    trim : bool
         If True, trim unnecessary decimals (trailing zeros).
-    output_dimension : int, default 3
+    output_dimension : int
         The output dimension for the WKT string. Supported values are 2 and 3.
         Specifying 3 means that up to 3 dimensions will be written but 2D
         geometries will still be represented as 2D in the WKT string.
-    old_3d : bool, default False
+    old_3d : bool
         Enable old style 3D/4D WKT generation. By default, new style 3D/4D WKT
         (ie. "POINT Z (10 20 30)") is returned, but with ``old_3d=True``
         the WKT will be formatted in the style "POINT (10 20 30)".
@@ -180,17 +180,17 @@ def to_wkb(
     Parameters
     ----------
     geometry : Geometry or array_like
-    hex : bool, default False
+    hex : bool
         If true, export the WKB as a hexidecimal string. The default is to
         return a binary bytes object.
-    output_dimension : int, default 3
+    output_dimension : int
         The output dimension for the WKB. Supported values are 2 and 3.
         Specifying 3 means that up to 3 dimensions will be written but 2D
         geometries will still be represented as 2D in the WKB represenation.
     byte_order : int
         Defaults to native machine byte order (-1). Use 0 to force big endian
         and 1 for little endian.
-    include_srid : bool, default False
+    include_srid : bool
         If True, the SRID is be included in WKB (this is an extension
         to the OGC WKB specification).
     **kwargs

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -282,8 +282,8 @@ def from_wkt(geometry, on_invalid="raise", **kwargs):
     on_invalid : {"raise", "warn", "ignore"}
         - raise: an exception will be raised if WKT input geometries are invalid.
         - warn: a warning will be raised and invalid WKT geometries will be
-          returned as `None`.
-        - ignore: invalid WKT geometries will be returned as `None` without a warning.
+          returned as ``None``.
+        - ignore: invalid WKT geometries will be returned as ``None`` without a warning.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
@@ -316,8 +316,8 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     on_invalid : {"raise", "warn", "ignore"}
         - raise: an exception will be raised if WKB input geometries are invalid.
         - warn: a warning will be raised and invalid WKB geometries will be
-          returned as `None`.
-        - ignore: invalid WKB geometries will be returned as `None` without a warning.
+          returned as ``None``.
+        - ignore: invalid WKB geometries will be returned as ``None`` without a warning.
     **kwargs
         For other keyword-only arguments, see the
         `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -102,16 +102,16 @@ def to_wkt(
     Parameters
     ----------
     geometry : Geometry or array_like
-    rounding_precision : int
+    rounding_precision : int, default 6
         The rounding precision when writing the WKT string. Set to a value of
         -1 to indicate the full precision.
-    trim : bool
+    trim : bool, default True
         If True, trim unnecessary decimals (trailing zeros).
-    output_dimension : int
+    output_dimension : int, default 3
         The output dimension for the WKT string. Supported values are 2 and 3.
         Specifying 3 means that up to 3 dimensions will be written but 2D
         geometries will still be represented as 2D in the WKT string.
-    old_3d : bool
+    old_3d : bool, default False
         Enable old style 3D/4D WKT generation. By default, new style 3D/4D WKT
         (ie. "POINT Z (10 20 30)") is returned, but with ``old_3d=True``
         the WKT will be formatted in the style "POINT (10 20 30)".
@@ -180,17 +180,17 @@ def to_wkb(
     Parameters
     ----------
     geometry : Geometry or array_like
-    hex : bool
+    hex : bool, default False
         If true, export the WKB as a hexidecimal string. The default is to
         return a binary bytes object.
-    output_dimension : int
+    output_dimension : int, default 3
         The output dimension for the WKB. Supported values are 2 and 3.
         Specifying 3 means that up to 3 dimensions will be written but 2D
         geometries will still be represented as 2D in the WKB represenation.
-    byte_order : int
+    byte_order : int, default -1
         Defaults to native machine byte order (-1). Use 0 to force big endian
         and 1 for little endian.
-    include_srid : bool
+    include_srid : bool, default False
         If True, the SRID is be included in WKB (this is an extension
         to the OGC WKB specification).
     **kwargs
@@ -279,7 +279,7 @@ def from_wkt(geometry, on_invalid="raise", **kwargs):
     ----------
     geometry : str or array_like
         The WKT string(s) to convert.
-    on_invalid : {"raise", "warn", "ignore"}
+    on_invalid : {"raise", "warn", "ignore"}, default "raise"
         - raise: an exception will be raised if WKT input geometries are invalid.
         - warn: a warning will be raised and invalid WKT geometries will be
           returned as ``None``.
@@ -313,7 +313,7 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     ----------
     geometry : str or array_like
         The WKB byte object(s) to convert.
-    on_invalid : {"raise", "warn", "ignore"}
+    on_invalid : {"raise", "warn", "ignore"}, default "raise"
         - raise: an exception will be raised if WKB input geometries are invalid.
         - warn: a warning will be raised and invalid WKB geometries will be
           returned as ``None``.

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -20,7 +20,7 @@ def line_interpolate_point(line, distance, normalized=False, **kwargs):
     distance : float or array_like
         Negative values measure distance from the end of the line. Out-of-range
         values will be clipped to the line endings.
-    normalized : bool
+    normalized : bool, default False
         If True, the distance is a fraction of the total
         line length instead of the absolute distance.
     **kwargs
@@ -61,7 +61,7 @@ def line_locate_point(line, other, normalized=False, **kwargs):
     ----------
     line : Geometry or array_like
     point : Geometry or array_like
-    normalized : bool
+    normalized : bool, default False
         If True, the distance is a fraction of the total
         line length instead of the absolute distance.
     **kwargs

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -183,7 +183,7 @@ def hausdorff_distance(a, b, densify=None, **kwargs):
     Parameters
     ----------
     a, b : Geometry or array_like
-    densify : float, array_like or None
+    densify : float or array_like, optional
         The value of densify is required to be between 0 and 1.
     **kwargs
         For other keyword-only arguments, see the
@@ -226,7 +226,7 @@ def frechet_distance(a, b, densify=None, **kwargs):
     Parameters
     ----------
     a, b : Geometry or array_like
-    densify : float, array_like or None
+    densify : float or array_like, optional
         The value of densify is required to be between 0 and 1.
     **kwargs
         For other keyword-only arguments, see the

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -464,7 +464,7 @@ def contains(a, b, **kwargs):
     point of the interior of B lies in the interior of A.
 
     Note: following this definition, a geometry does not contain its boundary,
-    but it does contain itself. See `contains_properly` for a version where
+    but it does contain itself. See ``contains_properly`` for a version where
     a geometry does not contain itself.
 
     Parameters
@@ -516,7 +516,7 @@ def contains_properly(a, b, **kwargs):
 
     A contains B properly if B intersects the interior of A but not the
     boundary (or exterior). This means that a geometry A does not
-    "contain properly" itself, which contrasts with the `contains` function,
+    "contain properly" itself, which contrasts with the ``contains`` function,
     where common points on the boundary are allowed.
 
     Note: this function will prepare the geometries under the hood if needed.
@@ -902,7 +902,7 @@ def equals_exact(a, b, tolerance=0.0, **kwargs):
 
     This method uses exact coordinate equality, which requires coordinates
     to be equal (within specified tolerance) and and in the same order for all
-    components of a geometry. This is in contrast with the `equals` function
+    components of a geometry. This is in contrast with the ``equals`` function
     which uses spatial (topological) equality.
 
     Parameters
@@ -972,7 +972,7 @@ def relate_pattern(a, b, pattern, **kwargs):
     ``True`` is returned, otherwise ``False``. The pattern specified can
     be an exact match (``0``, ``1`` or ``2``), a boolean match
     (uppercase ``T`` or ``F``), or a wildcard (``*``). For example,
-    the pattern for the `within` predicate is ``'T*F**F***'``.
+    the pattern for the ``within`` predicate is ``'T*F**F***'``.
 
     Parameters
     ----------

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -33,7 +33,7 @@ def difference(a, b, grid_size=None, **kwargs):
     ----------
     a : Geometry or array_like
     b : Geometry or array_like
-    grid_size : float, optional (default: None).
+    grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
@@ -90,7 +90,7 @@ def intersection(a, b, grid_size=None, **kwargs):
     ----------
     a : Geometry or array_like
     b : Geometry or array_like
-    grid_size : float, optional (default: None).
+    grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
@@ -139,7 +139,7 @@ def intersection_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int (default None)
+    axis : int
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
         Axis may be negative, in which case it counts from the last to the
@@ -180,7 +180,7 @@ def symmetric_difference(a, b, grid_size=None, **kwargs):
     ----------
     a : Geometry or array_like
     b : Geometry or array_like
-    grid_size : float, optional (default: None).
+    grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
@@ -229,7 +229,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int (default None)
+    axis : int
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
         Axis may be negative, in which case it counts from the last to the
@@ -269,7 +269,7 @@ def union(a, b, grid_size=None, **kwargs):
     ----------
     a : Geometry or array_like
     b : Geometry or array_like
-    grid_size : float, optional (default: None).
+    grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
     **kwargs
@@ -327,10 +327,10 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    grid_size : float, optional (default: None).
+    grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
-    axis : int (default None)
+    axis : int
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
         Axis may be negative, in which case it counts from the last to the

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -139,7 +139,7 @@ def intersection_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int
+    axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
         Axis may be negative, in which case it counts from the last to the
@@ -229,7 +229,7 @@ def symmetric_difference_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int
+    axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
         Axis may be negative, in which case it counts from the last to the
@@ -330,7 +330,7 @@ def union_all(geometries, grid_size=None, axis=None, **kwargs):
     grid_size : float, optional
         Precision grid size; requires GEOS >= 3.9.0.  Will use the highest
         precision of the inputs by default.
-    axis : int
+    axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
         Axis may be negative, in which case it counts from the last to the
@@ -438,7 +438,7 @@ def coverage_union_all(geometries, axis=None, **kwargs):
     Parameters
     ----------
     geometries : array_like
-    axis : int (default None)
+    axis : int, optional
         Axis along which the operation is performed. The default (None)
         performs the operation over all axes, returning a scalar value.
         Axis may be negative, in which case it counts from the last to the

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -35,7 +35,7 @@ class STRtree:
     Parameters
     ----------
     geometries : array_like
-    leafsize : int
+    leafsize : int, default 10
         the maximum number of child nodes that a node can have
 
     Examples
@@ -252,7 +252,7 @@ class STRtree:
         max_distance : float, optional
             Maximum distance within which to query for nearest items in tree.
             Must be greater than 0.
-        return_distance : bool, optional
+        return_distance : bool, default False
             If True, will return distances in addition to indexes.
 
         Returns

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -48,7 +48,7 @@ class STRtree:
     >>> # Query geometries that are contained by input geometry:
     >>> tree.query(pygeos.box(2, 2, 4, 4), predicate='contains').tolist()
     [3]
-    >>> # Query geometries that overlap envelopes of `geoms`
+    >>> # Query geometries that overlap envelopes of ``geoms``
     >>> tree.query_bulk([pygeos.box(2, 2, 4, 4), pygeos.box(5, 5, 6, 6)]).tolist()
     [[0, 0, 0, 1, 1], [2, 3, 4, 5, 6]]
     >>> tree.nearest([pygeos.points(1,1), pygeos.points(3,5)]).tolist()  # doctest: +SKIP

--- a/pygeos/strtree.py
+++ b/pygeos/strtree.py
@@ -249,10 +249,10 @@ class STRtree:
         ----------
         geometry : Geometry or array_like
             Input geometries to query the tree.
-        max_distance : float, optional (default: None)
+        max_distance : float, optional
             Maximum distance within which to query for nearest items in tree.
             Must be greater than 0.
-        return_distance : bool, optional (default: False)
+        return_distance : bool, optional
             If True, will return distances in addition to indexes.
 
         Returns


### PR DESCRIPTION
In #314 we decided to add `minimum_rotated_rectangle` as an alias for `oriented_envelope`. Now this is implemented as a duplicate (with duplicate docstrings & code).

I think it is better to not have "two things to do something". We do not have to consider legacy so there is no reason for having the duplicate there.

So instead I do `minimum_rotated_rectangle = oriented_envelope`, and hide the duplicate docstring.

Also it is not necessary (and we currently do it wrong) to show the `default` in the docstring under numpydoc convention. From https://numpydoc.readthedocs.io/en/latest/format.html#parameters: 

> Optional keyword parameters have default values, which are displayed as part of the function signature. They can also be detailed in the description: (...) or as part of the type, instead of optional. 