### PR TITLE
Solve RuntimeWarnings in tests

### DIFF
--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -36,9 +36,11 @@ jobs:
           - python: "3.10"
             geos: 3.10.1
             numpy: 1.21.3
+            extra_pytest_args: "-W error"  # error on warnings
           # dev
           - python: "3.10"
             geos: main
+            extra_pytest_args: "-W error"  # error on warnings
           # enable two 32-bit windows builds:
           - os: windows-2019
             architecture: x86
@@ -143,7 +145,7 @@ jobs:
 
       - name: Run tests
         continue-on-error: ${{ matrix.geos == 'main' }}
-        run: pytest pygeos
+        run: pytest pygeos ${{ matrix.extra_pytest_args }}
 
       # Only run doctests on 1 runner (because of typographic differences in doctest results)
       - name: Run doctests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,8 @@ Version 0.12 (unreleased)
 * Raise ``GEOSException`` in the rare case when predicate evalution in ``STRtree.query``
   errors. Previously, the exceptions were ignored silently and the geometry was added 
   to the result (as if the predicate returned ``True``) (#432).
+* Hide ``RuntimeWarning`` when using ``total_bounds`` on empty geometries, empty arrays,
+  or geometries with NaN coordinates (#441).
 
 
 **Acknowledgments**

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from . import Geometry  # NOQA
@@ -133,14 +135,17 @@ def total_bounds(geometry, **kwargs):
     if b.ndim == 1:
         return b
 
-    return np.array(
-        [
-            np.nanmin(b[..., 0]),
-            np.nanmin(b[..., 1]),
-            np.nanmax(b[..., 2]),
-            np.nanmax(b[..., 3]),
-        ]
-    )
+    with warnings.catch_warnings():
+        # ignore 'All-NaN slice encountered' warnings
+        warnings.simplefilter("ignore", RuntimeWarning)
+        return np.array(
+            [
+                np.nanmin(b[..., 0]),
+                np.nanmin(b[..., 1]),
+                np.nanmax(b[..., 2]),
+                np.nanmax(b[..., 3]),
+            ]
+        )
 
 
 @multithreading_enabled

--- a/pygeos/testing.py
+++ b/pygeos/testing.py
@@ -8,9 +8,13 @@ __all__ = ["assert_geometries_equal"]
 
 
 def _equals_exact_with_ndim(x, y, tolerance):
-    return pygeos.equals_exact(x, y, tolerance=tolerance) & (
-        pygeos.get_coordinate_dimension(x) == pygeos.get_coordinate_dimension(y)
-    )
+    dimension_equals = pygeos.get_coordinate_dimension(
+        x
+    ) == pygeos.get_coordinate_dimension(y)
+    with np.errstate(invalid="ignore"):
+        # Suppress 'invalid value encountered in equals_exact' with nan coordinates
+        geometry_equals = pygeos.equals_exact(x, y, tolerance=tolerance)
+    return dimension_equals & geometry_equals
 
 
 def _replace_nan(arr):

--- a/pygeos/tests/common.py
+++ b/pygeos/tests/common.py
@@ -82,3 +82,12 @@ def assert_decreases_refcount(obj):
         pytest.skip("sys.getrefcount is not available.")
     yield
     assert sys.getrefcount(obj) == before - 1
+
+
+@contextmanager
+def ignore_invalid(condition=True):
+    if condition:
+        with np.errstate(invalid="ignore"):
+            yield
+    else:
+        yield

--- a/pygeos/tests/test_constructive.py
+++ b/pygeos/tests/test_constructive.py
@@ -11,6 +11,7 @@ from .common import (
     empty_line_string,
     empty_point,
     empty_polygon,
+    ignore_invalid,
     line_string,
     multi_point,
     point,
@@ -51,7 +52,10 @@ def test_float_arg_array(geometry, func):
         with pytest.raises(GEOSException, match="only accept linestrings"):
             func([geometry, geometry], 0.0)
         return
-    actual = func([geometry, geometry], 0.0)
+    with ignore_invalid(
+        func is pygeos.voronoi_polygons and pygeos.get_type_id(geometry) == 0
+    ):
+        actual = func([geometry, geometry], 0.0)
     assert actual.shape == (2,)
     assert isinstance(actual[0], Geometry)
 
@@ -209,7 +213,8 @@ def test_normalize(geom, expected):
 
 
 def test_offset_curve_empty():
-    actual = pygeos.offset_curve(empty_line_string, 2.0)
+    with ignore_invalid():
+        actual = pygeos.offset_curve(empty_line_string, 2.0)
     assert pygeos.is_empty(actual)
 
 

--- a/pygeos/tests/test_constructive.py
+++ b/pygeos/tests/test_constructive.py
@@ -52,6 +52,8 @@ def test_float_arg_array(geometry, func):
         with pytest.raises(GEOSException, match="only accept linestrings"):
             func([geometry, geometry], 0.0)
         return
+    # voronoi_polygons emits an "invalid" warning when supplied with an empty
+    # point (see https://github.com/libgeos/geos/issues/515)
     with ignore_invalid(
         func is pygeos.voronoi_polygons and pygeos.get_type_id(geometry) == 0
     ):
@@ -214,6 +216,8 @@ def test_normalize(geom, expected):
 
 def test_offset_curve_empty():
     with ignore_invalid():
+        # Empty geometries emit an "invalid" warning
+        # (see https://github.com/libgeos/geos/issues/515)
         actual = pygeos.offset_curve(empty_line_string, 2.0)
     assert pygeos.is_empty(actual)
 

--- a/pygeos/tests/test_measurement.py
+++ b/pygeos/tests/test_measurement.py
@@ -7,6 +7,7 @@ import pygeos
 from .common import (
     empty,
     geometry_collection,
+    ignore_invalid,
     line_string,
     linear_ring,
     multi_line_string,
@@ -143,7 +144,9 @@ def test_hausdorff_distance():
     # example from GEOS docs
     a = pygeos.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = pygeos.linestrings([[0, 100], [0, 10], [80, 10]])
-    actual = pygeos.hausdorff_distance(a, b)
+    with ignore_invalid():
+        # Hausdorff distnace emits "invalid value encountered"
+        actual = pygeos.hausdorff_distance(a, b)
     assert actual == pytest.approx(22.360679775, abs=1e-7)
 
 
@@ -151,7 +154,9 @@ def test_hausdorff_distance_densify():
     # example from GEOS docs
     a = pygeos.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = pygeos.linestrings([[0, 100], [0, 10], [80, 10]])
-    actual = pygeos.hausdorff_distance(a, b, densify=0.001)
+    with ignore_invalid():
+        # Hausdorff distnace emits "invalid value encountered"
+        actual = pygeos.hausdorff_distance(a, b, densify=0.001)
     assert actual == pytest.approx(47.8, abs=0.1)
 
 

--- a/pygeos/tests/test_measurement.py
+++ b/pygeos/tests/test_measurement.py
@@ -145,7 +145,8 @@ def test_hausdorff_distance():
     a = pygeos.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = pygeos.linestrings([[0, 100], [0, 10], [80, 10]])
     with ignore_invalid():
-        # Hausdorff distnace emits "invalid value encountered"
+        # Hausdorff distance emits "invalid value encountered"
+        # (see https://github.com/libgeos/geos/issues/515)
         actual = pygeos.hausdorff_distance(a, b)
     assert actual == pytest.approx(22.360679775, abs=1e-7)
 
@@ -155,7 +156,8 @@ def test_hausdorff_distance_densify():
     a = pygeos.linestrings([[0, 0], [100, 0], [10, 100], [10, 100]])
     b = pygeos.linestrings([[0, 100], [0, 10], [80, 10]])
     with ignore_invalid():
-        # Hausdorff distnace emits "invalid value encountered"
+        # Hausdorff distance emits "invalid value encountered"
+        # (see https://github.com/libgeos/geos/issues/515)
         actual = pygeos.hausdorff_distance(a, b, densify=0.001)
     assert actual == pytest.approx(47.8, abs=0.1)
 

--- a/pygeos/tests/test_predicates.py
+++ b/pygeos/tests/test_predicates.py
@@ -86,6 +86,7 @@ def test_unary_missing(func):
 def test_binary_array(a, func):
     with ignore_invalid(pygeos.is_empty(a)):
         # Empty geometries give 'invalid value encountered' in all predicates
+        # (see https://github.com/libgeos/geos/issues/515)
         actual = func([a, a], point)
     assert actual.shape == (2,)
     assert actual.dtype == np.bool_
@@ -179,6 +180,7 @@ def test_relate_pattern():
 def test_relate_pattern_empty():
     with ignore_invalid():
         # Empty geometries give 'invalid value encountered' in all predicates
+        # (see https://github.com/libgeos/geos/issues/515)
         assert pygeos.relate_pattern(empty, empty, "*" * 9).item() is True
 
 
@@ -238,6 +240,7 @@ def _prepare_with_copy(geometry):
 def test_binary_prepared(a, func):
     with ignore_invalid(pygeos.is_empty(a)):
         # Empty geometries give 'invalid value encountered' in all predicates
+        # (see https://github.com/libgeos/geos/issues/515)
         actual = func(a, point)
         result = func(_prepare_with_copy(a), point)
     assert actual == result

--- a/pygeos/tests/test_predicates.py
+++ b/pygeos/tests/test_predicates.py
@@ -10,6 +10,7 @@ from .common import (
     all_types,
     empty,
     geometry_collection,
+    ignore_invalid,
     line_string,
     linear_ring,
     point,
@@ -83,7 +84,9 @@ def test_unary_missing(func):
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func", BINARY_PREDICATES)
 def test_binary_array(a, func):
-    actual = func([a, a], point)
+    with ignore_invalid(pygeos.is_empty(a)):
+        # Empty geometries give 'invalid value encountered' in all predicates
+        actual = func([a, a], point)
     assert actual.shape == (2,)
     assert actual.dtype == np.bool_
 
@@ -174,7 +177,9 @@ def test_relate_pattern():
 
 
 def test_relate_pattern_empty():
-    assert pygeos.relate_pattern(empty, empty, "*" * 9).item() is True
+    with ignore_invalid():
+        # Empty geometries give 'invalid value encountered' in all predicates
+        assert pygeos.relate_pattern(empty, empty, "*" * 9).item() is True
 
 
 @pytest.mark.parametrize("g1, g2", [(point, None), (None, point), (None, None)])
@@ -231,8 +236,10 @@ def _prepare_with_copy(geometry):
 @pytest.mark.parametrize("a", all_types)
 @pytest.mark.parametrize("func", BINARY_PREPARED_PREDICATES)
 def test_binary_prepared(a, func):
-    actual = func(a, point)
-    result = func(_prepare_with_copy(a), point)
+    with ignore_invalid(pygeos.is_empty(a)):
+        # Empty geometries give 'invalid value encountered' in all predicates
+        actual = func(a, point)
+        result = func(_prepare_with_copy(a), point)
     assert actual == result
 
 

--- a/pygeos/tests/test_strtree.py
+++ b/pygeos/tests/test_strtree.py
@@ -23,13 +23,13 @@ HALF_UNIT_DIAG = math.sqrt(2) / 2
 EPS = 1e-9
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def tree():
     geoms = pygeos.points(np.arange(10), np.arange(10))
     yield pygeos.STRtree(geoms)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def line_tree():
     x = np.arange(10)
     y = np.arange(10)
@@ -38,7 +38,7 @@ def line_tree():
     yield pygeos.STRtree(geoms)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def poly_tree():
     # create buffers so that midpoint between two buffers intersects
     # each buffer.  NOTE: add EPS to help mitigate rounding errors at midpoint.


### PR DESCRIPTION
Closes #357 - tests with GEOS 3.10.1 now pass without warnings.

There are some issues that should be reported upstream:

- binary predicates on empty geometries set an invalid flag
- voronoi_polygons on a point set an invalid flag
- hausdorff_distance sets an invalid flag (in our seemingly normal test)
- offset_curve on an empty linestring set an invalid flag