### PR TITLE
PERF: Use GEOSCoordSeq_copyFromBuffer for creating simple geometries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Version 0.12 (unreleased)
   to find geometries within a search distance for GEOS >= 3.10 (#425).
 * Added GeoJSON input/output capabilities (``pygeos.from_geojson``,
   ``pygeos.to_geojson``) for GEOS >= 3.10 (#413).
+* Performance improvement in constructing LineStrings or LinearRings from
+  numpy arrays for GEOS >= 3.10 (#436)
 
 **API Changes**
 

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -38,22 +38,11 @@ from pygeos._pygeos_api cimport (
     import_pygeos_c_api,
     PyGEOS_CreateGeometry,
     PyGEOS_GetGEOSGeometry,
+    PyGEOSCoordSeq_FromBuffer,
 )
 
 # initialize PyGEOS C API
 import_pygeos_c_api()
-
-
-cdef char _set_xyz(GEOSContextHandle_t geos_handle, GEOSCoordSequence *seq, unsigned int coord_idx,
-                   unsigned int dims, double[:, :] coord_view, Py_ssize_t idx):
-    if GEOSCoordSeq_setX_r(geos_handle, seq, coord_idx, coord_view[idx, 0]) == 0:
-        return 0
-    if GEOSCoordSeq_setY_r(geos_handle, seq, coord_idx, coord_view[idx, 1]) == 0:
-        return 0
-    if dims == 3:
-        if GEOSCoordSeq_setZ_r(geos_handle, seq, coord_idx, coord_view[idx, 2]) == 0:
-            return 0
-    return 1
 
 
 def _check_out_array(object out, Py_ssize_t size):
@@ -75,17 +64,16 @@ def _check_out_array(object out, Py_ssize_t size):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def simple_geometries_1d(object coordinates, object indices, int geometry_type, object out = None):
-    cdef Py_ssize_t idx = 0
+    cdef Py_ssize_t idx = 0, flat_idx = 0
     cdef unsigned int coord_idx = 0
     cdef Py_ssize_t geom_idx = 0
     cdef unsigned int geom_size = 0
     cdef unsigned int ring_closure = 0
-    cdef Py_ssize_t coll_geom_idx = 0
     cdef GEOSGeometry *geom = NULL
     cdef GEOSCoordSequence *seq = NULL
 
     # Cast input arrays and define memoryviews for later usage
-    coordinates = np.asarray(coordinates, dtype=np.float64)
+    coordinates = np.asarray(coordinates, dtype=np.float64, order="C")
     if coordinates.ndim != 2:
         raise TypeError("coordinates must be a two-dimensional array.")
 
@@ -99,7 +87,6 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
     cdef unsigned int dims = coordinates.shape[1]
     if dims not in {2, 3}:
         raise ValueError("coordinates should N by 2 or N by 3.")
-    cdef int has_z = int(dims == 3)
 
     if geometry_type not in {0, 1, 2}:
         raise ValueError(f"Invalid geometry_type: {geometry_type}.")
@@ -111,7 +98,7 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
     if np.any(indices[1:] < indices[:indices.shape[0] - 1]):
         raise ValueError("The indices must be sorted.")  
 
-    cdef double[:] coord_view = coordinates.ravel()
+    cdef double[:, :] coord_view = coordinates
 
     # get the geometry count per collection (this raises on negative indices)
     cdef unsigned int[:] coord_counts = np.bincount(indices).astype(np.uint32)
@@ -136,30 +123,22 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
                         f"Index {geom_idx} is missing from the input indices."
                     )
 
-            # # check if we need to close a linearring
-            # if geometry_type == 2:
-            #     ring_closure = 0
-            #     if geom_size == 3:
-            #         ring_closure = 1
-            #     else:
-            #         for coord_idx in range(dims):
-            #             if coord_view[idx, coord_idx] != coord_view[idx + geom_size - 1, coord_idx]:
-            #                 ring_closure = 1
-            #                 break
-            #     # check the resulting size to prevent invalid rings
-            #     if geom_size + ring_closure < 4:
-            #         # the error equals PGERR_LINEARRING_NCOORDS (in pygeos/src/geos.h)
-            #         raise ValueError("A linearring requires at least 4 coordinates.")
+            # check if we need to close a linearring
+            if geometry_type == 2:
+                ring_closure = 0
+                if geom_size == 3:
+                    ring_closure = 1
+                else:
+                    for coord_idx in range(dims):
+                        if coord_view[idx, coord_idx] != coord_view[idx + (geom_size - 1), coord_idx]:
+                            ring_closure = 1
+                            break
+                # check the resulting size to prevent invalid rings
+                if geom_size + ring_closure < 4:
+                    # the error equals PGERR_LINEARRING_NCOORDS (in pygeos/src/geos.h)
+                    raise ValueError("A linearring requires at least 4 coordinates.")
 
-            # seq = GEOSCoordSeq_create_r(geos_handle, geom_size + ring_closure, dims)
-            # for coord_idx in range(geom_size):
-            #     if _set_xyz(geos_handle, seq, coord_idx, dims, coord_view, idx) == 0:
-            #         GEOSCoordSeq_destroy_r(geos_handle, seq)
-            #         return  # GEOSException is raised by get_geos_handle
-            #     idx += 1
-
-            seq = GEOSCoordSeq_copyFromBuffer_r(geos_handle, &coord_view[idx*dims], geom_size, has_z, 0)
-
+            seq = PyGEOSCoordSeq_FromBuffer(geos_handle, &coord_view[idx, 0], geom_size, dims, ring_closure)
             if seq == NULL:
                 return  # GEOSException is raised by get_geos_handle
             idx += geom_size
@@ -169,10 +148,6 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
             elif geometry_type == 1:
                 geom = GEOSGeom_createLineString_r(geos_handle, seq)
             elif geometry_type == 2:
-                # if ring_closure == 1:
-                #     if _set_xyz(geos_handle, seq, geom_size, dims, coord_view, idx - geom_size) == 0:
-                #         GEOSCoordSeq_destroy_r(geos_handle, seq)
-                #         return  # GEOSException is raised by get_geos_handle
                 geom = GEOSGeom_createLinearRing_r(geos_handle, seq)
 
             if geom == NULL:

--- a/pygeos/_geometry.pyx
+++ b/pygeos/_geometry.pyx
@@ -12,12 +12,6 @@ import pygeos
 
 from pygeos._geos cimport (
     GEOSContextHandle_t,
-    GEOSCoordSeq_copyFromBuffer_r,
-    GEOSCoordSeq_create_r,
-    GEOSCoordSeq_destroy_r,
-    GEOSCoordSeq_setX_r,
-    GEOSCoordSeq_setY_r,
-    GEOSCoordSeq_setZ_r,
     GEOSCoordSequence,
     GEOSGeom_clone_r,
     GEOSGeom_createCollection_r,
@@ -36,9 +30,9 @@ from pygeos._geos cimport (
 )
 from pygeos._pygeos_api cimport (
     import_pygeos_c_api,
+    PyGEOS_CoordSeq_FromBuffer,
     PyGEOS_CreateGeometry,
     PyGEOS_GetGEOSGeometry,
-    PyGEOSCoordSeq_FromBuffer,
 )
 
 # initialize PyGEOS C API
@@ -64,7 +58,7 @@ def _check_out_array(object out, Py_ssize_t size):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def simple_geometries_1d(object coordinates, object indices, int geometry_type, object out = None):
-    cdef Py_ssize_t idx = 0, flat_idx = 0
+    cdef Py_ssize_t idx = 0
     cdef unsigned int coord_idx = 0
     cdef Py_ssize_t geom_idx = 0
     cdef unsigned int geom_size = 0
@@ -130,7 +124,7 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
                     ring_closure = 1
                 else:
                     for coord_idx in range(dims):
-                        if coord_view[idx, coord_idx] != coord_view[idx + (geom_size - 1), coord_idx]:
+                        if coord_view[idx, coord_idx] != coord_view[idx + geom_size - 1, coord_idx]:
                             ring_closure = 1
                             break
                 # check the resulting size to prevent invalid rings
@@ -138,7 +132,7 @@ def simple_geometries_1d(object coordinates, object indices, int geometry_type, 
                     # the error equals PGERR_LINEARRING_NCOORDS (in pygeos/src/geos.h)
                     raise ValueError("A linearring requires at least 4 coordinates.")
 
-            seq = PyGEOSCoordSeq_FromBuffer(geos_handle, &coord_view[idx, 0], geom_size, dims, ring_closure)
+            seq = PyGEOS_CoordSeq_FromBuffer(geos_handle, &coord_view[idx, 0], geom_size, dims, ring_closure)
             if seq == NULL:
                 return  # GEOSException is raised by get_geos_handle
             idx += geom_size

--- a/pygeos/_geos.pxd
+++ b/pygeos/_geos.pxd
@@ -42,7 +42,6 @@ cdef extern from "geos_c.h":
     int GEOSCoordSeq_setX_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int idx, double val) nogil
     int GEOSCoordSeq_setY_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int idx, double val) nogil
     int GEOSCoordSeq_setZ_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int idx, double val) nogil
-    GEOSCoordSequence* GEOSCoordSeq_copyFromBuffer_r(GEOSContextHandle_t handle, const double* buf, unsigned int size, int hasZ, int hasM)
 
 
 cdef class get_geos_handle:

--- a/pygeos/_geos.pxd
+++ b/pygeos/_geos.pxd
@@ -42,6 +42,7 @@ cdef extern from "geos_c.h":
     int GEOSCoordSeq_setX_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int idx, double val) nogil
     int GEOSCoordSeq_setY_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int idx, double val) nogil
     int GEOSCoordSeq_setZ_r(GEOSContextHandle_t handle, GEOSCoordSequence* s, unsigned int idx, double val) nogil
