### PR TITLE
BUG: Fix STRtree memory leaks

### DIFF
--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -3,16 +3,31 @@
 # Then run the pytest suite with valgrind enabled:
 # docker run --rm pygeos/valgrind:latest valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output python -m pytest -vv --valgrind --valgrind-log=/tmp/valgrind-output > valgrind.log
 
-FROM python:3.6-stretch
 
-RUN apt-get update && apt-get install -y valgrind libgeos-dev --no-install-recommends
+FROM python:3.9-slim-buster
 
-RUN pip install numpy Cython pytest pytest-valgrind
+RUN apt-get update && apt-get install -y build-essential valgrind curl --no-install-recommends
 
-COPY . /code
+RUN pip install cmake numpy Cython pytest pytest-valgrind
 
 WORKDIR /code
 
-RUN python setup.py build_ext --inplace
-
 ENV PYTHONMALLOC malloc
+
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+# Build GEOS
+RUN export GEOS_VERSION=3.10.1 && \
+    mkdir /code/geos && cd /code/geos && \
+    curl -OL http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2 && \
+    tar xfj geos-$GEOS_VERSION.tar.bz2 && \
+    cd geos-$GEOS_VERSION && mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib .. && \
+    cmake --build . -j 4 && \
+    cmake --install . && \
+    cd /code
+
+COPY . /code
+
+# Build pygeos
+RUN python setup.py build_ext --inplace && python setup.py install

--- a/pygeos/tests/test_strtree.py
+++ b/pygeos/tests/test_strtree.py
@@ -237,14 +237,39 @@ def test_query_prepared_inputs(tree, predicate, expected):
             "intersects",
             marks=pytest.mark.xfail(reason="intersects does not raise exception"),
         ),
-        "within",
-        "contains",
+        pytest.param(
+            "within",
+            marks=pytest.mark.xfail(
+                pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8"
+            ),
+        ),
+        pytest.param(
+            "contains",
+            marks=pytest.mark.xfail(
+                pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8"
+            ),
+        ),
         "overlaps",
         "crosses",
         "touches",
-        "covers",
-        "covered_by",
-        "contains_properly",
+        pytest.param(
+            "covers",
+            marks=pytest.mark.xfail(
+                pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8"
+            ),
+        ),
+        pytest.param(
+            "covered_by",
+            marks=pytest.mark.xfail(
+                pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8"
+            ),
+        ),
+        pytest.param(
+            "contains_properly",
+            marks=pytest.mark.xfail(
+                pygeos.geos_version < (3, 8, 0), reason="GEOS < 3.8"
+            ),
+        ),
     ],
 )
 def test_query_predicate_errors(tree, predicate):

--- a/pygeos/tests/test_strtree.py
+++ b/pygeos/tests/test_strtree.py
@@ -211,9 +211,45 @@ def test_query_unsupported_predicate(tree):
         tree.query(pygeos.points(1, 1), predicate="disjoint")
 
 
-def test_query_predicate_errors(tree):
+@pytest.mark.parametrize(
+    "predicate,expected",
+    [
+        ("intersects", [0, 1, 2]),
+        ("within", []),
+        ("contains", [1]),
+        ("overlaps", []),
+        ("crosses", []),
+        ("covers", [0, 1, 2]),
+        ("covered_by", []),
+        ("contains_properly", [1]),
+    ],
+)
+def test_query_prepared_inputs(tree, predicate, expected):
+    geom = box(0, 0, 2, 2)
+    pygeos.prepare(geom)
+    assert_array_equal(tree.query(geom, predicate=predicate), expected)
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        pytest.param(
+            "intersects",
+            marks=pytest.mark.xfail(reason="intersects does not raise exception"),
+        ),
+        "within",
+        "contains",
+        "overlaps",
+        "crosses",
+        "touches",
+        "covers",
+        "covered_by",
+        "contains_properly",
+    ],
+)
+def test_query_predicate_errors(tree, predicate):
     with pytest.raises(pygeos.GEOSException):
-        tree.query(pygeos.linestrings([1, 1], [1, float("nan")]), predicate="touches")
+        tree.query(pygeos.linestrings([1, 1], [1, float("nan")]), predicate=predicate)
 
 
 def test_query_tree_with_none():
