### PR TITLE
CI: upgrade GEOS patch versions for tests, use GEOS 3.10.3 for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -73,6 +75,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Cache GEOS build
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Build a source tarball
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools
-          python setup.py sdist
+          pip install build
+          python -m build --sdist
 
       - uses: actions/upload-artifact@v2
         with:
@@ -40,7 +40,7 @@ jobs:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      GEOS_VERSION: "3.10.2"
+      GEOS_VERSION: "3.10.3"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         architecture: [x64]
-        geos: [3.6.5, 3.7.3, 3.8.1, 3.9.2, 3.10.2, main]
+        geos: [3.6.5, 3.7.5, 3.8.3, 3.9.3, 3.10.3, main]
         include:
           # 2017
           - python: 3.6
@@ -22,19 +22,19 @@ jobs:
             numpy: 1.13.3
           # 2018
           - python: 3.7
-            geos: 3.7.3
+            geos: 3.7.5
             numpy: 1.15.4
           # 2019
           - python: 3.8
-            geos: 3.8.1
+            geos: 3.8.3
             numpy: 1.17.5
           # 2020
           - python: 3.9
-            geos: 3.9.2
+            geos: 3.9.3
             numpy: 1.19.5
           # 2021
           - python: "3.10"
-            geos: 3.10.2
+            geos: 3.10.3
             numpy: 1.21.3
             extra_pytest_args: "-W error"  # error on warnings
           # dev
@@ -50,7 +50,7 @@ jobs:
           - os: windows-2019
             architecture: x86
             python: 3.9
-            geos: 3.10.2
+            geos: 3.10.3
             numpy: 1.19.5
 
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: '3.8'
 
 env:
   global:
-  - GEOS_VERSION=3.10.2
+  - GEOS_VERSION=3.10.3
 
 cache:
   directories:

--- a/docker/Dockerfile.valgrind
+++ b/docker/Dockerfile.valgrind
@@ -17,7 +17,7 @@ ENV PYTHONMALLOC malloc
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Build GEOS
-RUN export GEOS_VERSION=3.10.2 && \
+RUN export GEOS_VERSION=3.10.3 && \
     mkdir /code/geos && cd /code/geos && \
     curl -OL http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2 && \
     tar xfj geos-$GEOS_VERSION.tar.bz2 && \


### PR DESCRIPTION
See https://lists.osgeo.org/pipermail/geos-devel/2022-June/010685.html for announcement of several patch releases.

Builds for releases have changed to GEOS 3.10.3 (see also #450).

Also, build sdist using PyPA's [build](https://github.com/pypa/build) tool.