+    GEOSCoordSequence* GEOSCoordSeq_copyFromBuffer_r(GEOSContextHandle_t handle, const double* buf, unsigned int size, int hasZ, int hasM)
 
 
 cdef class get_geos_handle:

--- a/pygeos/_pygeos_api.pxd
+++ b/pygeos/_pygeos_api.pxd
@@ -16,7 +16,7 @@ Segfaults will occur if the C API is not imported properly.
 cimport numpy as np
 from cpython.ref cimport PyObject
 
-from pygeos._geos cimport GEOSContextHandle_t, GEOSGeometry
+from pygeos._geos cimport GEOSContextHandle_t, GEOSCoordSequence, GEOSGeometry
 
 
 cdef extern from "c_api.h":
@@ -30,3 +30,6 @@ cdef extern from "c_api.h":
     # they are declared that way in the header file).
     object PyGEOS_CreateGeometry(GEOSGeometry *ptr, GEOSContextHandle_t ctx)
     char PyGEOS_GetGEOSGeometry(PyObject *obj, GEOSGeometry **out) nogil
+    GEOSCoordSequence* PyGEOSCoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
+                                                 unsigned int size, unsigned int dims,
+                                                 char ring_closure) nogil

--- a/pygeos/_pygeos_api.pxd
+++ b/pygeos/_pygeos_api.pxd
@@ -30,6 +30,6 @@ cdef extern from "c_api.h":
     # they are declared that way in the header file).
     object PyGEOS_CreateGeometry(GEOSGeometry *ptr, GEOSContextHandle_t ctx)
     char PyGEOS_GetGEOSGeometry(PyObject *obj, GEOSGeometry **out) nogil
