### PR TITLE
[Done] GeoJSON IO for GEOS 3.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,8 @@ Version 0.12 (unreleased)
 
 **Major enhancements**
 
-* ...
+* Added GeoJSON input/output capabilities (``pygeos.from_geojson``, 
+  ``pygeos.to_geojson``) (#413).
 
 **API Changes**
 

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -406,7 +406,6 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
 
 
 @requires_geos("3.10.0")
-@may_segfault
 def from_geojson(geometry, **kwargs):
     """Creates geometries from GeoJSON representations (strings).
 

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -247,7 +247,12 @@ def to_geojson(geometry, indent=None, **kwargs):
 
     The GeoJSON format is defined in the `RFC 7946 <https://geojson.org/>`__.
 
-    Unsupported are: 3D geometries, nan coordinates, and empty points.
+    Unsupported are:
+
+    - Geometries of type LINEARRING: these are output as 'null'.
+    - Three-dimensional geometries: the third dimension is ignored.
+    - NaN (not-a-number) coordinates: these are written as 'null', which renders
+      the GeoJSON invalid.
 
     Parameters
     ----------
@@ -416,7 +421,8 @@ def from_geojson(geometry, **kwargs):
 
 
     The GeoJSON format is defined in `RFC 7946 <https://geojson.org/>`__.
-    Unsupported are: 3D geometries, ``null``, or ``nan``.
+
+    Three-dimensional geometries are unsupported. The third dimension will be ignored.
 
     Parameters
     ----------

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -246,13 +246,12 @@ def to_geojson(geometry, indent=None, **kwargs):
     """Converts to the GeoJSON representation of a Geometry.
 
     The GeoJSON format is defined in the `RFC 7946 <https://geojson.org/>`__.
+    NaN (not-a-number) coordinates will be written as 'null'.
 
-    Unsupported are:
+    The following are currently unsupported:
 
     - Geometries of type LINEARRING: these are output as 'null'.
     - Three-dimensional geometries: the third dimension is ignored.
-    - NaN (not-a-number) coordinates: these are written as 'null', which renders
-      the GeoJSON invalid.
 
     Parameters
     ----------
@@ -278,6 +277,9 @@ def to_geojson(geometry, indent=None, **kwargs):
       ]
     }
     """
+    # GEOS Tickets:
+    # - handle linearrings: https://trac.osgeo.org/geos/ticket/1140
+    # - support 3D: https://trac.osgeo.org/geos/ticket/1141
     if indent is None:
         indent = -1
     elif not np.isscalar(indent):
@@ -415,7 +417,10 @@ def from_geojson(geometry, on_invalid="raise", **kwargs):
 
     The GeoJSON format is defined in `RFC 7946 <https://geojson.org/>`__.
 
-    Three-dimensional geometries are unsupported. The third dimension will be ignored.
+    The following are currently unsupported:
+
+    - Three-dimensional geometries: the third dimension is ignored.
+    - Geometries having 'null' in the coordinates.
 
     Parameters
     ----------
@@ -439,7 +444,9 @@ def from_geojson(geometry, on_invalid="raise", **kwargs):
     >>> from_geojson('{"type": "Point","coordinates": [1, 2]}')
     <pygeos.Geometry POINT (1 2)>
     """
-
+    # GEOS Tickets:
+    # - support 3D: https://trac.osgeo.org/geos/ticket/1141
+    # - handle null coordinates: https://trac.osgeo.org/geos/ticket/1142
     if not np.isscalar(on_invalid):
         raise TypeError("on_invalid only accepts scalar values")
 

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -247,6 +247,8 @@ def to_geojson(geometry, indent=None, **kwargs):
 
     The GeoJSON format is defined in the `RFC 7946 <https://geojson.org/>`__.
 
+    3-dimensional geometries are currently unsupported.
+
     Parameters
     ----------
     geometry : str, bytes or array_like

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -4,8 +4,21 @@ from collections.abc import Sized
 import numpy as np
 
 from . import Geometry  # noqa
