### PR TITLE
Move to manylinux2014 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,8 +108,6 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_SKIP: pp* *musllinux* cp310-win32 cp310-macosx_x86_64 cp310-manylinux_i686
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2010
           CIBW_ENVIRONMENT_LINUX:
             GEOS_VERSION=${{ env.GEOS_VERSION }}
             GEOS_INSTALL=/host${{ runner.temp }}/geos-${{ env.GEOS_VERSION }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Version 0.12 (unreleased)
   Python 3.10 (#427).
 * All binary wheels now have GEOS 3.10.1. See https://github.com/libgeos/geos/blob/main/NEWS
   for the changes (#422).
-
+* Linux x86_64 and i686 wheels are now built using the manylinux2014 image instead of manylinux2010 (#445).
 
 **Major enhancements**
 


### PR DESCRIPTION
manylinux2010 wheels are built for CentOS 6, which reached end of life in November 2020 (see https://www.python.org/dev/peps/pep-0599/)

So it is good to move on to manylinux2014 which is for CentOS 7.

Numpy also started doing this for their cp310 wheels; because of this our cp310 builds are compiling numpy. This PR solves that issue too.