-    GEOSCoordSequence* PyGEOSCoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
+    GEOSCoordSequence* PyGEOS_CoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
                                                  unsigned int size, unsigned int dims,
                                                  char ring_closure) nogil

--- a/pygeos/tests/test_creation.py
+++ b/pygeos/tests/test_creation.py
@@ -163,6 +163,20 @@ def test_linearrings_all_nan():
         pygeos.linearrings(coords)
 
 
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_linearrings_buffer(dim, order):
+    coords1 = np.random.randn(10, 4, dim)
+    coords1 = np.asarray(coords1, order=order)
+    result1 = pygeos.linearrings(coords1)
+
+    # with manual closure -> can directly copy from buffer if C order
+    coords2 = np.hstack((coords1, coords1[:, [0], :]))
+    coords2 = np.asarray(coords2, order=order)
+    result2 = pygeos.linearrings(coords2)
+    assert_geometries_equal(result1, result2)
+
+
 def test_polygon_from_linearring():
     actual = pygeos.polygons(pygeos.linearrings(box_tpl(0, 0, 1, 1)))
     assert_geometries_equal(

--- a/pygeos/tests/test_creation.py
+++ b/pygeos/tests/test_creation.py
@@ -176,6 +176,11 @@ def test_linearrings_buffer(dim, order):
     result2 = pygeos.linearrings(coords2)
     assert_geometries_equal(result1, result2)
 
+    # create scalar -> can also directly copy from buffer if F order
+    coords3 = np.asarray(coords2[0], order=order)
+    result3 = pygeos.linearrings(coords3)
+    assert_geometries_equal(result3, result1[0])
+
 
 def test_polygon_from_linearring():
     actual = pygeos.polygons(pygeos.linearrings(box_tpl(0, 0, 1, 1)))

--- a/pygeos/tests/test_creation_indices.py
+++ b/pygeos/tests/test_creation_indices.py
@@ -222,6 +222,22 @@ def test_linearrings_out(indices, expected):
     assert actual is out
 
 
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_linearrings_buffer(dim, order):
+    coords = np.random.randn(10, 4, dim)
+    coords1 = np.asarray(coords.reshape(10 * 4, dim), order=order)
+    indices1 = np.repeat(range(10), 4)
+    result1 = pygeos.linearrings(coords1, indices=indices1)
+
+    # with manual closure -> can directly copy from buffer if C order
+    coords2 = np.hstack((coords, coords[:, [0], :]))
+    coords2 = np.asarray(coords2.reshape(10 * 5, dim), order=order)
+    indices2 = np.repeat(range(10), 5)
+    result2 = pygeos.linearrings(coords2, indices=indices2)
+    assert_geometries_equal(result1, result2)
+
+
 hole_1 = pygeos.linearrings([(0.2, 0.2), (0.2, 0.4), (0.4, 0.4)])
 hole_2 = pygeos.linearrings([(0.6, 0.6), (0.6, 0.8), (0.8, 0.8)])
 poly = pygeos.polygons(linear_ring)

--- a/src/c_api.c
+++ b/src/c_api.c
@@ -24,3 +24,8 @@ extern PyObject* PyGEOS_CreateGeometry(GEOSGeometry *ptr, GEOSContextHandle_t ct
 extern char PyGEOS_GetGEOSGeometry(PyObject *obj, GEOSGeometry **out) {
     return get_geom((GeometryObject*)obj, out);
 }
+
+extern GEOSCoordSequence* PyGEOSCoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
+                                                    unsigned int size, unsigned int dims, char ring_closure) {
+    return coordseq_from_buffer(ctx, buf, size, dims, ring_closure, dims * 8, 8);
+}

--- a/src/c_api.c
+++ b/src/c_api.c
@@ -25,7 +25,7 @@ extern char PyGEOS_GetGEOSGeometry(PyObject *obj, GEOSGeometry **out) {
     return get_geom((GeometryObject*)obj, out);
 }
 
-extern GEOSCoordSequence* PyGEOSCoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
+extern GEOSCoordSequence* PyGEOS_CoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
                                                     unsigned int size, unsigned int dims, char ring_closure) {
     return coordseq_from_buffer(ctx, buf, size, dims, ring_closure, dims * 8, 8);
 }

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -32,11 +32,11 @@
 #define PyGEOS_GetGEOSGeometry_RETURN char
 #define PyGEOS_GetGEOSGeometry_PROTO (PyObject * obj, GEOSGeometry * *out)
 
