### PR TITLE
Revert Win32 CI version for faster builds

### DIFF
--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -47,9 +47,9 @@ jobs:
             numpy: 1.13.3
           - os: windows-2019
             architecture: x86
-            python: "3.10"
+            python: 3.9
             geos: 3.10.0
-            numpy: 1.21.3
+            numpy: 1.19.5
 
     env:
       GEOS_VERSION: ${{ matrix.geos }}


### PR DESCRIPTION
I noticed that Python 3.10 is not available on the win32 test runner and that numpy 1.21.3 doesn't supply a wheels for win32.

So I reverted the versions a bit to speed up our build process.