@@ -1187,6 +1223,13 @@ def test_query_bulk_intersects_lines(line_tree, geometry, expected):
 )
 def test_query_bulk_intersects_polygons(poly_tree, geometry, expected):
     assert_array_equal(poly_tree.query_bulk(geometry, predicate="intersects"), expected)
+
+
+def test_query_bulk_predicate_errors(tree):
+    with pytest.raises(pygeos.GEOSException):
+        tree.query_bulk(
+            [pygeos.linestrings([1, 1], [1, float("nan")])], predicate="touches"
+        )
 
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 6, 0), reason="GEOS < 3.6")


### PR DESCRIPTION
This fixes a couple memory leaks lurking in our tests and moves cleanup of some of the vectors we create during tree operations so that they are correctly cleaned up (hopefully; our tests don't cover these all).

This updates the `Dockerfile.valgrind` to build GEOS 3.10, so we can test against the latest features.

This also uncovered what looks like a memory leak in GEOS related to prepared geometry predicates, when those geometries have nan coordinates.  These memory leaks are present in our latest valgrind results, e.g.,

```

Valgrind has detected a memory leak:

**1** 
**1** **********************************************************************
**1** pygeos/tests/test_strtree.py::test_query_predicate_errors[touches]
**1** **********************************************************************
==1== 104 (+104) bytes in 1 (+1) blocks are definitely lost in loss record 10,171 of 17,899
==1==    at 0x4835DEF: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1==    by 0x8F5F1A8: geos::operation::relate::EdgeEndBuilder::createEdgeEndForPrev(geos::geomgraph::Edge*, std::vector<geos::geomgraph::EdgeEnd*, std::allocator<geos::geomgraph::EdgeEnd*> >*, geos::geomgraph::EdgeIntersection const*, geos::geomgraph::EdgeIntersection const*) (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8F5F418: geos::operation::relate::EdgeEndBuilder::computeEdgeEnds(geos::geomgraph::Edge*, std::vector<geos::geomgraph::EdgeEnd*, std::allocator<geos::geomgraph::EdgeEnd*> >*) (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8F5F6DD: geos::operation::relate::EdgeEndBuilder::computeEdgeEnds(std::vector<geos::geomgraph::Edge*, std::allocator<geos::geomgraph::Edge*> >*) (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8F61AD0: geos::operation::relate::RelateComputer::computeIM() (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8F62C3F: geos::operation::relate::RelateOp::getIntersectionMatrix() (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8F62C71: geos::operation::relate::RelateOp::relate(geos::geom::Geometry const*, geos::geom::Geometry const*) (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8E88608: geos::geom::Geometry::relate(geos::geom::Geometry const*) const (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8E88856: geos::geom::Geometry::touches(geos::geom::Geometry const*) const (in /usr/local/lib/libgeos.so.3.10.1)
==1==    by 0x8D799C1: GEOSPreparedTouches_r (in /usr/local/lib/libgeos_c.so.1.16.0)
==1==    by 0x8D3C1A3: ??? (in /code/pygeos/lib.cpython-39-x86_64-linux-gnu.so)
==1==    by 0x8D3CEA3: ??? (in /code/pygeos/lib.cpython-39-x86_64-linux-gnu.so)
==1== 
==1== LEAK SUMMARY:
==1==    definitely lost: 3,904 (+104) bytes in 37 (+1) blocks
==1==    indirectly lost: 1,224 (+0) bytes in 14 (+0) blocks
==1==      possibly lost: 6,212,274 (+1,048) bytes in 59,365 (+7) blocks
==1==    still reachable: 16,105,356 (+7,175) bytes in 112,594 (+70) blocks
==1==                       of which reachable via heuristic:
==1==                         newarray           : 544 (+0) bytes in 33 (+0) blocks
==1==         suppressed: 0 (+0) bytes in 0 (+0) blocks
==1== Reachable blocks (those to which a pointer was found) are not shown.
==1== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==1== 
**1** 
**1** **********************************************************************
```


Interestingly, the `intersects` predicate does not fail for linestrings with nan coordinates, so I have that marked as an xfail for now.  