### PR TITLE
[Done] Fix GEOS 3.10 tests for linearring construction

### DIFF
--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -141,6 +141,10 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
                     if coord_view[idx, coord_idx] != coord_view[idx + geom_size - 1, coord_idx]:
                         ring_closure = 1
                         break
+                # check the resulting size to prevent invalid rings
+                if geom_size + ring_closure < 4:
+                    # the error equals PGERR_LINEARRING_NCOORDS (in pygeos/src/geos.h)
+                    raise ValueError("A linearring requires at least 4 coordinates.")
 
             seq = GEOSCoordSeq_create_r(geos_handle, geom_size + ring_closure, dims)
             for coord_idx in range(geom_size):

--- a/pygeos/tests/test_creation_indices.py
+++ b/pygeos/tests/test_creation_indices.py
@@ -193,7 +193,7 @@ def test_linearrings(coordinates):
 )
 def test_linearrings_invalid(coordinates):
     # attempt to construct linestrings with 1 coordinate
-    with pytest.raises(pygeos.GEOSException):
+    with pytest.raises((pygeos.GEOSException, ValueError)):
         pygeos.linearrings(coordinates, indices=np.zeros(len(coordinates)))
 
 

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -20,6 +20,7 @@ GEOMETRYCOLLECTION_NAN_WKB = b'\x01\x07\x00\x00\x00\x01\x00\x00\x00\x01\x01\x00\
 GEOMETRYCOLLECTIONZ_NAN_WKB = b'\x01\x07\x00\x00\x80\x01\x00\x00\x00\x01\x01\x00\x00\x80' + (NAN * 3)
 NESTED_COLLECTION_NAN_WKB = b'\x01\x07\x00\x00\x00\x01\x00\x00\x00\x01\x04\x00\x00\x00\x01\x00\x00\x00\x01\x01\x00\x00\x00' + (NAN * 2)
 NESTED_COLLECTIONZ_NAN_WKB = b'\x01\x07\x00\x00\x80\x01\x00\x00\x00\x01\x04\x00\x00\x80\x01\x00\x00\x00\x01\x01\x00\x00\x80' + (NAN * 3)
+INVALID_WKB = "01030000000100000002000000507daec600b1354100de02498e5e3d41306ea321fcb03541a011a53d905e3d41"
 # fmt: on
 
 
@@ -166,11 +167,9 @@ def test_from_wkb_exceptions():
     # invalid ring in WKB
     with pytest.raises(
         pygeos.GEOSException,
-        match="Invalid number of points in LinearRing found 3 - must be 0 or >= 4",
+        match="Points of LinearRing do not form a closed linestring",
     ):
-        result = pygeos.from_wkb(
-            b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A"
-        )
+        result = pygeos.from_wkb(INVALID_WKB)
         assert result is None
 
 
@@ -182,10 +181,7 @@ def test_from_wkb_warn_on_invalid_warn():
 
     # invalid ring in WKB
     with pytest.warns(Warning, match="Invalid WKB"):
-        result = pygeos.from_wkb(
-            b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A",
-            on_invalid="warn",
-        )
+        result = pygeos.from_wkb(INVALID_WKB, on_invalid="warn")
         assert result is None
 
 
@@ -198,10 +194,7 @@ def test_from_wkb_ignore_on_invalid_ignore():
 
     # invalid ring in WKB
     with pytest.warns(None) as w:
-        result = pygeos.from_wkb(
-            b"\x01\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00P}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A0n\xa3!\xfc\xb05A\xa0\x11\xa5=\x90^=AP}\xae\xc6\x00\xb15A\x00\xde\x02I\x8e^=A",
-            on_invalid="ignore",
-        )
+        result = pygeos.from_wkb(INVALID_WKB, on_invalid="ignore")
         assert result is None
         assert len(w) == 0  # no warning
 


### PR DESCRIPTION
Following up #378: I missed some tests that were failing on GEOS 3.10.