### PR TITLE
[Done] Reinstate may_segfault for from_geojson

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,9 @@ Version 0.12 (unreleased)
 
 **Bug fixes**
 
-* ...
+* Protect ``pygeos.from_geojson`` against segfaults by running the function in a
+  subprocess (GEOS 3.10.0 only).
+
 
 **Acknowledgments**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Version 0.12 (unreleased)
 **Bug fixes**
 
 * Protect ``pygeos.from_geojson`` against segfaults by running the function in a
-  subprocess (GEOS 3.10.0 only).
+  subprocess (GEOS 3.10.0 only) (#418).
 
 
 **Acknowledgments**

--- a/pygeos/decorators.py
+++ b/pygeos/decorators.py
@@ -1,6 +1,4 @@
-import multiprocessing
 import os
-import warnings
 from functools import wraps
 
 import numpy as np
@@ -85,78 +83,3 @@ def multithreading_enabled(func):
                 arr.flags.writeable = old_flag
 
     return wrapped
-
-
-class ReturningProcess(multiprocessing.Process):
-    """A Process with an added Pipe for getting the return_value or exception."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._pconn, self._cconn = multiprocessing.Pipe()
-        self._result = {}
-
-    def run(self):
-        if not self._target:
-            return
-        try:
-            with warnings.catch_warnings(record=True) as w:
-                return_value = self._target(*self._args, **self._kwargs)
-            self._cconn.send({"return_value": return_value, "warnings": w})
-        except Exception as e:
-            self._cconn.send({"exception": e})
-
-    @property
-    def result(self):
-        if not self._result and self._pconn.poll():
-            self._result = self._pconn.recv()
-        return self._result
-
-    @property
-    def exception(self):
-        return self.result.get("exception")
-
-    @property
-    def warnings(self):
-        return self.result.get("warnings")
-
-    @property
-    def return_value(self):
-        return self.result.get("return_value")
-
-
-def may_segfault(func):
-    """The wrapped function will be called in another process.
-
-    If the execution crashes with a segfault or sigabort, an OSError
-    will be raised.
-
-    Note: do not use this to decorate a function at module level, because this
-    will render the function un-Picklable so that multiprocessing fails on OSX/Windows.
-
-    Instead, use it like this:
-
-    >>> def some_unstable_func():
-    ...     ...
-    >>> some_func = may_segfault(some_unstable_func)
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        process = ReturningProcess(target=func, args=args, kwargs=kwargs)
-        process.start()
-        process.join()
-        if process.exception:
-            raise process.exception
-        elif process.exitcode != 0:
-            raise OSError(f"GEOS crashed with exit code {process.exitcode}.")
-        else:
-            for w in process.warnings:
-                warnings.warn_explicit(
-                    w.message,
-                    w.category,
-                    w.filename,
-                    w.lineno,
-                )
-            return process.return_value
-
-    return wrapper

--- a/pygeos/decorators.py
+++ b/pygeos/decorators.py
@@ -1,9 +1,11 @@
+import multiprocessing
 import os
+import warnings
 from functools import wraps
 
 import numpy as np
 
-from . import lib
+from . import GEOSException, lib
 
 
 class UnsupportedGEOSOperation(ImportError):
@@ -83,3 +85,69 @@ def multithreading_enabled(func):
                 arr.flags.writeable = old_flag
 
     return wrapped
+
+
+class ReturningProcess(multiprocessing.Process):
+    """A Process with an added Pipe for getting the return_value or exception."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._pconn, self._cconn = multiprocessing.Pipe()
+        self._result = {}
+
+    def run(self):
+        if not self._target:
+            return
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                return_value = self._target(*self._args, **self._kwargs)
+            self._cconn.send({"return_value": return_value, "warnings": w})
+        except Exception as e:
+            self._cconn.send({"exception": e})
+
+    @property
+    def result(self):
+        if not self._result and self._pconn.poll():
+            self._result = self._pconn.recv()
+        return self._result
+
+    @property
+    def exception(self):
+        return self.result.get("exception")
+
+    @property
+    def warnings(self):
+        return self.result.get("warnings")
+
+    @property
+    def return_value(self):
+        return self.result.get("return_value")
+
+
+def may_segfault(func):
+    """The wrapped function will be called in another process.
+
+    If the execution crashes with a segfault or sigabort, an Exception
+    will be raised.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        process = ReturningProcess(target=func, args=args, kwargs=kwargs)
+        process.start()
+        process.join()
+        if process.exception:
+            raise process.exception
+        elif process.exitcode != 0:
+            raise GEOSException(f"GEOS crashed with exit code {process.exitcode}.")
+        else:
+            for w in process.warnings:
+                warnings.warn_explicit(
+                    w.message,
+                    w.category,
+                    w.filename,
+                    w.lineno,
+                )
+            return process.return_value
+
+    return wrapper

--- a/pygeos/decorators.py
+++ b/pygeos/decorators.py
@@ -129,6 +129,15 @@ def may_segfault(func):
 
     If the execution crashes with a segfault or sigabort, an Exception
     will be raised.
+
+    Note: do not use this to decorate a function at module level, because this
+    will render the function un-Picklable so that multiprocessing fails on OSX/Windows.
+
+    Instead, use it like this:
+
+    >>> def some_unstable_func():
+    ...     ...
+    >>> some_func = may_segfault(some_unstable_func)
     """
 
     @wraps(func)

--- a/pygeos/decorators.py
+++ b/pygeos/decorators.py
@@ -5,7 +5,7 @@ from functools import wraps
 
 import numpy as np
 
-from . import GEOSException, lib
+from . import lib
 
 
 class UnsupportedGEOSOperation(ImportError):
@@ -127,7 +127,7 @@ class ReturningProcess(multiprocessing.Process):
 def may_segfault(func):
     """The wrapped function will be called in another process.
 
-    If the execution crashes with a segfault or sigabort, an Exception
+    If the execution crashes with a segfault or sigabort, an OSError
     will be raised.
 
     Note: do not use this to decorate a function at module level, because this
@@ -148,7 +148,7 @@ def may_segfault(func):
         if process.exception:
             raise process.exception
         elif process.exitcode != 0:
-            raise GEOSException(f"GEOS crashed with exit code {process.exitcode}.")
+            raise OSError(f"GEOS crashed with exit code {process.exitcode}.")
         else:
             for w in process.warnings:
                 warnings.warn_explicit(

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -5,8 +5,9 @@ import numpy as np
 
 from . import Geometry  # noqa
 from . import geos_capi_version_string, geos_version_string, lib
-from .decorators import may_segfault, requires_geos
+from .decorators import requires_geos
 from .enum import ParamEnum
+from .may_segfault import may_segfault
 
 __all__ = [
     "from_geojson",

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -4,8 +4,8 @@ from collections.abc import Sized
 import numpy as np
 
 from . import Geometry  # noqa
-from . import geos_capi_version_string, lib
-from .decorators import requires_geos
+from . import geos_capi_version_string, geos_version, lib
+from .decorators import may_segfault, requires_geos
 from .enum import ParamEnum
 
 __all__ = [
@@ -415,6 +415,11 @@ def from_geojson(geometry, on_invalid="raise", **kwargs):
     (with type GEOMETRYCOLLECTION). This may be unpacked using the ``pygeos.get_parts``.
     Properties are not read.
 
+    .. note::
+
+      For GEOS 3.10.0, this function is executed in a subprocess. This is because invalid
+      GeoJSON input may result in a crash. For GEOS 3.10.1 the issue is expected to be fixed.
+
     The GeoJSON format is defined in `RFC 7946 <https://geojson.org/>`__.
 
     The following are currently unsupported:
@@ -457,7 +462,13 @@ def from_geojson(geometry, on_invalid="raise", **kwargs):
     # of array elements)
     geometry = np.asarray(geometry, dtype=object)
 
-    return lib.from_geojson(geometry, invalid_handler, **kwargs)
+    # GEOS 3.10.0 may segfault on invalid GeoJSON input. This bug is currently
+    # solved in main branch, expected fix in (3, 10, 1)
+    if geos_version == (3, 10, 0):
+        _from_geojson = may_segfault(lib.from_geojson)
+    else:
+        _from_geojson = lib.from_geojson
+    return _from_geojson(geometry, invalid_handler, **kwargs)
 
 
 def from_shapely(geometry, **kwargs):

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -4,7 +4,7 @@ from collections.abc import Sized
 import numpy as np
 
 from . import Geometry  # noqa
-from . import geos_capi_version_string, geos_version, lib
+from . import geos_capi_version_string, geos_version_string, lib
 from .decorators import may_segfault, requires_geos
 from .enum import ParamEnum
 
@@ -464,7 +464,7 @@ def from_geojson(geometry, on_invalid="raise", **kwargs):
 
     # GEOS 3.10.0 may segfault on invalid GeoJSON input. This bug is currently
     # solved in main branch, expected fix in (3, 10, 1)
-    if geos_version == (3, 10, 0):
+    if geos_version_string == "3.10.0":  # so not on dev versions!
         _from_geojson = may_segfault(lib.from_geojson)
     else:
         _from_geojson = lib.from_geojson

--- a/pygeos/may_segfault.py
+++ b/pygeos/may_segfault.py
@@ -1,0 +1,76 @@
+import multiprocessing
+import warnings
+
+
+class ReturningProcess(multiprocessing.Process):
+    """A Process with an added Pipe for getting the return_value or exception."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._pconn, self._cconn = multiprocessing.Pipe()
+        self._result = {}
+
+    def run(self):
+        if not self._target:
+            return
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                return_value = self._target(*self._args, **self._kwargs)
+            self._cconn.send({"return_value": return_value, "warnings": w})
+        except Exception as e:
+            self._cconn.send({"exception": e, "warnings": w})
+
+    @property
+    def result(self):
+        if not self._result and self._pconn.poll():
+            self._result = self._pconn.recv()
+        return self._result
+
+    @property
+    def exception(self):
+        return self.result.get("exception")
+
+    @property
+    def warnings(self):
+        return self.result.get("warnings", [])
+
+    @property
+    def return_value(self):
+        return self.result.get("return_value")
+
+
+def may_segfault(func):
+    """The wrapped function will be called in another process.
+
+    If the execution crashes with a segfault or sigabort, an OSError
+    will be raised.
+
+    Note: do not use this to decorate a function at module level, because this
+    will render the function un-Picklable so that multiprocessing fails on OSX/Windows.
+
+    Instead, use it like this:
+
+    >>> def some_unstable_func():
+    ...     ...
+    >>> some_func = may_segfault(some_unstable_func)
+    """
+
+    def wrapper(*args, **kwargs):
+        process = ReturningProcess(target=func, args=args, kwargs=kwargs)
+        process.start()
+        process.join()
+        for w in process.warnings:
+            warnings.warn_explicit(
+                w.message,
+                w.category,
+                w.filename,
+                w.lineno,
+            )
+        if process.exception:
+            raise process.exception
+        elif process.exitcode != 0:
+            raise OSError(f"GEOS crashed with exit code {process.exitcode}.")
+        else:
+            return process.return_value
+
+    return wrapper

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -775,12 +775,12 @@ def test_from_geojson_exceptions():
     with pytest.raises(pygeos.GEOSException, match="type must be array, but is null"):
         pygeos.from_geojson('{"type": "LineString", "coordinates": null}')
 
-    # Note: The two below tests make GEOS 3.10.0 crash if it is compiled in Debug mode
+    # Note: The two below tests may make GEOS 3.10.0 crash
     # https://trac.osgeo.org/geos/ticket/1138
-    with pytest.raises(pygeos.GEOSException, match="ParseException"):
+    with pytest.raises(pygeos.GEOSException):
         pygeos.from_geojson('{"geometry": null, "properties": []}')
 
-    with pytest.raises(pygeos.GEOSException, match="ParseException"):
+    with pytest.raises(pygeos.GEOSException):
         pygeos.from_geojson('{"no": "geojson"}')
 
 
@@ -789,17 +789,11 @@ def test_from_geojson_warn_on_invalid():
     with pytest.warns(Warning, match="Invalid GeoJSON"):
         assert pygeos.from_geojson("", on_invalid="warn") is None
 
-    with pytest.warns(Warning, match="Invalid GeoJSON"):
-        assert pygeos.from_geojson('{"no": "geojson"}', on_invalid="warn") is None
-
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")
 def test_from_geojson_ignore_on_invalid():
     with pytest.warns(None):
         assert pygeos.from_geojson("", on_invalid="ignore") is None
-
-    with pytest.warns(None):
-        assert pygeos.from_geojson('{"no": "geojson"}', on_invalid="ignore") is None
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 10, 0), reason="GEOS < 3.10")

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -777,10 +777,10 @@ def test_from_geojson_exceptions():
 
     # Note: The two below tests may make GEOS 3.10.0 crash
     # https://trac.osgeo.org/geos/ticket/1138
-    with pytest.raises(pygeos.GEOSException):
+    with pytest.raises((pygeos.GEOSException, OSError)):
         pygeos.from_geojson('{"geometry": null, "properties": []}')
 
-    with pytest.raises(pygeos.GEOSException):
+    with pytest.raises((pygeos.GEOSException, OSError)):
         pygeos.from_geojson('{"no": "geojson"}')
 
 

--- a/pygeos/tests/test_misc.py
+++ b/pygeos/tests/test_misc.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 import pygeos
-from pygeos import GEOSException
 from pygeos.decorators import may_segfault, multithreading_enabled, requires_geos
 
 
@@ -203,12 +202,16 @@ def my_unstable_func(event=None):
 
 
 def test_may_segfault():
-    with pytest.raises(GEOSException, match="GEOS crashed with exit code"):
+    if os.name == "nt":
+        match = "access violation"
+    else:
+        match = "GEOS crashed"
+    with pytest.raises(OSError, match=match):
         may_segfault(my_unstable_func)("segfault")
 
 
 def test_may_segfault_exit():
-    with pytest.raises(GEOSException, match="GEOS crashed with exit code 1."):
+    with pytest.raises(OSError, match="GEOS crashed with exit code 1."):
         may_segfault(my_unstable_func)("exit")
 
 

--- a/pygeos/tests/test_misc.py
+++ b/pygeos/tests/test_misc.py
@@ -189,8 +189,7 @@ def test_multithreading_enabled_ok(args, kwargs):
     assert result[0] == 42
 
 
-@may_segfault
-def may_unstable_func(event=None):
+def my_unstable_func(event=None):
     if event == "segfault":
         ctypes.string_at(0)  # segfault
     elif event == "exit":
@@ -205,23 +204,23 @@ def may_unstable_func(event=None):
 
 def test_may_segfault():
     with pytest.raises(GEOSException, match="GEOS crashed with exit code"):
-        may_unstable_func("segfault")
+        may_segfault(my_unstable_func)("segfault")
 
 
 def test_may_segfault_exit():
     with pytest.raises(GEOSException, match="GEOS crashed with exit code 1."):
-        may_unstable_func("exit")
+        may_segfault(my_unstable_func)("exit")
 
 
 def test_may_segfault_raises():
     with pytest.raises(ValueError, match="This is a test"):
-        may_unstable_func("raise")
+        may_segfault(my_unstable_func)("raise")
 
 
 def test_may_segfault_returns():
-    assert may_unstable_func("return") == "This is a test"
+    assert may_segfault(my_unstable_func)("return") == "This is a test"
 
 
 def test_may_segfault_warns():
     with pytest.warns(RuntimeWarning, match="This is a test"):
-        may_unstable_func("warn")
+        may_segfault(my_unstable_func)("warn")

--- a/pygeos/tests/test_misc.py
+++ b/pygeos/tests/test_misc.py
@@ -189,45 +189,39 @@ def test_multithreading_enabled_ok(args, kwargs):
     assert result[0] == 42
 
 
-def test_may_segfault():
-    @may_segfault
-    def my_func():
+@may_segfault
+def may_unstable_func(event=None):
+    if event == "segfault":
         ctypes.string_at(0)  # segfault
+    elif event == "exit":
+        exit(1)
+    elif event == "raise":
+        raise ValueError("This is a test")
+    elif event == "warn":
+        warnings.warn("This is a test", RuntimeWarning)
+    elif event == "return":
+        return "This is a test"
 
+
+def test_may_segfault():
     with pytest.raises(GEOSException, match="GEOS crashed with exit code"):
-        my_func()
+        may_unstable_func("segfault")
 
 
 def test_may_segfault_exit():
-    @may_segfault
-    def my_func():
-        exit(1)
-
     with pytest.raises(GEOSException, match="GEOS crashed with exit code 1."):
-        my_func()
+        may_unstable_func("exit")
 
 
 def test_may_segfault_raises():
-    @may_segfault
-    def my_func():
-        raise GEOSException("This is a test")
-
-    with pytest.raises(GEOSException, match="This is a test"):
-        my_func()
+    with pytest.raises(ValueError, match="This is a test"):
+        may_unstable_func("raise")
 
 
 def test_may_segfault_returns():
-    @may_segfault
-    def my_func():
-        return "This is a test"
-
-    assert my_func() == "This is a test"
+    assert may_unstable_func("return") == "This is a test"
 
 
 def test_may_segfault_warns():
-    @may_segfault
-    def my_func():
-        warnings.warn("This is a test", UserWarning)
-
-    with pytest.warns(UserWarning, match="This is a test"):
-        my_func()
+    with pytest.warns(RuntimeWarning, match="This is a test"):
+        may_unstable_func("warn")

--- a/pygeos/tests/test_misc.py
+++ b/pygeos/tests/test_misc.py
@@ -10,7 +10,8 @@ import numpy as np
 import pytest
 
 import pygeos
-from pygeos.decorators import may_segfault, multithreading_enabled, requires_geos
+from pygeos.decorators import multithreading_enabled, requires_geos
+from pygeos.may_segfault import may_segfault
 
 
 @pytest.fixture


### PR DESCRIPTION
In #413  we concluded that from_geojson segfaults for some inputs only when GEOS is built in Debug mode.

Now, a CI failed (https://github.com/pygeos/pygeos/runs/4059627215?check_suite_focus=true) which builds GEOS in Release mode. So I think it is best to stay on the safe side and reinstate the segfault protection here.

Related GEOS Ticket has been solved in main already:
- https://trac.osgeo.org/geos/ticket/1138
- https://github.com/libgeos/geos/pull/498

 