-/* GEOSCoordSequence* PyGEOSCoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
+/* GEOSCoordSequence* PyGEOS_CoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
                                                 unsigned int size, unsigned int dims, char ring_closure)*/
-#define PyGEOSCoordSeq_FromBuffer_NUM 2
-#define PyGEOSCoordSeq_FromBuffer_RETURN GEOSCoordSequence*
-#define PyGEOSCoordSeq_FromBuffer_PROTO (GEOSContextHandle_t ctx, const double* buf, unsigned int size, unsigned int dims, char ring_closure)
+#define PyGEOS_CoordSeq_FromBuffer_NUM 2
+#define PyGEOS_CoordSeq_FromBuffer_RETURN GEOSCoordSequence*
+#define PyGEOS_CoordSeq_FromBuffer_PROTO (GEOSContextHandle_t ctx, const double* buf, unsigned int size, unsigned int dims, char ring_closure)
 
 /* Total number of C API pointers */
 #define PyGEOS_API_num_pointers 3
@@ -48,7 +48,7 @@
 
 extern PyGEOS_CreateGeometry_RETURN PyGEOS_CreateGeometry PyGEOS_CreateGeometry_PROTO;
 extern PyGEOS_GetGEOSGeometry_RETURN PyGEOS_GetGEOSGeometry PyGEOS_GetGEOSGeometry_PROTO;
-extern PyGEOSCoordSeq_FromBuffer_RETURN PyGEOSCoordSeq_FromBuffer PyGEOSCoordSeq_FromBuffer_PROTO;
+extern PyGEOS_CoordSeq_FromBuffer_RETURN PyGEOS_CoordSeq_FromBuffer PyGEOS_CoordSeq_FromBuffer_PROTO;
 
 #else
 /* This section is used in modules that use the PyGEOS C API
@@ -64,8 +64,8 @@ static void **PyGEOS_API;
 #define PyGEOS_GetGEOSGeometry \
     (*(PyGEOS_GetGEOSGeometry_RETURN(*) PyGEOS_GetGEOSGeometry_PROTO)PyGEOS_API[PyGEOS_GetGEOSGeometry_NUM])
 
-#define PyGEOSCoordSeq_FromBuffer \
-    (*(PyGEOSCoordSeq_FromBuffer_RETURN(*) PyGEOSCoordSeq_FromBuffer_PROTO)PyGEOS_API[PyGEOSCoordSeq_FromBuffer_NUM])
+#define PyGEOS_CoordSeq_FromBuffer \
+    (*(PyGEOS_CoordSeq_FromBuffer_RETURN(*) PyGEOS_CoordSeq_FromBuffer_PROTO)PyGEOS_API[PyGEOS_CoordSeq_FromBuffer_NUM])
 
 /* Dynamically load C API from PyCapsule.
  * This MUST be called prior to using C API functions in other modules; otherwise

--- a/src/c_api.h
+++ b/src/c_api.h
@@ -32,8 +32,14 @@
 #define PyGEOS_GetGEOSGeometry_RETURN char
 #define PyGEOS_GetGEOSGeometry_PROTO (PyObject * obj, GEOSGeometry * *out)
 
+/* GEOSCoordSequence* PyGEOSCoordSeq_FromBuffer(GEOSContextHandle_t ctx, const double* buf,
+                                                unsigned int size, unsigned int dims, char ring_closure)*/
+#define PyGEOSCoordSeq_FromBuffer_NUM 2
+#define PyGEOSCoordSeq_FromBuffer_RETURN GEOSCoordSequence*
+#define PyGEOSCoordSeq_FromBuffer_PROTO (GEOSContextHandle_t ctx, const double* buf, unsigned int size, unsigned int dims, char ring_closure)
+
 /* Total number of C API pointers */
