### PR TITLE
Release workflow: automate sdist creation / GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release and publish pygeos to GitHub
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-n-publish:
+    name: Build and publish pygeos to GitHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Build a source tarball
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
+          python setup.py sdist
+
+      # - name: Publish distribution to PyPI
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Get Asset name
+        run: |
+          export PKG=$(ls dist/ | grep tar)
+          set -- $PKG
+          echo "name=$1" >> $GITHUB_ENV
+
+      - name: Upload Release Asset (sdist) to GitHub
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/${{ env.name }}
+          asset_name: ${{ env.name }}
+          asset_content_type: application/zip


### PR DESCRIPTION
@caspervdw what do you think of this?

We have been happily using this for GeoPandas and some related packages (https://github.com/geopandas/geopandas/blob/master/.github/workflows/release_to_pypi.yml). 
Of course, here the scope is more limited (I didn't include releasing to PyPI, as for that ideally you directly upload both sdist and wheels), making this less useful. But automating the sdist creation, and uploading it to a new GitHub release still could be useful,I think (not fully sure, the sdist creation is also not a lot of work, you only need to be careful about not including eg cythonized files, which is safer on a new checkout in the github action). 

The workflow would then be: 1) tag locally and push the tag (as before), 2) let the action run and create the github release, 3) update the github release notes 4) build wheels and upload those together with sdist to PyPI (same as before).