### PR TITLE
Exclude Cythonized .c files from distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ include src/*
 include pygeos/*.pyx pygeos/*.pxd
 include versioneer.py
 include pygeos/_version.py
-include pygeos/*.dll
 include LICENSE
 include pyproject.toml
 exclude pygeos/*.c

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ include pygeos/_version.py
 include pygeos/*.dll
 include LICENSE
 include pyproject.toml
+exclude pygeos/*.c
 exclude MANIFEST.in

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include src/*
 include pygeos/*.pyx pygeos/*.pxd
 include versioneer.py
 include pygeos/_version.py
+include pygeos/*.dll
 include LICENSE
 include pyproject.toml
 exclude pygeos/*.c


### PR DESCRIPTION
Fixes #284 

The cythonized .c files should not be included in a source distribution.