-#define PyGEOS_API_num_pointers 2
+#define PyGEOS_API_num_pointers 3
 
 #ifdef PyGEOS_API_Module
 /* This section is used when compiling pygeos.lib C extension.
@@ -42,6 +48,7 @@
 
 extern PyGEOS_CreateGeometry_RETURN PyGEOS_CreateGeometry PyGEOS_CreateGeometry_PROTO;
 extern PyGEOS_GetGEOSGeometry_RETURN PyGEOS_GetGEOSGeometry PyGEOS_GetGEOSGeometry_PROTO;
+extern PyGEOSCoordSeq_FromBuffer_RETURN PyGEOSCoordSeq_FromBuffer PyGEOSCoordSeq_FromBuffer_PROTO;
 
 #else
 /* This section is used in modules that use the PyGEOS C API
@@ -56,6 +63,9 @@ static void **PyGEOS_API;
 
 #define PyGEOS_GetGEOSGeometry \
     (*(PyGEOS_GetGEOSGeometry_RETURN(*) PyGEOS_GetGEOSGeometry_PROTO)PyGEOS_API[PyGEOS_GetGEOSGeometry_NUM])
+
+#define PyGEOSCoordSeq_FromBuffer \
+    (*(PyGEOSCoordSeq_FromBuffer_RETURN(*) PyGEOSCoordSeq_FromBuffer_PROTO)PyGEOS_API[PyGEOSCoordSeq_FromBuffer_NUM])
 
 /* Dynamically load C API from PyCapsule.
  * This MUST be called prior to using C API functions in other modules; otherwise

--- a/src/geos.c
+++ b/src/geos.c
@@ -886,16 +886,14 @@ GEOSCoordSequence* coordseq_from_buffer(GEOSContextHandle_t ctx, const double* b
                                         unsigned int size, unsigned int dims, char ring_closure,
                                         npy_intp cs1, npy_intp cs2) {
   GEOSCoordSequence* coord_seq;
-  // unsigned int dims = 2 + hasZ;
-  int hasZ = dims == 3;
-  char* cp1;
-  char* cp2;
-  int i, j;
-  double first_coord, last_coord;
+  char *cp1, *cp2;
+  unsigned int i, j;
+  double first_coord;
 
 #if GEOS_SINCE_3_10_0
 
   if ((!ring_closure) && (cs1 == dims * 8) && (cs2 == 8)) {
+    int hasZ = dims == 3;
     coord_seq = GEOSCoordSeq_copyFromBuffer_r(ctx, buf, size, hasZ, 0);
     return coord_seq;
   }

--- a/src/geos.c
+++ b/src/geos.c
@@ -4,8 +4,10 @@
 #include "geos.h"
 
 #include <Python.h>
+#include <numpy/ndarraytypes.h>
 #include <numpy/npy_math.h>
 #include <structmember.h>
+#include <stdio.h>
 
 /* This initializes a globally accessible GEOSException object */
 PyObject* geos_exception[1] = {NULL};
