### PR TITLE
FIX: Handle NULL in object-dtype arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Version 0.11 (unreleased)
 
 **Bug fixes**
 
+* Fixed operations on geometry arrays containing NULL instead of None.
+  These occur for instance by using ``numpy.empty_like`` (#371)
+
 **Acknowledgements**
 
 Thanks to everyone who contributed to this release!

--- a/pygeos/test/test_geometry.py
+++ b/pygeos/test/test_geometry.py
@@ -268,11 +268,16 @@ def test_set_nan_same_objects():
         empty_line_string,
         empty_polygon,
         empty_geometry_collection,
+        np.array([None]),
+        np.empty_like(np.array([None])),
     ],
 )
 def test_get_parts(geom):
     expected_num_parts = pygeos.get_num_geometries(geom)
-    expected_parts = pygeos.get_geometry(geom, range(0, expected_num_parts))
+    if expected_num_parts == 0:
+        expected_parts = []
+    else:
+        expected_parts = pygeos.get_geometry(geom, range(0, expected_num_parts))
 
     parts = pygeos.get_parts(geom)
     assert len(parts) == expected_num_parts
@@ -549,3 +554,9 @@ def test_set_precision_intersection():
     out = pygeos.intersection(box1, box2)
     assert pygeos.get_precision(out) == 0.5
     assert pygeos.equals(out, pygeos.Geometry("LINESTRING (1 1, 1 0)"))
+
+
+def test_empty():
+    """Compatibility with empty_like, see GH373"""
+    g = np.empty_like(np.array([None, None]))
+    assert pygeos.is_missing(g).all()

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -424,14 +424,14 @@ int __Pyx_InBases(PyTypeObject* a, PyTypeObject* b) {
 /* Get a GEOSGeometry pointer from a GeometryObject, or NULL if the input is
 Py_None. Returns 0 on error, 1 on success. */
 char get_geom(GeometryObject* obj, GEOSGeometry** out) {
+  // Numpy treats NULL the same as Py_None
+  if ((obj == NULL) || ((PyObject*)obj == Py_None)) {
+    *out = NULL;
+    return 1;
+  }
   PyTypeObject* type = ((PyObject*)obj)->ob_type;
   if ((type != &GeometryType) && !(__Pyx_InBases(type, &GeometryType))) {
-    if ((PyObject*)obj == Py_None) {
-      *out = NULL;
-      return 1;
-    } else {
-      return 0;
-    }
+    return 0;
   } else {
     *out = obj->ptr;
     return 1;


### PR DESCRIPTION
Closes #373 

Apparently, Numpy treats NULL the same as None in object-dtype arrays.