### PR TITLE
[Done] Add pygeos.empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ Version 0.11 (unreleased)
 
 **Major enhancements**
 
-* ...
+* Added ``pygeos.empty`` to create a geometry array pre-filled with None or
+  with empty geometries (#381).
 
 **API Changes**
 

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -16,6 +16,7 @@ __all__ = [
     "box",
     "prepare",
     "destroy_prepared",
+    "empty",
 ]
 
 
@@ -480,3 +481,26 @@ def destroy_prepared(geometry, **kwargs):
     prepare
     """
     lib.destroy_prepared(geometry, **kwargs)
+
+
+def empty(shape, geom_type=None, order="C"):
+    """Create an geometry array prefilled with None or empty geometries.
+
+    Parameters
+    ----------
+    shape : int or tuple of int
+        Shape of the empty array, e.g., ``(2, 3)`` or ``2``.
+    geom_type : pygeos.GeometryType, optional
+        The desired geometry type in case the array should be prefilled
+        with empty geometries. Default ``None``.
+    order : {'C', 'F'}, optional, default: 'C'
+        Whether to store multi-dimensional data in row-major
+        (C-style) or column-major (Fortran-style) order in
+        memory.
+    """
+    if geom_type is None:
+        return np.empty(shape, dtype=object, order=order)
+    else:
+        wkt = GeometryType(geom_type).name + " EMPTY"
+    fill_value = Geometry(wkt)
+    return np.full(shape, fill_value, dtype=object, order=order)

--- a/pygeos/tests/test_creation.py
+++ b/pygeos/tests/test_creation.py
@@ -468,3 +468,16 @@ def test_subclass_is_geometry(with_point_in_registry):
 
 def test_subclass_is_valid_input(with_point_in_registry):
     assert pygeos.is_valid_input(Point("POINT (1 1)"))
+
+
+def test_empty_none():
+    actual = pygeos.empty((2,))
+    assert pygeos.is_missing(actual).all()
+
+
+@pytest.mark.parametrize("geom_type", range(8))
+def test_empty(geom_type):
+    actual = pygeos.empty((2,), geom_type=geom_type)
+    assert (~pygeos.is_missing(actual)).all()
+    assert pygeos.is_empty(actual).all()
+    assert (pygeos.get_type_id(actual) == geom_type).all()


### PR DESCRIPTION
Closes #149 

Some thoughts: I first wanted to make this a ufunc and use the GEOS API to construct the empty geometries with code.
But this approach is much simpler. It does have some ~10 microseconds overhead from WKT deserialization, but as it is O(1) (not scaling with shape) I think it is acceptable.

Some timings:
```
In [5]: %timeit pygeos.empty((1000,), geom_type=1)
18.7 µs ± 147 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [12]: fill_value = pygeos.Geometry("POINT EMPTY")

In [13]: %timeit np.full((1000,), fill_value=fill_value, dtype=object)
8.46 µs ± 40.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```