-from . import geos_capi_version_string, lib
+from . import GeometryType, geos_capi_version_string, get_parts, get_type_id, lib
+from .decorators import requires_geos
 from .enum import ParamEnum
+
+__all__ = [
+    "from_geojson",
+    "from_shapely",
+    "from_wkb",
+    "from_wkt",
+    "to_geojson",
+    "to_shapely",
+    "to_wkb",
+    "to_wkt",
+]
+
 
 # Allowed options for handling WKB/WKT decoding errors
 # Note: cannot use standard constructor since "raise" is a keyword
@@ -82,16 +95,13 @@ def check_shapely_version():
         _shapely_checked = True
 
 
-__all__ = ["from_shapely", "from_wkb", "from_wkt", "to_shapely", "to_wkb", "to_wkt"]
-
-
 def to_wkt(
     geometry,
     rounding_precision=6,
     trim=True,
     output_dimension=3,
     old_3d=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Converts to the Well-Known Text (WKT) representation of a Geometry.
@@ -231,6 +241,50 @@ def to_wkb(
     )
 
 
+@requires_geos("3.10.0")
+def to_geojson(geometry, indent=None, **kwargs):
+    """Converts to the GeoJSON representation of a Geometry.
+
+    The GeoJSON format is defined in the `RFC 7946 <https://geojson.org/>`__.
+
+    Parameters
+    ----------
+    geometry : str, bytes or array_like
+        The GeoJSON string or byte object(s) to convert.
+    indent : int, optional
+        If indent is a non-negative integer, then GeoJSON will be formatted.
+        An indent level of 0 will only insert newlines. None (the default)
+        selects the most compact representation.
+    unpack : bool, default True
+        If True, unpacks a FeatureCollection or GeometryCollection into a 1D ndarray.
+        Only works for scalar inputs.
+    **kwargs
+        For other keyword-only arguments, see the
+        `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+
+    Examples
+    --------
+    >>> to_geojson(Geometry("POINT (1 1)"))
+    '{"type":"Point","coordinates":[1.0,1.0]}'
+    >>> print(to_geojson(Geometry("POINT (1 1)"), indent=2))
+    {
+      "type": "Point",
+      "coordinates": [
+          1.0,
+          1.0
+      ]
+    }
+    """
+    if indent is None:
+        indent = -1
+    elif not np.isscalar(indent):
+        raise TypeError("indent only accepts scalar values")
+    elif indent < 0:
+        raise ValueError("indent cannot be negative")
+
+    return lib.to_geojson(geometry, np.intc(indent), **kwargs)
+
+
 def to_shapely(geometry):
     """
     Converts PyGEOS geometries to Shapely.
@@ -322,7 +376,7 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     geometry : str or array_like
         The WKB byte object(s) to convert.
     on_invalid : {"raise", "warn", "ignore"}, default "raise"
-        - raise: an exception will be raised if WKB input geometries are invalid.
+        - raise: an exception will be raised if a WKB input geometry is invalid.
         - warn: a warning will be raised and invalid WKB geometries will be
           returned as ``None``.
         - ignore: invalid WKB geometries will be returned as ``None`` without a warning.
@@ -346,6 +400,60 @@ def from_wkb(geometry, on_invalid="raise", **kwargs):
     # of array elements)
     geometry = np.asarray(geometry, dtype=object)
     return lib.from_wkb(geometry, invalid_handler, **kwargs)
+
+
+@requires_geos("3.10.0")
+def from_geojson(geometry, on_invalid="raise", unpack=False, **kwargs):
+    """Creates geometries from GeoJSON representations (strings).
+
+    If a GeoJSON is a FeatureCollection, it is read as a single geometry
+    (with type GEOMETRYCOLLECTION). Properties fields are not read.
+
+    A single input FeatureCollection can optionally be unpacked into a
+    1D ndarray by using ``unpack=True`` parameter.
+
+    The GeoJSON format is defined in `RFC 7946 <https://geojson.org/>`__.
+
+    Parameters
+    ----------
+    geometry : str, bytes or array_like
+        The GeoJSON string or byte object(s) to convert.
+    on_invalid : {"raise", "warn", "ignore"}, default "raise"
+        - raise: an exception will be raised if a GeoJSON input geometry is invalid.
+        - warn: a warning will be emitted and invalid GeoJSON geometries will be
+          returned as ``None``.
+        - ignore: invalid GeoJSON geometries will be returned as ``None`` without a warning.
+    unpack : bool, default False
+        If True, unpacks a FeatureCollection or GeometryCollection into a 1D ndarray.
+        Raises a ValueError for non-scalar inputs.
+    **kwargs
+        For other keyword-only arguments, see the
+        `NumPy ufunc docs <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+
+    Examples
+    --------
+    >>> from_geojson('{"type": "Point","coordinates": [1, 2]}')
+    <pygeos.Geometry POINT (1 2)>
+    """
+    if not np.isscalar(on_invalid):
+        raise TypeError("on_invalid only accepts scalar values")
+
+    invalid_handler = np.uint8(DecodingErrorOptions.get_value(on_invalid))
+
+    # ensure the input has object dtype, to avoid numpy inferring it as a
+    # fixed-length string dtype (which removes trailing null bytes upon access
+    # of array elements)
+    geometry = np.asarray(geometry, dtype=object)
+
+    if unpack and geometry.ndim != 0:
+        raise ValueError(
+            f"Can only unpack 0-dimensional (scalar) input, got: {geometry.ndim}"
+        )
+
+    result = lib.from_geojson(geometry, invalid_handler, **kwargs)
+    if unpack and get_type_id(result) == GeometryType.GEOMETRYCOLLECTION:
+        result = get_parts(result)
+    return result
 
 
 def from_shapely(geometry, **kwargs):

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -247,7 +247,7 @@ def to_geojson(geometry, indent=None, **kwargs):
 
     The GeoJSON format is defined in the `RFC 7946 <https://geojson.org/>`__.
 
-    3-dimensional geometries are currently unsupported.
+    Unsupported are: 3D geometries, nan coordinates, and empty points.
 
     Parameters
     ----------
@@ -411,11 +411,12 @@ def from_geojson(geometry, **kwargs):
 
     .. note::
 
-       This function is executed in a subprocess as GEOS may crash on invalid input.
+       GEOS 3.10.0 may crash on invalid input. Because of that, this function
+       creates a subprocess.
 
 
     The GeoJSON format is defined in `RFC 7946 <https://geojson.org/>`__.
-    ``null`` or ``nan`` coordinates are not supported.
+    Unsupported are: 3D geometries, ``null``, or ``nan``.
 
     Parameters
     ----------
@@ -436,7 +437,7 @@ def from_geojson(geometry, **kwargs):
     """
     # Hardcode this until GEOS doesn't crash anymore. Not all errors
     # can be caught and warnings are lost anyway.
-    invalid_handler = DecodingErrorOptions.error
+    invalid_handler = np.uint8(DecodingErrorOptions.get_value("raise"))
 
     # ensure the input has object dtype, to avoid numpy inferring it as a
     # fixed-length string dtype (which removes trailing null bytes upon access

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -409,6 +409,11 @@ def from_geojson(geometry, **kwargs):
     (with type GEOMETRYCOLLECTION). This may be unpacked using the ``pygeos.get_parts``.
     Properties are not read.
 
+    .. note::
+
+       This function is executed in a subprocess as GEOS may crash on invalid input.
+
+
     The GeoJSON format is defined in `RFC 7946 <https://geojson.org/>`__.
     ``null`` or ``nan`` coordinates are not supported.
 

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -813,6 +813,8 @@ def test_to_geojson_exceptions():
     [
         empty_point,
         pygeos.multipoints([empty_point, point]),
+        pygeos.geometrycollections([empty_point, point]),
+        pygeos.geometrycollections([pygeos.geometrycollections([empty_point]), point]),
     ],
 )
 def test_to_geojson_point_empty(geom):

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -779,7 +779,7 @@ def test_from_geojson_exceptions():
     with pytest.raises(pygeos.GEOSException, match="ParseException"):
         pygeos.from_geojson('{"geometry": null, "properties": []}')
 
-    with pytest.raises(pygeos.GEOSException, match="GEOS crashed"):
+    with pytest.raises(pygeos.GEOSException, match="ParseException"):
         pygeos.from_geojson('{"no": "geojson"}')
 
 

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -776,7 +776,7 @@ def test_from_geojson_exceptions():
         pygeos.from_geojson('{"type": "LineString", "coordinates": null}')
 
     # The following inputs give crash, PyGEOS captures these:
-    with pytest.raises(pygeos.GEOSException, match="GEOS crashed"):
+    with pytest.raises(pygeos.GEOSException, match="ParseException"):
         pygeos.from_geojson('{"geometry": null, "properties": []}')
 
     with pytest.raises(pygeos.GEOSException, match="GEOS crashed"):

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -806,6 +806,7 @@ def test_from_geojson_none():
     assert pygeos.from_geojson(None) is None
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_exceptions():
     with pytest.raises(TypeError, match="Expected bytes or string, got int"):
         pygeos.from_geojson(1)
@@ -818,6 +819,7 @@ def test_from_geojson_exceptions():
     #     pygeos.from_geojson('{"no": "geojson"}')
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_warn_on_invalid():
     with pytest.warns(Warning, match="Invalid GeoJSON"):
         pygeos.from_geojson("", on_invalid="warn")
@@ -827,6 +829,7 @@ def test_from_geojson_warn_on_invalid():
     #     pygeos.from_geojson('{"no": "geojson"}', on_invalid="warn")
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_ignore_on_invalid():
     with pytest.warns(None):
         pygeos.from_geojson("", on_invalid="ignore")
@@ -836,6 +839,7 @@ def test_from_geojson_ignore_on_invalid():
     #     pygeos.from_geojson('{"no": "geojson"}', on_invalid="ignore")
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_on_invalid_unsupported_option():
     with pytest.raises(ValueError, match="not a valid option"):
         pygeos.from_geojson(GEOJSON_GEOMETRY, on_invalid="unsupported_option")

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -785,12 +785,6 @@ def test_from_geojson_exceptions():
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
-def test_from_geojson_on_invalid_unsupported_option():
-    with pytest.raises(ValueError, match="not a valid option"):
-        pygeos.from_geojson(GEOJSON_GEOMETRY, on_invalid="unsupported_option")
-
-
-@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 @pytest.mark.parametrize("indent", [None, 0, 4])
 def test_to_geojson(indent):
     separators = (",", ":") if indent is None else (",", ": ")
@@ -813,10 +807,17 @@ def test_to_geojson_exceptions():
         pygeos.to_geojson(1)
 
 
-# @pytest.mark.skip("Segfaults")
-# @pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
-# def test_to_geojson_point_empty():
-#     assert pygeos.to_geojson(pygeos.Geometry("POINT EMPTY")) == '{"type":"Point","coordinates":[]}'
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
+@pytest.mark.parametrize(
+    "geom",
+    [
+        empty_point,
+        pygeos.multipoints([empty_point, point]),
+    ],
+)
+def test_to_geojson_point_empty(geom):
+    with pytest.raises(ValueError):
+        assert pygeos.to_geojson(geom)
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -784,6 +784,7 @@ def test_from_geojson_exceptions():
         pygeos.from_geojson('{"no": "geojson"}')
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_warn_on_invalid():
     with pytest.warns(Warning, match="Invalid GeoJSON"):
         assert pygeos.from_geojson("", on_invalid="warn") is None
@@ -792,6 +793,7 @@ def test_from_geojson_warn_on_invalid():
         assert pygeos.from_geojson('{"no": "geojson"}', on_invalid="warn") is None
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_ignore_on_invalid():
     with pytest.warns(None):
         assert pygeos.from_geojson("", on_invalid="ignore") is None
@@ -800,6 +802,7 @@ def test_from_geojson_ignore_on_invalid():
         assert pygeos.from_geojson('{"no": "geojson"}', on_invalid="ignore") is None
 
 
+@pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_on_invalid_unsupported_option():
     with pytest.raises(ValueError, match="not a valid option"):
         pygeos.from_geojson(GEOJSON_GEOMETRY, on_invalid="unsupported_option")

--- a/src/geos.c
+++ b/src/geos.c
@@ -25,11 +25,11 @@ void destroy_geom_arr(void* context, GEOSGeometry** array, int length) {
   }
 }
 
-/* These functions are used to workaround two Pre-GEOS 3.9.0 issues:
+/* These functions are used to workaround two GEOS issues (in WKB writer for
+ * GEOS < 3.9, in WKT writer for GEOS < 3.9 and in GeoJSON writer for GEOS 3.10.0):
  * - POINT EMPTY was not handled correctly (we do it ourselves)
  * - MULTIPOINT (EMPTY) resulted in segfault (we check for it and raise)
  */
-#if !GEOS_SINCE_3_9_0
 
 /* Returns 1 if a multipoint has an empty point, 0 otherwise, 2 on error.
  */
@@ -288,8 +288,6 @@ char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
     return PGERR_GEOS_EXCEPTION;
   }
 }
-
-#endif  // !GEOS_SINCE_3_9_0
 
 #if GEOS_SINCE_3_9_0
 

--- a/src/geos.h
+++ b/src/geos.h
@@ -52,6 +52,7 @@ enum {
   PGERR_GEOMETRY_TYPE,
   PGERR_MULTIPOINT_WITH_POINT_EMPTY,
   PGERR_EMPTY_GEOMETRY,
+  PGERR_GEOJSON_EMPTY_POINT,
   PGERR_LINEARRING_NCOORDS,
   PGWARN_INVALID_WKB,  // raise the GEOS WKB error as a warning instead of exception
   PGWARN_INVALID_WKT,  // raise the GEOS WKT error as a warning instead of exception
@@ -89,6 +90,9 @@ enum {
     case PGERR_EMPTY_GEOMETRY:                                                           \
       PyErr_SetString(PyExc_ValueError, "One of the Geometry inputs is empty.");         \
       break;                                                                             \
+    case PGERR_GEOJSON_EMPTY_POINT:                                                      \
+      PyErr_SetString(PyExc_ValueError, "GeoJSON output of empty points is unsupported."); \
+      break;  \
     case PGERR_LINEARRING_NCOORDS:                                                       \
       PyErr_SetString(PyExc_ValueError,                                                  \
                       "A linearring requires at least 4 coordinates.");                  \
@@ -151,12 +155,10 @@ extern PyObject* geos_exception[1];
 extern void geos_error_handler(const char* message, void* userdata);
 extern void geos_notice_handler(const char* message, void* userdata);
 extern void destroy_geom_arr(void* context, GEOSGeometry** array, int length);
-#if !GEOS_SINCE_3_9_0
 extern char has_point_empty(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 extern GEOSGeometry* point_empty_to_nan_all_geoms(GEOSContextHandle_t ctx,
                                                   GEOSGeometry* geom);
 extern char check_to_wkt_compatible(GEOSContextHandle_t ctx, GEOSGeometry* geom);
-#endif  // !GEOS_SINCE_3_9_0
 #if GEOS_SINCE_3_9_0
 extern char wkt_empty_3d_geometry(GEOSContextHandle_t ctx, GEOSGeometry* geom,
                                   char** wkt);

--- a/src/geos.h
+++ b/src/geos.h
@@ -91,8 +91,9 @@ enum {
       PyErr_SetString(PyExc_ValueError, "One of the Geometry inputs is empty.");         \
       break;                                                                             \
     case PGERR_GEOJSON_EMPTY_POINT:                                                      \
-      PyErr_SetString(PyExc_ValueError, "GeoJSON output of empty points is unsupported."); \
-      break;  \
+      PyErr_SetString(PyExc_ValueError,                                                  \
+                      "GeoJSON output of empty points is currently unsupported.");       \
+      break;                                                                             \
     case PGERR_LINEARRING_NCOORDS:                                                       \
       PyErr_SetString(PyExc_ValueError,                                                  \
                       "A linearring requires at least 4 coordinates.");                  \

--- a/src/geos.h
+++ b/src/geos.h
@@ -54,7 +54,8 @@ enum {
   PGERR_EMPTY_GEOMETRY,
   PGERR_LINEARRING_NCOORDS,
   PGWARN_INVALID_WKB,  // raise the GEOS WKB error as a warning instead of exception
-  PGWARN_INVALID_WKT   // raise the GEOS WKB error as a warning instead of exception
+  PGWARN_INVALID_WKT,  // raise the GEOS WKT error as a warning instead of exception
+  PGWARN_INVALID_GEOJSON
 };
 
 // Define how the states are handled by CPython
@@ -99,6 +100,10 @@ enum {
     case PGWARN_INVALID_WKT:                                                             \
       PyErr_WarnFormat(PyExc_Warning, 0,                                                 \
                        "Invalid WKT: geometry is returned as None. %s", last_error);     \
+      break;                                                                             \
+    case PGWARN_INVALID_GEOJSON:                                                         \
+      PyErr_WarnFormat(PyExc_Warning, 0,                                                 \
+                       "Invalid GeoJSON: geometry is returned as None. %s", last_error); \
       break;                                                                             \
     default:                                                                             \
       PyErr_Format(PyExc_RuntimeError,                                                   \

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3108,6 +3108,7 @@ static void to_geojson_func(char** args, npy_intp* dimensions, npy_intp* steps,
       Py_INCREF(Py_None);
       *out = Py_None;
     } else {
+      // Check for empty points (https://trac.osgeo.org/geos/ticket/1139)
       point_empty_error = has_point_empty(ctx, in1);
       if (point_empty_error == 2) {
         errstate = PGERR_GEOS_EXCEPTION;

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -3082,8 +3082,7 @@ static void to_geojson_func(char** args, npy_intp* dimensions, npy_intp* steps,
   char point_empty_error;
 
   if (is2 != 0) {
-    PyErr_Format(PyExc_ValueError,
-                 "to_geojson function called with non-scalar parameters");
+    PyErr_Format(PyExc_ValueError, "to_geojson indent parameter must be a scalar");
     return;
   }
   indent = *(int*)ip2;

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2617,7 +2617,7 @@ static void from_wkb_func(char** args, npy_intp* dimensions, npy_intp* steps,
           goto finish;
         }
       } else {
-        PyErr_Format(PyExc_TypeError, "Expected bytes, got %s", Py_TYPE(in1)->tp_name);
+        PyErr_Format(PyExc_TypeError, "Expected bytes or string, got %s", Py_TYPE(in1)->tp_name);
         goto finish;
       }
 
@@ -2704,7 +2704,7 @@ static void from_wkt_func(char** args, npy_intp* dimensions, npy_intp* steps,
           goto finish;
         }
       } else {
-        PyErr_Format(PyExc_TypeError, "Expected bytes, got %s", Py_TYPE(in1)->tp_name);
+        PyErr_Format(PyExc_TypeError, "Expected bytes or string, got %s", Py_TYPE(in1)->tp_name);
         goto finish;
       }
 
@@ -2730,6 +2730,82 @@ finish:
   GEOS_FINISH;
 }
 static PyUFuncGenericFunction from_wkt_funcs[1] = {&from_wkt_func};
+
+static char from_geojson_dtypes[3] = {NPY_OBJECT, NPY_UINT8, NPY_OBJECT};
+static void from_geojson_func(char** args, npy_intp* dimensions, npy_intp* steps,
+                          void* data) {
+  char *ip1 = args[0], *ip2 = args[1], *op1 = args[2];
+  npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+  PyObject* in1;
+  npy_uint8 on_invalid = *(npy_uint8*)ip2;
+  npy_intp n = dimensions[0];
+  npy_intp i;
+  GEOSGeometry* ret_ptr;
+  GEOSGeoJSONReader* reader;
+  const char* geojson;
+
+  if ((is2 != 0)) {
+    PyErr_Format(PyExc_ValueError, "from_geojson function called with non-scalar parameters");
+    return;
+  }
+
+  GEOS_INIT;
+
+  /* Create the WKT reader */
+  reader = GEOSGeoJSONReader_create_r(ctx);
+  if (reader == NULL) {
+    errstate = PGERR_GEOS_EXCEPTION;
+    goto finish;
+  }
+
+  for (i = 0; i < n; i++, ip1 += is1, op1 += os1) {
+    /* ip1 is pointer to array element PyObject* */
+    in1 = *(PyObject**)ip1;
+
+    if (in1 == Py_None) {
+      /* None in the input propagates to the output */
+      ret_ptr = NULL;
+    } else {
+      /* Cast the PyObject (bytes or str) to char* */
+      if (PyBytes_Check(in1)) {
+        geojson = PyBytes_AsString(in1);
+        if (geojson == NULL) {
+          errstate = PGERR_GEOS_EXCEPTION;
+          goto finish;
+        }
+      } else if (PyUnicode_Check(in1)) {
+        geojson = PyUnicode_AsUTF8(in1);
+        if (geojson == NULL) {
+          errstate = PGERR_GEOS_EXCEPTION;
+          goto finish;
+        }
+      } else {
+        PyErr_Format(PyExc_TypeError, "Expected bytes or string, got %s", Py_TYPE(in1)->tp_name);
+        goto finish;
+      }
+
+      /* Read the GeoJSON */
+      ret_ptr = GEOSGeoJSONReader_readGeometry_r(ctx, reader, geojson);
+      if (ret_ptr == NULL) {
+        if (on_invalid == 2) {
+          // raise exception
+          errstate = PGERR_GEOS_EXCEPTION;
+          goto finish;
+        } else if (on_invalid == 1) {
+          // raise warning, return None
+          errstate = PGWARN_INVALID_GEOJSON;
+        }
+        // else: return None, no warning
+      }
+    }
+    OUTPUT_Y;
+  }
+
+finish:
+  GEOSGeoJSONReader_destroy_r(ctx, reader);
+  GEOS_FINISH;
+}
+static PyUFuncGenericFunction from_geojson_funcs[1] = {&from_geojson_func};
 
 static char from_shapely_dtypes[2] = {NPY_OBJECT, NPY_OBJECT};
 static void from_shapely_func(char** args, npy_intp* dimensions, npy_intp* steps,
@@ -2974,6 +3050,62 @@ finish:
 }
 static PyUFuncGenericFunction to_wkt_funcs[1] = {&to_wkt_func};
 
+
+static char to_geojson_dtypes[3] = {NPY_OBJECT, NPY_INT, NPY_OBJECT};
+static void to_geojson_func(char** args, npy_intp* dimensions, npy_intp* steps, void* data) {
+  char *ip1 = args[0], *ip2 = args[1], *op1 = args[2];
+  npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+  npy_intp n = dimensions[0];
+  npy_intp i;
+
+  GEOSGeometry* in1;
+  int indent;
+  GEOSGeoJSONWriter* writer;
+  char* geojson;
+
+  if (is2 != 0) {
+    PyErr_Format(PyExc_ValueError, "to_geojson function called with non-scalar parameters");
+    return;
+  }
+  indent = *(int*)ip2;
+
+  GEOS_INIT;
+
+  /* Create the WKT writer */
+  writer = GEOSGeoJSONWriter_create_r(ctx);
+  if (writer == NULL) {
+    errstate = PGERR_GEOS_EXCEPTION;
+    goto finish;
+  }
+
+  for (i = 0; i < n; i++, ip1 += is1, op1 += os1) {
+    if (!get_geom(*(GeometryObject**)ip1, &in1)) {
+      errstate = PGERR_NOT_A_GEOMETRY;
+      goto finish;
+    }
+    PyObject** out = (PyObject**)op1;
+
+    if (in1 == NULL) {
+      Py_XDECREF(*out);
+      Py_INCREF(Py_None);
+      *out = Py_None;
+    } else {
+      geojson = GEOSGeoJSONWriter_writeGeometry_r(ctx, writer, in1, indent);
+      if (geojson == NULL) {
+        errstate = PGERR_GEOS_EXCEPTION;
+        goto finish;
+      }
+      Py_XDECREF(*out);
+      *out = PyUnicode_FromString(geojson);
+      GEOSFree_r(ctx, geojson);
+    }
+  }
+
+finish:
+  GEOSGeoJSONWriter_destroy_r(ctx, writer);
+  GEOS_FINISH;
+}
+static PyUFuncGenericFunction to_geojson_funcs[1] = {&to_geojson_func};
 /*
 TODO polygonizer functions
 TODO prepared geometry predicate functions
@@ -3223,6 +3355,8 @@ int init_ufuncs(PyObject* m, PyObject* d) {
 
 #if GEOS_SINCE_3_10_0
   DEFINE_Yd_Y(segmentize);
+  DEFINE_CUSTOM(from_geojson, 2);
+  DEFINE_CUSTOM(to_geojson, 2);
 #endif
 
   Py_DECREF(ufunc);


### PR DESCRIPTION
This implements to/from geojson ufuncs using the new GeoJSON reader and writer from GEOS 3.10.

There are a few open issues, we get crashes on:

```
>>> pygeos.from_geojson('{"no": "geojson"}')
python: /home/casper/code/geos/include/geos/vend/json.hpp:20363: const value_type& geos_nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::operator[](T*) const [with T = const char; ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = geos_nlohmann::adl_serializer; BinaryType = std::vector<unsigned char>; geos_nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::const_reference = const geos_nlohmann::basic_json<>&; geos_nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer, BinaryType>::value_type = geos_nlohmann::basic_json<>]: Assertion `m_value.object->find(key) != m_value.object->end()' failed.
Aborted (core dumped)
```

And on:

```
In [2]: pygeos.to_geojson(pygeos.Geometry("POINT EMPTY"))
Segmentation fault (core dumped)
```

The Z coordinates are dropped:

```
In [6]: pygeos.to_geojson(pygeos.Geometry("POINT Z (1 1 2)"))
Out[6]: '{"type":"Point","coordinates":[1.0,1.0]}
```

Also, nan coordinates are serialized to null, but null is not serialized to nan:
```
in [3] pygeos.to_geojson(pygeos.Geometry("LINESTRING (1 nan, 2 2)"))
Out[3]: '{"type":"LineString","coordinates":[[1.0,null],[2.0,2.0]]}'
In [4]: pygeos.from_geojson('{"type":"LineString","coordinates":[[1.0,null],[2.0,2.0]]}')
---------------------------------------------------------------------------
GEOSException                             Traceback (most recent call last)
<ipython-input-4-22368789e223> in <module>
----> 1 pygeos.from_geojson('{"type":"LineString","coordinates":[[1.0,null],[2.0,2.0]]}')

~/code/pygeos/pygeos/io.py in from_geojson(geometry, on_invalid, unpack, **kwargs)
    453         )
    454 
--> 455     result = lib.from_geojson(geometry, invalid_handler, **kwargs)
    456     if unpack and get_type_id(result) == GeometryType.GEOMETRYCOLLECTION:
    457         result = get_parts(result)

GEOSException: ParseException: Error parsing JSON: '[json.exception.type_error.302] type must be number, but is null'