### PR TITLE
TST: rename head branch for GEOS from 'master' to 'main'

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -28,7 +28,7 @@ jobs:
             numpy: 1.19.5
           # dev
           - python: 3.9
-            geos: master
+            geos: main
 
     env:
       GEOS_VERSION: ${{ matrix.geos }}
@@ -61,7 +61,7 @@ jobs:
         run: |
           pip install --disable-pip-version-check --upgrade pip
           pip install --upgrade wheel
-          if [ "$GEOS_VERSION" = "master" ]; then
+          if [ "$GEOS_VERSION" = "main" ]; then
             pip install --upgrade --pre Cython numpy pytest;
           else
             pip install --upgrade Cython numpy==${{ matrix.numpy }} pytest;
@@ -82,6 +82,6 @@ jobs:
 
       - name: Run tests
         shell: bash
-        continue-on-error: ${{ matrix.geos == 'master' }}
+        continue-on-error: ${{ matrix.geos == 'main' }}
         run: |
           pytest pygeos

--- a/ci/install_geos.sh
+++ b/ci/install_geos.sh
@@ -4,7 +4,7 @@
 #
 # This script requires environment variables to be set
 #  - export GEOS_INSTALL=/path/to/cached/prefix -- to build or use as cache
-#  - export GEOS_VERSION=3.7.3 or master -- to download and compile
+#  - export GEOS_VERSION=3.7.3 or main -- to download and compile
 
 set -e
 
@@ -38,11 +38,12 @@ build_geos(){
     make install
 }
 
-if [ "$GEOS_VERSION" = "master" ]; then
+if [ "$GEOS_VERSION" = "main" ]; then
     prepare_geos_build_dir
     # use GitHub mirror
     git clone --depth 1 https://github.com/libgeos/geos.git geos-$GEOS_VERSION
     cd geos-$GEOS_VERSION
+    git log -1
     git rev-parse HEAD > newrev.txt
     BUILD=no
     # Only build if nothing cached or if the GEOS revision changed


### PR DESCRIPTION
GEOS renamed their git development head branch from 'master' to 'main' in March 2021 ([ref](https://lists.osgeo.org/pipermail/geos-devel/2021-March/010193.html)).