@@ -879,4 +881,56 @@ GEOSGeometry* PyGEOSForce2D(GEOSContextHandle_t ctx, GEOSGeometry* geom) {
 
 GEOSGeometry* PyGEOSForce3D(GEOSContextHandle_t ctx, GEOSGeometry* geom, double z) {
   return force_dims(ctx, geom, 3, z);
+}
+
+GEOSCoordSequence* PyGEOSCoordSeq_copyFromBuffer(GEOSContextHandle_t ctx, const double* buf,
+                                                 unsigned int size, unsigned int dims, char ring_closure,
+                                                 npy_intp cs1, npy_intp cs2) {
+  GEOSCoordSequence* coord_seq;
+  // unsigned int dims = 2 + hasZ;
+  int hasZ = dims == 3;
+  char* cp1;
+  char* cp2;
+  int i, j;
+  double first_coord, last_coord;
+  // printf("Shape: %d, %d \n", (int)size, (int)dims);
+  // printf("Steps: %d, %d \n", (int)cs1, (int)cs2);
+  // printf("Args: %d, %d\n", hasZ, ring_closure);
+  // printf("Args: %d, %d, %d\n", size, dims, ring_closure);
+
+#if GEOS_SINCE_3_10_0
+
+  if ((!ring_closure) && (cs1 == dims * 8) && (cs2 == 8)) {
+    printf("Going to call GEOSCoordSeq_copyFromBuffer_r\n");
+    coord_seq = GEOSCoordSeq_copyFromBuffer_r(ctx, buf, size, hasZ, 0);
+    return coord_seq;
+  }
+
+#endif
+
+  coord_seq = GEOSCoordSeq_create_r(ctx, size + ring_closure, dims);
+  if (coord_seq == NULL) {
+    return NULL;
+  }
+  cp1 = (char*)buf;
+  for (i = 0; i < size; i++, cp1 += cs1) {
+    cp2 = cp1;
+    for (j = 0; j < dims; j++, cp2 += cs2) {
+      if (!GEOSCoordSeq_setOrdinate_r(ctx, coord_seq, i, j, *(double*)cp2)) {
+        GEOSCoordSeq_destroy_r(ctx, coord_seq);
+        return NULL;
+      }
+    }
+  }
+  /* add the closing coordinate if necessary */
+  if (ring_closure) {
+    for (j = 0; j < dims; j++){
+      first_coord = *(double*)((char*)buf + j * cs2);
+      if (!GEOSCoordSeq_setOrdinate_r(ctx, coord_seq, size, j, first_coord)) {
+        GEOSCoordSeq_destroy_r(ctx, coord_seq);
+        return NULL;
+      }
+    }
+  }
+  return coord_seq;
 }

--- a/src/geos.c
+++ b/src/geos.c
@@ -7,7 +7,6 @@
 #include <numpy/ndarraytypes.h>
 #include <numpy/npy_math.h>
 #include <structmember.h>
-#include <stdio.h>
 
 /* This initializes a globally accessible GEOSException object */
 PyObject* geos_exception[1] = {NULL};
@@ -883,9 +882,9 @@ GEOSGeometry* PyGEOSForce3D(GEOSContextHandle_t ctx, GEOSGeometry* geom, double 
   return force_dims(ctx, geom, 3, z);
 }
 
-GEOSCoordSequence* PyGEOSCoordSeq_copyFromBuffer(GEOSContextHandle_t ctx, const double* buf,
-                                                 unsigned int size, unsigned int dims, char ring_closure,
-                                                 npy_intp cs1, npy_intp cs2) {
+GEOSCoordSequence* coordseq_from_buffer(GEOSContextHandle_t ctx, const double* buf,
+                                        unsigned int size, unsigned int dims, char ring_closure,
+                                        npy_intp cs1, npy_intp cs2) {
   GEOSCoordSequence* coord_seq;
   // unsigned int dims = 2 + hasZ;
   int hasZ = dims == 3;
@@ -893,15 +892,10 @@ GEOSCoordSequence* PyGEOSCoordSeq_copyFromBuffer(GEOSContextHandle_t ctx, const 
   char* cp2;
   int i, j;
   double first_coord, last_coord;
-  // printf("Shape: %d, %d \n", (int)size, (int)dims);
-  // printf("Steps: %d, %d \n", (int)cs1, (int)cs2);
-  // printf("Args: %d, %d\n", hasZ, ring_closure);
-  // printf("Args: %d, %d, %d\n", size, dims, ring_closure);
 
 #if GEOS_SINCE_3_10_0
 
   if ((!ring_closure) && (cs1 == dims * 8) && (cs2 == 8)) {
-    printf("Going to call GEOSCoordSeq_copyFromBuffer_r\n");
     coord_seq = GEOSCoordSeq_copyFromBuffer_r(ctx, buf, size, hasZ, 0);
     return coord_seq;
   }

--- a/src/geos.h
+++ b/src/geos.h
@@ -2,6 +2,7 @@
 #define _GEOS_H
 
 #include <Python.h>
+#include <numpy/ndarraytypes.h>
 
 /* To avoid accidental use of non reentrant GEOS API. */
 #ifndef GEOS_USE_ONLY_R_API
@@ -175,5 +176,9 @@ GEOSGeometry* create_box(GEOSContextHandle_t ctx, double xmin, double ymin, doub
 GEOSGeometry* create_point(GEOSContextHandle_t ctx, double x, double y);
 GEOSGeometry* PyGEOSForce2D(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 GEOSGeometry* PyGEOSForce3D(GEOSContextHandle_t ctx, GEOSGeometry* geom, double z);
+
+GEOSCoordSequence* PyGEOSCoordSeq_copyFromBuffer(GEOSContextHandle_t ctx, const double* buf,
+                                                 unsigned int size, unsigned int dims, char ring_closure,
+                                                 npy_intp cs1, npy_intp cs2);
 
 #endif  // _GEOS_H

--- a/src/geos.h
+++ b/src/geos.h
@@ -177,8 +177,8 @@ GEOSGeometry* create_point(GEOSContextHandle_t ctx, double x, double y);
 GEOSGeometry* PyGEOSForce2D(GEOSContextHandle_t ctx, GEOSGeometry* geom);
 GEOSGeometry* PyGEOSForce3D(GEOSContextHandle_t ctx, GEOSGeometry* geom, double z);
 
-GEOSCoordSequence* PyGEOSCoordSeq_copyFromBuffer(GEOSContextHandle_t ctx, const double* buf,
-                                                 unsigned int size, unsigned int dims, char ring_closure,
-                                                 npy_intp cs1, npy_intp cs2);
+GEOSCoordSequence* coordseq_from_buffer(GEOSContextHandle_t ctx, const double* buf,
+                                        unsigned int size, unsigned int dims, char ring_closure,
+                                        npy_intp cs1, npy_intp cs2);
 
 #endif  // _GEOS_H

--- a/src/lib.c
+++ b/src/lib.c
@@ -89,6 +89,7 @@ PyMODINIT_FUNC PyInit_lib(void) {
   /* Initialize the C API pointer array */
   PyGEOS_API[PyGEOS_CreateGeometry_NUM] = (void*)PyGEOS_CreateGeometry;
   PyGEOS_API[PyGEOS_GetGEOSGeometry_NUM] = (void*)PyGEOS_GetGEOSGeometry;
+  PyGEOS_API[PyGEOSCoordSeq_FromBuffer_NUM] = (void*)PyGEOSCoordSeq_FromBuffer;
 
   /* Create a Capsule containing the API pointer array's address */
   c_api_object = PyCapsule_New((void*)PyGEOS_API, "pygeos.lib._C_API", NULL);

--- a/src/lib.c
+++ b/src/lib.c
@@ -89,7 +89,7 @@ PyMODINIT_FUNC PyInit_lib(void) {
   /* Initialize the C API pointer array */
   PyGEOS_API[PyGEOS_CreateGeometry_NUM] = (void*)PyGEOS_CreateGeometry;
   PyGEOS_API[PyGEOS_GetGEOSGeometry_NUM] = (void*)PyGEOS_GetGEOSGeometry;
-  PyGEOS_API[PyGEOSCoordSeq_FromBuffer_NUM] = (void*)PyGEOSCoordSeq_FromBuffer;
+  PyGEOS_API[PyGEOS_CoordSeq_FromBuffer_NUM] = (void*)PyGEOS_CoordSeq_FromBuffer;
 
   /* Create a Capsule containing the API pointer array's address */
   c_api_object = PyCapsule_New((void*)PyGEOS_API, "pygeos.lib._C_API", NULL);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2198,7 +2198,7 @@ static void linestrings_func(char** args, npy_intp* dimensions, npy_intp* steps,
   GEOS_INIT_THREADS;
 
   DOUBLE_COREDIM_LOOP_OUTER {
-    coord_seq = PyGEOSCoordSeq_copyFromBuffer(ctx, (double*)ip1, n_c1, n_c2, 0, cs1, cs2);
+    coord_seq = coordseq_from_buffer(ctx, (double*)ip1, n_c1, n_c2, 0, cs1, cs2);
     if (coord_seq == NULL) {
       errstate = PGERR_GEOS_EXCEPTION;
       destroy_geom_arr(ctx, geom_arr, i - 1);
@@ -2261,7 +2261,7 @@ static void linearrings_func(char** args, npy_intp* dimensions, npy_intp* steps,
       goto finish;
     }
     /* fill the coordinate sequence */
-    coord_seq = PyGEOSCoordSeq_copyFromBuffer(ctx, (double*)ip1, n_c1, n_c2, ring_closure, cs1, cs2);
+    coord_seq = coordseq_from_buffer(ctx, (double*)ip1, n_c1, n_c2, ring_closure, cs1, cs2);
     if (coord_seq == NULL) {
       errstate = PGERR_GEOS_EXCEPTION;
       destroy_geom_arr(ctx, geom_arr, i - 1);

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -2198,21 +2198,11 @@ static void linestrings_func(char** args, npy_intp* dimensions, npy_intp* steps,
   GEOS_INIT_THREADS;
 
   DOUBLE_COREDIM_LOOP_OUTER {
-    coord_seq = GEOSCoordSeq_create_r(ctx, n_c1, n_c2);
+    coord_seq = PyGEOSCoordSeq_copyFromBuffer(ctx, (double*)ip1, n_c1, n_c2, 0, cs1, cs2);
     if (coord_seq == NULL) {
       errstate = PGERR_GEOS_EXCEPTION;
       destroy_geom_arr(ctx, geom_arr, i - 1);
       goto finish;
-    }
-    DOUBLE_COREDIM_LOOP_INNER_1 {
-      DOUBLE_COREDIM_LOOP_INNER_2 {
-        if (!GEOSCoordSeq_setOrdinate_r(ctx, coord_seq, i_c1, i_c2, *(double*)cp2)) {
-          errstate = PGERR_GEOS_EXCEPTION;
-          GEOSCoordSeq_destroy_r(ctx, coord_seq);
-          destroy_geom_arr(ctx, geom_arr, i - 1);
-          goto finish;
-        }
-      }
     }
     geom_arr[i] = GEOSGeom_createLineString_r(ctx, coord_seq);
     // Note: coordinate sequence is owned by linestring; if linestring fails to construct,
@@ -2271,33 +2261,11 @@ static void linearrings_func(char** args, npy_intp* dimensions, npy_intp* steps,
       goto finish;
     }
     /* fill the coordinate sequence */
-    coord_seq = GEOSCoordSeq_create_r(ctx, n_c1 + ring_closure, n_c2);
+    coord_seq = PyGEOSCoordSeq_copyFromBuffer(ctx, (double*)ip1, n_c1, n_c2, ring_closure, cs1, cs2);
     if (coord_seq == NULL) {
       errstate = PGERR_GEOS_EXCEPTION;
       destroy_geom_arr(ctx, geom_arr, i - 1);
       goto finish;
-    }
-    DOUBLE_COREDIM_LOOP_INNER_1 {
-      DOUBLE_COREDIM_LOOP_INNER_2 {
-        if (!GEOSCoordSeq_setOrdinate_r(ctx, coord_seq, i_c1, i_c2, *(double*)cp2)) {
-          errstate = PGERR_GEOS_EXCEPTION;
-          GEOSCoordSeq_destroy_r(ctx, coord_seq);
-          destroy_geom_arr(ctx, geom_arr, i - 1);
-          goto finish;
-        }
-      }
-    }
-    /* add the closing coordinate if necessary */
-    if (ring_closure) {
-      DOUBLE_COREDIM_LOOP_INNER_2 {
-        first_coord = *(double*)(ip1 + i_c2 * cs2);
-        if (!GEOSCoordSeq_setOrdinate_r(ctx, coord_seq, n_c1, i_c2, first_coord)) {
-          errstate = PGERR_GEOS_EXCEPTION;
-          GEOSCoordSeq_destroy_r(ctx, coord_seq);
-          destroy_geom_arr(ctx, geom_arr, i - 1);
-          goto finish;
-        }
-      }
     }
     geom_arr[i] = GEOSGeom_createLinearRing_r(ctx, coord_seq);
     // Note: coordinate sequence is owned by linearring; if linearring fails to construct,


### PR DESCRIPTION
Experiment in using the new `GEOSCoordSeq_copyFromBuffer` for creating CoordinateSequences instead of setting each ordinate individually.

This requires GEOS 3.10, so will require https://github.com/pygeos/pygeos/issues/255 to use this in cython.

I was benchmarking it with the US census polygons ([tl_2019_us_zcta510.zip](https://catalog.data.gov/dataset/tiger-line-shapefile-2019-2010-nation-u-s-2010-census-5-digit-zip-code-tabulation-area-zcta5-na), 33144 (multi)polygons, with on average ~1200 coordinates per ring).

Focusing on LinearRing creation (the actual creation of (Multi)Polygons from those rings will of course see less of a difference):

I saved the coordinates and offsets in a numpy file, to load them again to benchmark (see https://nbviewer.org/gist/jorisvandenbossche/4fab9c94525dcb5ddda8a89b4a5ad9f3 for the full notebook):

```python
import numpy as np
import pygeos

with np.load("pygeos-benchmark-linearrings.npz") as data:
    offsets = data["offsets"]
    coords = data["coords"]

ring_lengths = np.diff((offsets / 2).astype(int))
ring_indices = np.repeat(np.arange(len(ring_lengths)), ring_lengths)
rings = pygeos.linearrings(coords, indices=ring_indices)
```

and this gives:

```
In [2]: %timeit pygeos.linearrings(coords, indices=ring_indices)
1.13 s ± 6.86 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)   # <-- master
558 ms ± 2.35 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <-- PR
```

I had maybe hoped on a bit more :), but it's certainly a nice speed-up.
