### PR TITLE
Only use fastpath in to/from_shapely conversion when using conda

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.0
     hooks:
     - id: flake8

--- a/pygeos/io.py
+++ b/pygeos/io.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import warnings
 from collections.abc import Sized
 
@@ -78,9 +80,12 @@ def check_shapely_version():
 
             # shapely has something like: "3.6.2-CAPI-1.10.2 4d2925d6"
             # pygeos has something like: "3.6.2-CAPI-1.10.2"
-            shapely_compatible = True
-            if not geos_version_string.startswith(geos_capi_version_string):
-                shapely_compatible = False
+            shapely_compatible = False
+            if os.path.exists(os.path.join(sys.prefix, "conda-meta")):
+                if geos_version_string.startswith(geos_capi_version_string):
+                    # only if using conda and having the same GEOS version
+                    shapely_compatible = True
+            if not shapely_compatible:
                 warnings.warn(
                     "The shapely GEOS version ({}) is incompatible "
                     "with the PyGEOS GEOS version ({}). "


### PR DESCRIPTION
Since we have had several reports of subtle crashes in certain cases when using wheels that seem to be related to this sharing of GEOS pointers (for example https://github.com/pygeos/pygeos/issues/447, https://github.com/pygeos/pygeos/issues/377, https://github.com/pygeos/pygeos/issues/122, https://github.com/geopandas/geopandas/issues/2551, https://github.com/geopandas/geopandas/issues/2613#issuecomment-1290387118), it seems safer to restrict this fastpath to conda-only. 

This shouldn't impact results, only a slowdown in shapely / pygeos conversion. 
This also doesn't actually check that you are using a shapely and pygeos conda package, only if you are in a python managed by conda (but you can still install wheels into a conda environment).