### PR TITLE
MAINT: upgrade release and tests to use GEOS 3.10.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      GEOS_VERSION: "3.10.1"
+      GEOS_VERSION: "3.10.2"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         architecture: [x64]
-        geos: [3.6.5, 3.7.3, 3.8.1, 3.9.2, 3.10.1, main]
+        geos: [3.6.5, 3.7.3, 3.8.1, 3.9.2, 3.10.2, main]
         include:
           # 2017
           - python: 3.6
@@ -34,7 +34,7 @@ jobs:
             numpy: 1.19.5
           # 2021
           - python: "3.10"
-            geos: 3.10.1
+            geos: 3.10.2
             numpy: 1.21.3
             extra_pytest_args: "-W error"  # error on warnings
           # dev
@@ -50,7 +50,7 @@ jobs:
           - os: windows-2019
             architecture: x86
             python: 3.9
-            geos: 3.10.1
+            geos: 3.10.2
             numpy: 1.19.5
 
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: '3.8'
 
 env:
   global:
-  - GEOS_VERSION=3.10.1
+  - GEOS_VERSION=3.10.2
 
 cache:
   directories:

--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -17,7 +17,7 @@ ENV PYTHONMALLOC malloc
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Build GEOS
-RUN export GEOS_VERSION=3.10.1 && \
+RUN export GEOS_VERSION=3.10.2 && \
     mkdir /code/geos && cd /code/geos && \
     curl -OL http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2 && \
     tar xfj geos-$GEOS_VERSION.tar.bz2 && \

--- a/pygeos/tests/test_io.py
+++ b/pygeos/tests/test_io.py
@@ -1,6 +1,7 @@
 import json
 import pickle
 import struct
+import warnings
 from unittest import mock
 
 import numpy as np
@@ -169,10 +170,9 @@ def test_from_wkt_warn_on_invalid():
 
 
 def test_from_wkb_ignore_on_invalid():
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning
         pygeos.from_wkt("", on_invalid="ignore")
-
-    with pytest.warns(None):
         pygeos.from_wkt("NOT A WKT STRING", on_invalid="ignore")
 
 
@@ -250,17 +250,16 @@ def test_from_wkb_warn_on_invalid_warn():
 
 
 def test_from_wkb_ignore_on_invalid_ignore():
-    # invalid WKB
-    with pytest.warns(None) as w:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning
+
+        # invalid WKB
         result = pygeos.from_wkb(b"\x01\x01\x00\x00\x00\x00", on_invalid="ignore")
         assert result is None
-        assert len(w) == 0  # no warning
 
-    # invalid ring in WKB
-    with pytest.warns(None) as w:
+        # invalid ring in WKB
         result = pygeos.from_wkb(INVALID_WKB, on_invalid="ignore")
         assert result is None
-        assert len(w) == 0  # no warning
 
 
 def test_from_wkb_on_invalid_unsupported_option():
@@ -792,7 +791,8 @@ def test_from_geojson_warn_on_invalid():
 
 @pytest.mark.skipif(pygeos.geos_version < (3, 10, 1), reason="GEOS < 3.10.1")
 def test_from_geojson_ignore_on_invalid():
-    with pytest.warns(None):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning
         assert pygeos.from_geojson("", on_invalid="ignore") is None
 
 


### PR DESCRIPTION
The motivation for this is from GeoPandas and pygeos installed via pip:
```
../../../../tmp/py39/lib/python3.9/site-packages/geopandas/_compat.py:111
  /tmp/py39/lib/python3.9/site-packages/geopandas/_compat.py:111: UserWarning: The Shapely GEOS version (3.10.2-CAPI-1.16.0) is incompatible with the GEOS version PyGEOS was compiled with (3.10.1-CAPI-1.16.0). Conversions between both will be slow.
    warnings.warn(
```
While Shapely-2.0 is not out yet, it would be nice to have binary wheels on PyPI that have he same GEOS version as Shapely.