### PR TITLE
Handle linearrings in is_closed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Version 0.11 (unreleased)
 
 **Bug fixes**
 
-* ...
+* Return True instead of False for LINEARRING geometries in ``is_closed`` (#379).
 
 **Acknowledgments**
 

--- a/pygeos/tests/test_predicates.py
+++ b/pygeos/tests/test_predicates.py
@@ -4,7 +4,15 @@ import pytest
 import pygeos
 from pygeos import Geometry
 
-from .common import all_types, empty, geometry_collection, point, polygon
+from .common import (
+    all_types,
+    empty,
+    geometry_collection,
+    line_string,
+    linear_ring,
+    point,
+    polygon,
+)
 
 UNARY_PREDICATES = (
     pygeos.is_empty,
@@ -102,6 +110,19 @@ def test_equals_exact_tolerance():
     # default value for tolerance
     assert pygeos.equals_exact(p1, p1).item() is True
     assert pygeos.equals_exact(p1, p2).item() is False
+
+
+@pytest.mark.parametrize(
+    "geometry,expected",
+    [
+        (point, False),
+        (line_string, False),
+        (linear_ring, True),
+        (empty, False),
+    ],
+)
+def test_is_closed(geometry, expected):
+    assert pygeos.is_closed(geometry) == expected
 
 
 def test_relate():

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -84,7 +84,7 @@ static char GEOSisClosedAllTypes_r(void* context, void* geom) {
   int type = GEOSGeomTypeId_r(context, geom);
   if (type == -1) {
     return 2;  // Predicates use a return value of 2 for errors
-  } else if ((type == 1) || (type == 5)) {
+  } else if ((type == 1) || (type == 2) || (type == 5)) {
     return GEOSisClosed_r(context, geom);
   } else {
     return 0;


### PR DESCRIPTION
Closes #337

Turns out GEOS is perfectly capable to determine whether a linearring is closed. Our code was just in the way.